### PR TITLE
Minimalist Projection API

### DIFF
--- a/akka-projection-alpakka-kafka/src/main/scala/akka/projection/scaladsl/kafka/KafkaConsumer.scala
+++ b/akka-projection-alpakka-kafka/src/main/scala/akka/projection/scaladsl/kafka/KafkaConsumer.scala
@@ -1,0 +1,24 @@
+package akka.projection.scaladsl.kafka
+
+import akka.{Done, NotUsed}
+import akka.kafka.ConsumerMessage.{Committable, CommittableMessage}
+import akka.kafka.{CommitterSettings, ConsumerSettings, Subscription}
+import akka.kafka.scaladsl.{Committer, Consumer}
+import akka.kafka.scaladsl.Consumer.Control
+import akka.stream.scaladsl.{Flow, Source}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+// Either users need to build their own at-least-once Kafka source or we provide this convenience in Alpakka
+object KafkaConsumer {
+
+  def atLeastOnce[K, V](settings: ConsumerSettings[K, V],
+                        subscription: Subscription,
+                        committerSettings: CommitterSettings)(handler: CommittableMessage[K, V] => Future[_])(implicit ec: ExecutionContext): Source[Done, Control] = {
+   Consumer
+      .committableSource(settings, subscription)
+      .mapAsync(1) { msg => handler(msg).map( _ => msg.committableOffset) }
+      .via(Committer.flow(committerSettings))
+  }
+
+}

--- a/akka-projection-alpakka-kafka/src/main/scala/akka/projection/scaladsl/kafka/KafkaProjection.scala
+++ b/akka-projection-alpakka-kafka/src/main/scala/akka/projection/scaladsl/kafka/KafkaProjection.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2019-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.scaladsl.kafka
+
+import akka.Done
+import akka.kafka.scaladsl.Consumer.{Control, DrainingControl}
+import akka.projection.scaladsl._
+import akka.stream.Materializer
+import akka.stream.scaladsl.{Keep, Sink, Source}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object KafkaProjection {
+
+  def apply[E](src: Source[E, Control]): Projection =
+    new KafkaProjection[E](src)
+}
+
+/**
+ * A Projection implementation tailored for Alpakka Kafka.
+ *
+ * The materializer value must be a Control since the lifecycle of the stream will be managed by Akka Projection
+ */
+class KafkaProjection[E](kafkaSource: Source[E, Control]) extends Projection {
+
+  private var control: Option[DrainingControl[Done]] = None
+
+  override def start()(implicit ex: ExecutionContext, materializer: Materializer): Unit = {
+
+    val drainingControl =
+      kafkaSource
+        .toMat(Sink.ignore)(Keep.both)
+        .mapMaterializedValue(DrainingControl.apply)
+        .run()
+
+        control = Some(drainingControl)
+  }
+
+    override def stop()(implicit ex: ExecutionContext): Future[Done] =
+      control match {
+        case Some(control) => control.drainAndShutdown().map(_ => Done)
+        case _             => Future.successful(Done)
+      }
+}

--- a/akka-projection-alpakka-kafka/src/test/resources/application.conf
+++ b/akka-projection-alpakka-kafka/src/test/resources/application.conf
@@ -1,0 +1,21 @@
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  loglevel = "DEBUG"
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+  logger-startup-timeout = 15s
+
+  actor {
+    debug {
+      lifecycle = off
+      receive = off
+    }
+  }
+
+  test {
+    single-expect-default = 10s
+  }
+
+  kafka.consumer {
+    stop-timeout = 3 s
+  }
+}

--- a/akka-projection-alpakka-kafka/src/test/resources/logback-test.xml
+++ b/akka-projection-alpakka-kafka/src/test/resources/logback-test.xml
@@ -1,0 +1,26 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="akka" level="DEBUG"/>
+    <logger name="akka.actor.TimerScheduler" level="INFO"/>
+    <logger name="akka.kafka" level="DEBUG"/>
+
+    <logger name="org.apache.zookeeper" level="WARN"/>
+    <logger name="org.I0Itec.zkclient" level="WARN"/>
+
+    <logger name="kafka" level="WARN"/>
+    <logger name="org.apache.kafka" level="WARN"/>
+    <logger name="org.apache.kafka.common.utils.AppInfoParser" level="ERROR"/>
+    <logger name="org.apache.kafka.clients.NetworkClient" level="ERROR"/>
+
+    <logger name="com.github.dockerjava" level="WARN"/>
+    <logger name="org.testcontainers" level="WARN"/>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/akka-projection-alpakka-kafka/src/test/scala/akka/projection/scaladsl/kafka/CommittableSourceAtLeastOnceSpec.scala
+++ b/akka-projection-alpakka-kafka/src/test/scala/akka/projection/scaladsl/kafka/CommittableSourceAtLeastOnceSpec.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.scaladsl.kafka
+
+import akka.kafka.Subscriptions
+import akka.kafka.scaladsl.Consumer
+import akka.projection.testkit.{TestEventHandler, TestInMemoryRepository}
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
+
+import scala.concurrent.duration._
+
+class CommittableSourceAtLeastOnceSpec extends TestcontainersKafkaSpec {
+
+  implicit val patience: PatienceConfig = PatienceConfig(30.seconds, 500.millis)
+
+  "Kafka Projection using at-least-once delivery" must {
+
+    "deliver events to ProjectionHandler" in assertAllStagesStopped {
+
+      val Messages = "abc" :: "def" :: "ghi" :: Nil
+      val topic1 = createTopic(1)
+      val group1 = createGroupId(1)
+      produceString(topic1, Messages).futureValue(Timeout(remainingOrDefault))
+
+      val repository = new TestInMemoryRepository[String]
+      val handler = TestEventHandler(repository)
+
+      val src = KafkaConsumer.atLeastOnce(
+        consumerDefaults.withGroupId(group1),
+        Subscriptions.topics(topic1),
+        committerDefaults.withMaxBatch(1)) { msg =>
+        handler.onEvent(msg.record.value())
+      }
+
+      val projection = KafkaProjection(src)
+
+      runProjection(projection) {
+        eventually {
+          withClue("all messages are delivered to projection") {
+            repository.size shouldBe Messages.size
+          }
+
+          withClue("projected stream contains all elements") {
+            repository.list shouldBe Messages
+          }
+        }
+      }
+
+    }
+
+    "re-delivered an event after a failure (at-least-once)" in assertAllStagesStopped {
+
+      val Messages = "abc" :: "def" :: "ghi" :: Nil
+      val topic1 = createTopic(1)
+      val group1 = createGroupId(1)
+      produceString(topic1, Messages).futureValue(Timeout(remainingOrDefault))
+
+      val repository = new TestInMemoryRepository[String]
+
+      // fail handler on "def"
+      val failingHandler = TestEventHandler(repository, failPredicate = (s: String) => s == "def")
+
+      val failingSrc = KafkaConsumer.atLeastOnce(
+        consumerDefaults.withGroupId(group1),
+        Subscriptions.topics(topic1),
+        committerDefaults.withMaxBatch(1)) { msg =>
+        failingHandler.onEvent(msg.record.value())
+      }
+
+      val projection1 = KafkaProjection(failingSrc)
+
+      runProjection(projection1) {
+        eventually {
+          withClue("one message is delivery before failing") {
+            repository.size shouldBe 1
+          }
+
+          withClue("projected list contains only one element, 'def' failed") {
+            repository.list shouldBe List("abc")
+          }
+        }
+      }
+
+      //re-try without failing
+      val handler = TestEventHandler(repository)
+
+      val src = KafkaConsumer.atLeastOnce(
+        consumerDefaults.withGroupId(group1),
+        Subscriptions.topics(topic1),
+        committerDefaults.withMaxBatch(1)) { msg =>
+        handler.onEvent(msg.record.value())
+      }
+
+      val projection2 = KafkaProjection(src)
+
+      runProjection(projection2) {
+        eventually {
+          withClue("all messages are delivered to projection") {
+            repository.size shouldBe Messages.size
+          }
+
+          withClue("projected list contains all elements, 'def' is re-delivered") {
+            repository.list shouldBe Messages
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/akka-projection-alpakka-kafka/src/test/scala/akka/projection/scaladsl/kafka/ConsumerRecordAtMostOnceSpec.scala
+++ b/akka-projection-alpakka-kafka/src/test/scala/akka/projection/scaladsl/kafka/ConsumerRecordAtMostOnceSpec.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.scaladsl.kafka
+
+import akka.kafka.Subscriptions
+import akka.kafka.scaladsl.Consumer
+import akka.projection.testkit.{TestEventHandler, TestInMemoryRepository}
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
+
+import scala.concurrent.duration._
+
+class ConsumerRecordAtMostOnceSpec extends TestcontainersKafkaSpec {
+
+  implicit val patience: PatienceConfig = PatienceConfig(30.seconds, 500.millis)
+
+  "Kafka Projection using at-most-once delivery" must {
+
+    "deliver events to ProjectionHandler" in assertAllStagesStopped {
+
+      val Messages = "abc" :: "def" :: "ghi" :: Nil
+      val topic1 = createTopic(1)
+      val group1 = createGroupId(1)
+
+      produceString(topic1, Messages).futureValue(Timeout(remainingOrDefault))
+
+      val repository = new TestInMemoryRepository[String]
+      val handler = TestEventHandler(repository)
+
+      // user define the Source the way they want as long it's a Alpakka one (materializer Control)
+      // and define the handler (mapAsync) or flow. They have full flexibility
+      val src =
+        Consumer.atMostOnceSource(consumerDefaults.withGroupId(group1), Subscriptions.topics(topic1)).mapAsync(1) {
+          msg =>
+            handler.onEvent(msg.value())
+        }
+
+      val projection = KafkaProjection(src)
+
+      runProjection(projection) {
+        eventually {
+          withClue("all messages are delivered to projection") {
+            repository.size shouldBe Messages.size
+          }
+
+          withClue("projected stream contains all elements") {
+            repository.list shouldBe Messages
+          }
+        }
+      }
+    }
+
+    "not re-delivered an event after a failure (at-most-once)" in assertAllStagesStopped {
+
+      val Messages = "abc" :: "def" :: "ghi" :: Nil
+      val topic1 = createTopic(1)
+      val group1 = createGroupId(1)
+
+      produceString(topic1, Messages).futureValue(Timeout(remainingOrDefault))
+
+      val repository = new TestInMemoryRepository[String]
+
+      // fail handler on "def"
+      val failingHandler = TestEventHandler(repository, failPredicate = (s: String) => s == "def")
+
+      // user define the Source the way they want as long it's a Alpakka one (materializer Control)
+      // and define the handler (mapAsync) or flow. They have full flexibility
+      val failingSrc =
+        Consumer.atMostOnceSource(consumerDefaults.withGroupId(group1), Subscriptions.topics(topic1)).mapAsync(1) {
+          msg =>
+            failingHandler.onEvent(msg.value())
+        }
+
+      val projection1 = KafkaProjection(failingSrc)
+
+      runProjection(projection1) {
+        eventually {
+          withClue("one message is delivery before failing") {
+            repository.size shouldBe 1
+          }
+
+          withClue("projected list contains only one element, 'def' failed") {
+            repository.list shouldBe List("abc")
+          }
+        }
+      }
+
+      //re-try without failing
+      val handler = TestEventHandler(repository)
+      // user define the Source the way they want as long it's a Alpakka one (materializer Control)
+      // and define the handler (mapAsync) or flow. They have full flexibility
+      val src =
+      Consumer.atMostOnceSource(consumerDefaults.withGroupId(group1), Subscriptions.topics(topic1)).mapAsync(1) {
+        msg =>
+          handler.onEvent(msg.value())
+      }
+      val projection2 = KafkaProjection(src)
+
+      runProjection(projection2) {
+        eventually {
+          withClue("not all messages are delivered to projection") {
+            repository.size shouldBe 2
+          }
+
+          withClue("projected list is missing 'def'") {
+            repository.list shouldBe List("abc", "ghi")
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/akka-projection-alpakka-kafka/src/test/scala/akka/projection/scaladsl/kafka/SpecBase.scala
+++ b/akka-projection-alpakka-kafka/src/test/scala/akka/projection/scaladsl/kafka/SpecBase.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.scaladsl.kafka
+
+import akka.kafka.testkit.scaladsl.ScalatestKafkaSpec
+import akka.projection.testkit.ProjectionTestRunner
+import org.scalatest.concurrent.{ Eventually, ScalaFutures }
+import org.scalatest.{ Matchers, WordSpecLike }
+
+abstract class SpecBase(kafkaPort: Int)
+    extends ScalatestKafkaSpec(kafkaPort)
+    with WordSpecLike
+    with Matchers
+    with ScalaFutures
+    with ProjectionTestRunner
+    with Eventually {
+
+  protected def this() = this(kafkaPort = -1)
+
+}

--- a/akka-projection-alpakka-kafka/src/test/scala/akka/projection/scaladsl/kafka/TestcontainersKafkaSpec.scala
+++ b/akka-projection-alpakka-kafka/src/test/scala/akka/projection/scaladsl/kafka/TestcontainersKafkaSpec.scala
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.scaladsl.kafka
+
+import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
+
+abstract class TestcontainersKafkaSpec extends SpecBase with TestcontainersKafkaLike

--- a/akka-projection-core/src/main/scala/akka/projection/scaladsl/Projection.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/scaladsl/Projection.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2019-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.scaladsl
+
+import akka.Done
+import akka.stream.{ KillSwitch, KillSwitches, Materializer }
+import akka.stream.scaladsl.{ Keep, Sink, Source }
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+trait Projection {
+  def start()(implicit ex: ExecutionContext, materializer: Materializer): Unit
+  def stop()(implicit ex: ExecutionContext): Future[Done]
+}

--- a/akka-projection-samples/src/main/scala/akka/projection/Samples.scala
+++ b/akka-projection-samples/src/main/scala/akka/projection/Samples.scala
@@ -1,0 +1,168 @@
+package akka.projection
+
+import akka.{ Done, NotUsed }
+import akka.actor.ActorSystem
+import akka.kafka.{ CommitterSettings, ConsumerSettings, Subscriptions }
+import akka.kafka.scaladsl.{ Committer, Consumer }
+import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
+import akka.persistence.jdbc.query.scaladsl.JdbcReadJournal
+import akka.persistence.query.scaladsl.EventsByTagQuery
+import akka.persistence.query.{ EventEnvelope, Offset, PersistenceQuery, TimeBasedUUID }
+import akka.projection.KafkaAtLeastOnceSample.projection
+import akka.projection.KafkaSourceWithTransactionalJDBCSample.{ projection, system }
+import akka.projection.scaladsl.jdbc.{ JdbcOffsetStore, JdbcOffsetStoreAkkaOffset, JdbcOffsetStoreLong, JdbcProjection }
+import akka.projection.scaladsl.kafka.{ KafkaConsumer, KafkaProjection }
+import akka.stream.scaladsl.Source
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.TopicPartition
+
+import scala.concurrent.Future
+
+/**
+ * A Kafka projection that commits the offset in the topic using the Committer.flow (at-least-once)
+ */
+object KafkaAtLeastOnceSample {
+  implicit val system = ActorSystem("sample")
+  implicit val ec = system.dispatcher
+
+  val consumerSettings: ConsumerSettings[String, String] = ???
+  val committerSettings = CommitterSettings(system).withMaxBatch(100)
+
+  val src = KafkaConsumer.atLeastOnce(
+    consumerSettings.withGroupId("group1"),
+    Subscriptions.topics("topic1"),
+    committerSettings) { msg =>
+    Future.successful("pretending that this is projected to somewhere")
+  }
+
+  // a pure Kafka projection is super simple, as it only requires a Source
+  val projection = KafkaProjection(src)
+  projection.start()
+  projection.stop()
+}
+
+object KafkaAtLeastOnceSample2 {
+  implicit val system = ActorSystem("sample")
+  implicit val ec = system.dispatcher
+
+  val consumerSettings: ConsumerSettings[String, String] = ???
+  val committerSettings = CommitterSettings(system).withMaxBatch(100)
+
+  val src = Consumer
+    .committableSource(consumerSettings, Subscriptions.topics("topic1"))
+    .mapAsync(1) { msg =>
+      Future.successful(s"pretending that this is projected to somewhere").map(_ => msg.committableOffset)
+    }
+    .via(Committer.flow(committerSettings))
+
+  // a pure Kafka projection is super simple, as it only requires a Source
+  val projection = KafkaProjection(src)
+  projection.start()
+  projection.stop()
+}
+
+/**
+ * A Kafka projection that commits the offset in the topic before delivering to handler (at-most-once)
+ */
+object KafkaAtMostOnceSample {
+
+  implicit val system = ActorSystem("sample")
+  implicit val ec = system.dispatcher
+
+  val consumerSettings: ConsumerSettings[String, String] = ???
+
+  val src =
+    Consumer.atMostOnceSource(consumerSettings.withGroupId("group1"), Subscriptions.topics("topic1")).mapAsync(1) {
+      msg =>
+        println(s"pretending that this is projected to somewhere")
+        Future.successful(Done)
+    }
+
+  // a pure Kafka projection is super simple, as it only requires a Source
+  val projection = KafkaProjection(src)
+  projection.start()
+  projection.stop()
+}
+
+/**
+ * Sample showing a rough API for consuming events from Akka Persistence Cassandra and saving the
+ * projected model and the offset in a JDBC table
+ */
+object AkkaPersistenceCassandraWithTransactionalJDBCSample {
+
+  implicit val system = ActorSystem("sample")
+  implicit val ec = system.dispatcher
+
+  // we need a function that given an optional offset, returns a Source
+  def sourceProvider(offset: Option[Offset]): Source[EventEnvelope, _] = {
+    val queries = PersistenceQuery(system).readJournalFor[CassandraReadJournal](CassandraReadJournal.Identifier)
+    queries.eventsByTag("someTag", offset.getOrElse(Offset.noOffset))
+  }
+
+  val projection =
+    JdbcProjection.transactional(
+      sourceProvider = sourceProvider,
+      offsetStore = new JdbcOffsetStoreAkkaOffset(projectionId = "demo"),
+      offsetExtractor = (ev: EventEnvelope) => ev.offset) { (connec, envelope) =>
+      println(s"pretending that this is projected to some JDBC model")
+    }
+
+  projection.start()
+  projection.stop()
+}
+
+/**
+ * sample showing a rough API for consuming events from Akka Persistence JDBC and saving the
+ * projected model and the offset in a JDBC table
+ */
+object AkkaPersistenceJdbcWithTransactionalJDBCSample {
+
+  implicit val system = ActorSystem("sample")
+  implicit val ec = system.dispatcher
+
+  // we need a function that given an optional offset, returns a Source
+  def sourceProvider(offset: Option[Offset]): Source[EventEnvelope, _] = {
+    val queries = PersistenceQuery(system).readJournalFor[JdbcReadJournal](JdbcReadJournal.Identifier)
+    queries.eventsByTag("someTag", offset.getOrElse(Offset.noOffset))
+  }
+
+  val projection =
+    JdbcProjection.transactional(
+      sourceProvider = sourceProvider,
+      offsetStore = new JdbcOffsetStoreAkkaOffset(projectionId = "demo"),
+      offsetExtractor = (ev: EventEnvelope) => ev.offset) { (connec, envelope) =>
+      println(s"pretending that this is projected to some JDBC model")
+    }
+
+  projection.start()
+  projection.stop()
+}
+
+/**
+ * sample showing a rough API for consuming events from Alpakka Kafka and saving the
+ * projected model and the offset in a JDBC table
+ */
+object KafkaSourceWithTransactionalJDBCSample {
+
+  implicit val system = ActorSystem("sample")
+  implicit val ec = system.dispatcher
+
+  // we need a function that given an optional offset, returns a Source
+  def sourceProvider(offset: Option[Long]): Source[ConsumerRecord[String, String], _] = {
+    val consumerSettings: ConsumerSettings[String, String] = ???
+    val topicPartition: TopicPartition = ???
+    Consumer.plainSource(
+      consumerSettings,
+      Subscriptions.assignmentWithOffset(topicPartition -> offset.map(_ + 1).getOrElse(0L)))
+  }
+
+  val projection =
+    JdbcProjection.transactional(
+      sourceProvider = sourceProvider,
+      offsetStore = new JdbcOffsetStoreLong(projectionId = "demo"),
+      offsetExtractor = (record: ConsumerRecord[String, String]) => record.offset()) { (connec, envelope) =>
+      // whatever is
+      println(s"pretending that this is projected to some JDBC model")
+    }
+  projection.start()
+}

--- a/akka-projection-samples/src/main/scala/akka/projection/scaladsl/jdbc/Connection.scala
+++ b/akka-projection-samples/src/main/scala/akka/projection/scaladsl/jdbc/Connection.scala
@@ -1,0 +1,4 @@
+package akka.projection.scaladsl.jdbc
+
+trait Connection
+object Connection extends Connection

--- a/akka-projection-samples/src/main/scala/akka/projection/scaladsl/jdbc/FakeJdbcRepository.scala
+++ b/akka-projection-samples/src/main/scala/akka/projection/scaladsl/jdbc/FakeJdbcRepository.scala
@@ -1,0 +1,21 @@
+package akka.projection.scaladsl.jdbc
+
+import org.slf4j.LoggerFactory
+
+class FakeJdbcRepository[T] {
+
+  val logger = LoggerFactory.getLogger(this.getClass)
+
+  // FIXME: not safe, we need to harden it as test cases get more evolved
+  private var internalList: List[T] = Nil
+
+  def save(value: T): Unit = {
+    logger.info(s"Saving event: '$value'")
+    internalList = value :: internalList
+  }
+
+  def size = internalList.size
+
+  def list = internalList.reverse
+
+}

--- a/akka-projection-samples/src/main/scala/akka/projection/scaladsl/jdbc/JdbcOffsetStore.scala
+++ b/akka-projection-samples/src/main/scala/akka/projection/scaladsl/jdbc/JdbcOffsetStore.scala
@@ -1,0 +1,36 @@
+package akka.projection.scaladsl.jdbc
+
+import akka.persistence.query.{ Offset, TimeBasedUUID }
+
+import scala.concurrent.Future
+
+trait JdbcOffsetStore[O] {
+  def projectionId: String
+  def readOffset(connection: Connection): Future[Option[O]]
+  def saveOffset(connection: Connection, offset: O): Unit
+}
+
+class JdbcOffsetStoreLong(val projectionId: String) extends JdbcOffsetStore[Long] {
+
+  private var lastOffset: Option[Long] = None
+
+  override def readOffset(connection: Connection): Future[Option[Long]] =
+    Future.successful(lastOffset)
+
+  override def saveOffset(connection: Connection, offset: Long): Unit =
+    lastOffset = Some(offset)
+}
+
+// we will need a separated module that glues together jdbc-projection with akka persistence offset
+// this implementation will need to be a little bit smarter, we will need to keep track of the offset type (Sequence / TimeBasedUUID)
+// and be able to ser/deser it properly. Maybe a simplified version of Manifest with payload saved as String
+class JdbcOffsetStoreAkkaOffset(val projectionId: String) extends JdbcOffsetStore[Offset] {
+
+  private var lastOffset: Option[Offset] = None
+
+  override def readOffset(connection: Connection): Future[Option[Offset]] =
+    Future.successful(lastOffset)
+
+  override def saveOffset(connection: Connection, offset: Offset): Unit =
+    lastOffset = Some(offset)
+}

--- a/akka-projection-samples/src/main/scala/akka/projection/scaladsl/jdbc/JdbcProjection.scala
+++ b/akka-projection-samples/src/main/scala/akka/projection/scaladsl/jdbc/JdbcProjection.scala
@@ -1,0 +1,67 @@
+package akka.projection.scaladsl.jdbc
+
+import akka.{Done, NotUsed}
+import akka.projection.scaladsl.Projection
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.stream.{KillSwitch, KillSwitches, Materializer}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object JdbcProjection {
+
+  def transactional[E, O](
+      sourceProvider: Option[O] => Source[E, _],
+      offsetStore: JdbcOffsetStore[O],
+      offsetExtractor: E => O)(handler: (Connection, E) => Unit): Projection =
+    new TransactionalProjection(sourceProvider, offsetStore, offsetExtractor, handler)
+
+}
+
+class TransactionalProjection[E, O](
+    sourceProvider: Option[O] => Source[E, _],
+    offsetStore: JdbcOffsetStore[O],
+    offsetExtractor: E => O,
+    handler: (Connection, E) => Unit)
+    extends Projection {
+
+  private var shutdown: Option[KillSwitch] = None
+
+  private def getConnection: Connection = Connection
+
+  private def inTransaction[T](txBlock: Connection => Unit): Future[Done] = {
+    // do all the necessary to get a connection,
+    // use it in a transaction and close it
+    // and run `txBlock` in a dedicated dispatcher
+
+    txBlock(getConnection)
+
+    Future.successful(Done)
+  }
+
+  override def start()(implicit ex: ExecutionContext, materializer: Materializer): Unit = {
+
+    // read latest offset
+    val offset = offsetStore.readOffset(getConnection)
+
+    val killSwitch =
+      Source
+        .future(offset.map(sourceProvider))
+        .flatMapConcat[E, Any](identity)
+        .mapAsync(1) { envelope =>
+          inTransaction { connec =>
+            offsetStore.saveOffset(connec, offsetExtractor(envelope))
+            handler(connec, envelope)
+          }
+        }
+        .viaMat(KillSwitches.single)(Keep.right)
+        .toMat(Sink.ignore)(Keep.left)
+        .run()
+
+    shutdown = Some(killSwitch)
+  }
+
+  override def stop()(implicit ex: ExecutionContext): Future[Done] = {
+    shutdown.foreach(_.shutdown())
+    Future.successful(Done)
+  }
+}

--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/ProjectionTestRunner.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/ProjectionTestRunner.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2019-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.testkit
+
+import akka.Done
+import akka.projection.scaladsl.Projection
+import akka.stream.Materializer
+import scala.concurrent.duration._
+import scala.concurrent.{ Await, ExecutionContext, Future }
+
+trait ProjectionTestRunner {
+
+  def runProjection(proj: Projection)(
+      testFunc: => Unit)(implicit ex: ExecutionContext, materializer: Materializer): Unit =
+    runProjection(proj, 5.seconds)(testFunc)
+
+  def runProjection(proj: Projection, timeout: FiniteDuration)(
+      testFunc: => Unit)(implicit ex: ExecutionContext, materializer: Materializer): Unit = {
+    try {
+      proj.start()
+      testFunc
+    } finally {
+      Await.ready(proj.stop(), timeout)
+    }
+  }
+}

--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/TestEventHandler.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/TestEventHandler.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2019-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.testkit
+
+import akka.Done
+import org.slf4j.LoggerFactory
+import scala.concurrent.Future
+
+class TestEventHandler[E](repository: TestInMemoryRepository[E], failPredicate: E => Boolean) {
+
+  val logger = LoggerFactory.getLogger(this.getClass)
+
+  def onEvent(event: E): Future[Done] = {
+    if (failPredicate(event)) {
+      logger.info(s"failing on '$event'")
+      throw new RuntimeException(s"Failed on event '$event'")
+    } else
+      repository.save(event)
+  }
+
+}
+
+object TestEventHandler {
+
+  def apply[E](repository: TestInMemoryRepository[E]): TestEventHandler[E] =
+    TestEventHandler.apply(repository, (_: E) => false)
+
+  def apply[E](repository: TestInMemoryRepository[E], failPredicate: E => Boolean): TestEventHandler[E] =
+    new TestEventHandler(repository, failPredicate)
+}

--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/TestInMemoryRepository.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/TestInMemoryRepository.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2019-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.testkit
+
+import akka.Done
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.Future
+
+class TestInMemoryRepository[T] {
+
+  val logger = LoggerFactory.getLogger(this.getClass)
+
+  // FIXME: not safe, we need to harden it as test cases get more evolved
+  private var internalList: List[T] = Nil
+
+  def save(value: T): Future[Done] = {
+    logger.info(s"Saving event: '$value'")
+    internalList = value :: internalList
+    Future.successful(Done)
+  }
+
+  def size = internalList.size
+
+  def list = internalList.reverse
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -23,8 +23,29 @@ lazy val akkaProjectionCore = Project(
   ).settings(Dependencies.core)
 
 
+// provides Sources backed by Alpakka 
+// and Runners that commits on Topic (at-least-once, at-most-once)
+lazy val akkaProjectionAlpakkaKafka = Project(
+  id = "akka-projection-alpakka-kafka",
+  base = file("akka-projection-alpakka-kafka")
+).settings(Dependencies.alpakkaKafka)
+  .dependsOn(akkaProjectionCore, akkaProjectionTestkit)
+
+
+lazy val akkaProjectionSamples = Project(
+  id = "akka-projection-samples",
+  base = file("akka-projection-samples")
+).settings(Dependencies.sample)
+  .dependsOn(akkaProjectionCore, akkaProjectionAlpakkaKafka, akkaProjectionTestkit)
+
+lazy val akkaProjectionTestkit = Project(
+  id = "akka-projection-testkit",
+  base = file("akka-projection-testkit")
+).settings(libraryDependencies ++= Seq(Dependencies.Test.scalaTest, Dependencies.Compile.logback))
+  .dependsOn(akkaProjectionCore)
+
 
 lazy val root = Project(
     id = "akka-projection",
     base = file(".")
-  ).aggregate(akkaProjectionCore)
+  ).aggregate(akkaProjectionCore, akkaProjectionAlpakkaKafka, akkaProjectionTestkit)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+# See dockerhub for different versions of kafka and zookeeper
+# https://hub.docker.com/r/wurstmeister/kafka/
+# https://hub.docker.com/r/wurstmeister/zookeeper/
+version: '2.2'
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper:3.4.6
+    ports:
+      - "2181:2181"
+  kafka:
+    scale: ${KAFKA_SCALE:-1}
+    image: wurstmeister/kafka:1.1.0
+    ports:
+      - "9094"
+    environment:
+      HOSTNAME_COMMAND: "docker info | grep ^Name: | cut -d' ' -f 2"
+      PORT_COMMAND: "docker port `hostname` 9094 | cut -d: -f 2"
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://:9092,OUTSIDE://_{HOSTNAME_COMMAND}:_{PORT_COMMAND}
+      KAFKA_LISTENERS: INSIDE://:9092,OUTSIDE://:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS: 1 # default was 300 (5 minutes)
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: ${KAFKA_SCALE:-1}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,27 +6,55 @@ import sbt.Keys._
 object Dependencies {
 
   object Versions {
-    val akka = "2.5.17"
+    val akka = "2.6.4"
+
+    val scalaJava8Compat = "0.9.0"
+    val alpakkaKafka = "2.0.2"
 
     val scalaTest = "3.0.5"
-    val scalaJava8Compat = "0.9.0"
+    val testContainers = "1.11.2"
   }
 
   object Compile {
-    val akkaStream        = "com.typesafe.akka" %% "akka-stream" % Versions.akka
+    val persistenceQuery = "com.typesafe.akka" %% "akka-persistence-query" % Versions.akka
+
+    val akkaStream = "com.typesafe.akka" %% "akka-stream" % Versions.akka
+    val akkaSlf4j = "com.typesafe.akka" %% "akka-slf4j" % Versions.akka
+
+    val persistenceJDBC = "com.github.dnvriend" %% "akka-persistence-jdbc" % "3.5.3"
+    val persistenceCassandra = "com.typesafe.akka" %% "akka-persistence-cassandra" % "0.103"
+
+    val alpakkaKafka = "com.typesafe.akka" %% "akka-stream-kafka" % Versions.alpakkaKafka
+    val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
   }
 
   object Test {
-    val scalaTest = "org.scalatest" %% "scalatest" % Versions.scalaTest % "test" // ApacheV2
+    val aplakkaKafkaTestkit = "com.typesafe.akka" %% "akka-stream-kafka-testkit" % Versions.alpakkaKafka % sbt.Test
+
+    val scalaTest = "org.scalatest" %% "scalatest" % Versions.scalaTest %  sbt.Test
+    val testContainers = "org.testcontainers" % "kafka" % Versions.testContainers % sbt.Test
   }
 
   private val deps = libraryDependencies
+
 
   val core = deps ++= Seq(
     Compile.akkaStream
   )
 
-  val kafka = deps ++= Seq(
-    Compile.akkaStream
+  val sample = deps ++= Seq(
+    Compile.persistenceQuery,
+    Compile.persistenceJDBC,
+    Compile.persistenceCassandra
+  )
+
+  val alpakkaKafka = deps ++= Seq(
+    Compile.akkaStream,
+    Compile.alpakkaKafka,
+    // test
+    Compile.akkaSlf4j % sbt.Test,
+    Test.aplakkaKafkaTestkit,
+    Test.testContainers,
+    Test.scalaTest
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,7 @@
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.6")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.4.0")
-addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
- 
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0") 
 addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.31")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.18")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")


### PR DESCRIPTION
There is only a minimalistic Projection trait and one single Alpakka Kafka implementation that manages the lifecycle using `Consumer.Control`.

The user defines the Source the way they want, also any transformations, flow, whatever. Akka Projection only takes it and run it with the necessary start/stop hooks.

