### PR TITLE
API explorations(take 2)

### DIFF
--- a/akka-projection-core/src/main/scala/akka/projection/scaladsl/OffsetManagement.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/scaladsl/OffsetManagement.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.scaladsl
+
+import akka.Done
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.higherKinds
+
+trait OffsetManagement[Offset, IO] {
+
+  def readOffset(name: String): Future[Option[Offset]]
+
+  def run(name: String, offset: Offset)
+                   (block: => IO)
+                   (implicit ec: ExecutionContext): Future[Done]
+
+}

--- a/akka-projection-core/src/main/scala/akka/projection/scaladsl/Projection.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/scaladsl/Projection.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.scaladsl
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.{Sink, Source}
+
+import scala.concurrent.ExecutionContext
+
+case class Projection[Envelope, Event, Offset, IO](name: String,
+                                                   sourceProvider: SourceProvider[Envelope, Event, Offset],
+                                                   offsetManagement: OffsetManagement[Offset, IO],
+                                                   handler: ProjectionHandler[Event, IO]) {
+
+  def start(implicit ex: ExecutionContext, materializer: Materializer): Unit = {
+
+    val offset = offsetManagement.readOffset(name)
+
+    val source =
+      Source
+        .fromFuture(offset.map(sourceProvider.source))
+        .flatMapConcat(identity)
+
+    val src =
+      source.mapAsync(1) { envelope =>
+        // OffsetManagement is responsible for the call to ProjectionHandler
+        // so it can define what to do with the Offset: at-least-once, at-most-once, effectively-once
+        offsetManagement.run(name, sourceProvider.extractOffset(envelope))  {
+          handler.onEvent(sourceProvider.extractPayload(envelope))
+        }
+      }
+
+    src.runWith(Sink.ignore)
+  }
+}

--- a/akka-projection-core/src/main/scala/akka/projection/scaladsl/ProjectionHandler.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/scaladsl/ProjectionHandler.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.scaladsl
+
+import akka.Done
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.higherKinds
+import scala.util.control.NonFatal
+
+trait ProjectionHandler[Event, IO] {
+
+  def handleEvent(event: Event): IO
+
+  def onFailure(event: Event, throwable: Throwable): IO
+
+  def onEvent(event: Event): IO
+}
+
+trait AsyncProjectionHandler[Event] extends ProjectionHandler[Event, Future[Done]]{
+
+  implicit def exc: ExecutionContext
+
+  def handleEvent(event: Event): Future[Done]
+
+  def onFailure(event: Event, throwable: Throwable): Future[Done] =
+    Future.failed(throwable)
+
+  final def onEvent(event: Event): Future[Done] = {
+    handleEvent(event)
+      .recoverWith {
+        case NonFatal(exp) => onFailure(event, exp)
+      }
+  }
+
+}

--- a/akka-projection-core/src/main/scala/akka/projection/scaladsl/SourceProvider.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/scaladsl/SourceProvider.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.scaladsl
+
+import akka.stream.scaladsl.Source
+
+trait SourceProvider[Envelope, Payload, Offset] {
+
+
+  /**
+   * Provides a Source[S, _] starting from the passed offset.
+   * When Offset is None, the Source will start from the first element.
+   *
+   */
+  def source(offset: Option[Offset]): Source[Envelope, _]
+
+  def extractOffset(envelope: Envelope): Offset
+
+  def extractPayload(envelope: Envelope): Payload
+  
+}
+

--- a/akka-projection-core/src/main/scala/akka/projection/scaladsl/SourceProvider.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/scaladsl/SourceProvider.scala
@@ -8,7 +8,6 @@ import akka.stream.scaladsl.Source
 
 trait SourceProvider[Envelope, Payload, Offset] {
 
-
   /**
    * Provides a Source[S, _] starting from the passed offset.
    * When Offset is None, the Source will start from the first element.
@@ -19,6 +18,24 @@ trait SourceProvider[Envelope, Payload, Offset] {
   def extractOffset(envelope: Envelope): Offset
 
   def extractPayload(envelope: Envelope): Payload
-  
+
+
 }
 
+object SourceProvider {
+
+  /**
+   * This method converts a [[SourceProvider]] into one that will not extract the [[Payload]] and instead
+   * will deliver the [[Envelope]] to the [[ProjectionHandler]].
+   */
+  def exposeEnvelope[Envelope, Payload, Offset](sourceProvider: SourceProvider[Envelope, Payload, Offset]) = {
+    new SourceProvider[Envelope, Envelope, Offset] {
+
+      override def source(offset: Option[Offset]): Source[Envelope, _] = sourceProvider.source(offset)
+
+      override def extractOffset(envelope: Envelope): Offset = sourceProvider.extractOffset(envelope)
+
+      override def extractPayload(envelope: Envelope): Envelope = envelope
+    }
+  }
+}

--- a/akka-projection-poc/src/main/scala/akka/projection/scaladsl/Record.scala
+++ b/akka-projection-poc/src/main/scala/akka/projection/scaladsl/Record.scala
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.scaladsl
+
+/**
+ * This simulates a potential Envelope.
+ */
+case class Record(offset: Long, payload: String)

--- a/akka-projection-poc/src/main/scala/akka/projection/scaladsl/RecordSourceProvider.scala
+++ b/akka-projection-poc/src/main/scala/akka/projection/scaladsl/RecordSourceProvider.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.scaladsl
+import akka.stream.scaladsl.Source
+
+import scala.collection.immutable
+
+class RecordSourceProvider extends SourceProvider[Record, String, Long]{
+
+  private val records = for (i <- 1 to 100) yield Record(i, s"record-$i")
+  private val stream = Source(records)
+
+  override def source(offset: Option[Long]): Source[Record, _] = {
+    offset match {
+      case Some(latestOffset) => stream.drop(latestOffset)
+      case _ => stream
+    }
+  }
+
+  override def extractOffset(envelope: Record): Long = envelope.offset
+
+  override def extractPayload(envelope: Record): String = envelope.payload
+}

--- a/akka-projection-poc/src/main/scala/akka/projection/scaladsl/transactional/AppFakeDb.scala
+++ b/akka-projection-poc/src/main/scala/akka/projection/scaladsl/transactional/AppFakeDb.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.scaladsl.transactional
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.projection.scaladsl.{Projection, ProjectionHandler, Record, RecordSourceProvider}
+import akka.stream.ActorMaterializer
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+object AppFakeDb extends App {
+
+  val actorSys = ActorSystem("projections")
+
+  import actorSys.dispatcher
+
+  implicit val materializer = ActorMaterializer()(actorSys)
+
+  val repository = new InMemoryRepository
+
+  val projectionHandler = new DbProjectionHandler[String] {
+    override def handleEvent(event: String): DBIO[Done] = {
+      repository.save(event)
+    }
+  }
+
+  val proj = Projection(
+    name = "fake-db",
+    sourceProvider = new RecordSourceProvider,
+    offsetManagement = new TransactionalOffsetManagement,
+    handler = projectionHandler
+  )
+
+  proj.start
+
+  Thread.sleep(3000)
+
+  println(s"""
+              | ${repository.size} events in projection
+              | -----------------------------------------
+            """.stripMargin)
+
+  Await.ready(actorSys.terminate(), 3.seconds)
+}

--- a/akka-projection-poc/src/main/scala/akka/projection/scaladsl/transactional/AppFakeDbWithEnvelope.scala
+++ b/akka-projection-poc/src/main/scala/akka/projection/scaladsl/transactional/AppFakeDbWithEnvelope.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.scaladsl.transactional
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.projection.scaladsl._
+import akka.stream.ActorMaterializer
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+
+/**
+ * This example is exactly the same as AppFakeDb except that the ProjectionHandler takes
+ * the 'Record' (ie: the Envelope type). 
+ */
+object AppFakeDbWithEnvelope extends App {
+
+    val actorSys = ActorSystem("projections")
+
+    import actorSys.dispatcher
+
+    implicit val materializer = ActorMaterializer()(actorSys)
+
+    val repository = new InMemoryRepository
+
+    val projectionHandler = new DbProjectionHandler[Record] {
+      override def handleEvent(record: Record): DBIO[Done] = {
+        repository.save(record.toString)
+      }
+    }
+
+    val proj = Projection(
+      name = "fake-db-with-envelope",
+      sourceProvider = SourceProvider.exposeEnvelope(new RecordSourceProvider),
+      offsetManagement = new TransactionalOffsetManagement,
+      handler = projectionHandler
+    )
+
+    proj.start
+
+    Thread.sleep(3000)
+
+    println(s"""
+               | ${repository.size} events in projection
+               | -----------------------------------------
+            """.stripMargin)
+
+    Await.ready(actorSys.terminate(), 3.seconds)
+
+}

--- a/akka-projection-poc/src/main/scala/akka/projection/scaladsl/transactional/DBIO.scala
+++ b/akka-projection-poc/src/main/scala/akka/projection/scaladsl/transactional/DBIO.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.scaladsl.transactional
+
+import scala.concurrent.Future
+
+/**
+ * Fake DBIO 'Monad' just for the PoC
+ */
+case class DBIO[A](value: A) {
+  def flatMap[B](f: A => DBIO[B]): DBIO[B] = f(value)
+}
+
+object Database {
+  def run[A](dbio: DBIO[A]): Future[A] = Future.successful(dbio.value)
+}

--- a/akka-projection-poc/src/main/scala/akka/projection/scaladsl/transactional/DbProjectionHandler.scala
+++ b/akka-projection-poc/src/main/scala/akka/projection/scaladsl/transactional/DbProjectionHandler.scala
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.scaladsl.transactional
+
+import akka.Done
+import akka.projection.scaladsl.ProjectionHandler
+
+trait DbProjectionHandler[E] extends ProjectionHandler[E, DBIO[Done]] {
+
+  override def onFailure(event: E, throwable: Throwable): DBIO[Done] = throw throwable
+
+  override def onEvent(event: E): DBIO[Done] = handleEvent(event)
+}

--- a/akka-projection-poc/src/main/scala/akka/projection/scaladsl/transactional/InMemoryRepository.scala
+++ b/akka-projection-poc/src/main/scala/akka/projection/scaladsl/transactional/InMemoryRepository.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.scaladsl.transactional
+
+import akka.Done
+
+class InMemoryRepository {
+
+
+
+  private var list: List[String] = Nil
+
+  def save(str: String): DBIO[Done] = {
+    list = str :: list
+    DBIO(Done)
+  }
+
+  def size = list.size
+
+}

--- a/akka-projection-poc/src/main/scala/akka/projection/scaladsl/transactional/InMemoryRepository.scala
+++ b/akka-projection-poc/src/main/scala/akka/projection/scaladsl/transactional/InMemoryRepository.scala
@@ -13,6 +13,10 @@ class InMemoryRepository {
   private var list: List[String] = Nil
 
   def save(str: String): DBIO[Done] = {
+    println(s"""
+                | Saving '$str' in repository!
+                | -----------------------------------------
+              """.stripMargin)
     list = str :: list
     DBIO(Done)
   }

--- a/akka-projection-poc/src/main/scala/akka/projection/scaladsl/transactional/TransactionalOffsetManagement.scala
+++ b/akka-projection-poc/src/main/scala/akka/projection/scaladsl/transactional/TransactionalOffsetManagement.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.scaladsl.transactional
+
+import akka.Done
+import akka.projection.scaladsl.OffsetManagement
+
+import scala.concurrent.{ExecutionContext, Future}
+
+
+class TransactionalOffsetManagement extends OffsetManagement[Long, DBIO[Done]] {
+
+  private var lastOffset: Option[Long] = None
+
+  def save(offset: Long): DBIO[Done] = {
+    lastOffset = Some(offset)
+    DBIO(Done)
+  }
+
+  override def readOffset(name: String): Future[Option[Long]] = {
+    println(s"reading offset for projection '$name', '$lastOffset'")
+    // a real implementation would read it from a DB
+    Database.run(DBIO(lastOffset))
+  }
+
+  override def run(name: String, offset: Long)
+                  (block: => DBIO[Done])(implicit ec: ExecutionContext): Future[Done] = {
+
+    println(s"saving offset '$offset' for projection '$name'")
+
+    // a real implementation would run the DBIO on a real DB
+    val dbio = block.flatMap(_ => save(offset))
+    Database.run(dbio).map(_ => Done)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -22,9 +22,15 @@ lazy val akkaProjectionCore = Project(
     base = file("akka-projection-core")
   ).settings(Dependencies.core)
 
+lazy val akkaProjectionPoc = Project(
+  id = "akka-projection-poc",
+  base = file("akka-projection-poc")
+).settings(Dependencies.core)
+  .dependsOn(akkaProjectionCore)
+
 
 
 lazy val root = Project(
     id = "akka-projection",
     base = file(".")
-  ).aggregate(akkaProjectionCore)
+  ).aggregate(akkaProjectionCore, akkaProjectionPoc)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.4.0")
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.2.0")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.1.0")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
 addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.12")


### PR DESCRIPTION
That new experiment has a much simpler and correct API, IMO.

It allows the users to compose a projection as long as the types align.

There are three main parts (or participants):

* Something that provides a stream of elements that one now the shape of element is knows how to extract the event and the offset out of it. That part is called a `SourceProvider`
* Something to read and save the offsets, we call it the `OffsetManagement`
* The user defined projection function, `ProjectionHandler`

Each of them, knows part of types involved, for instance:

* `SourceProvider` has `Envelope`, `Payload` and `Offset`. The `Envelope` is the type that will be streamed and the `SourceProvider` knows how to extract the `Payload` and the `Offset` from it.
* `OffsetManagement` knows about the `Offset` and the underlying Database `IO` type. It’s the `OffsetManagement` that ultimately runs the processing because it's the sole capable of deciding about the supported semantics: `at-least-once`, `at-most-once`, `effectively-once`, etc.
* The user `ProjectionHandler` knows about the `Event` type and the Database `IO` type. It defines the user handling function. That function must return the Database IO type that in turns must align with the one used by the `OffsetManagement`.

So, once we plugin those three elements and create a projection, we get everything working as expected. The types make sure that everything runs smoothly.

The branch has two sbt modules, the core API and the PoC. In the PoC there are two samples using a FakeDB. 

Have fun!