### PR TITLE
ProjectionTestKit with support for TestSink

### DIFF
--- a/akka-projection-core/src/main/scala/akka/projection/Projection.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/Projection.scala
@@ -6,7 +6,8 @@ package akka.projection
 
 import akka.Done
 import akka.actor.ClassicActorSystemProvider
-import akka.annotation.ApiMayChange
+import akka.annotation.{ ApiMayChange, InternalApi }
+import akka.stream.scaladsl.Source
 
 import scala.concurrent.Future
 
@@ -44,17 +45,27 @@ trait Projection[StreamElement] {
    * @return A [[scala.concurrent.Future]] that represents the asynchronous completion of the user EventHandler
    *         function.
    */
-  def processElement(elt: StreamElement): Future[StreamElement]
+  def processElement(elt: StreamElement): Future[Done]
 
   /**
-   * Start to run a Projection.
+   * INTERNAL API
    *
-   * @param systemProvider An Akka ActorSystem.
+   * This method returns the projection Source mapped with `processElement`, but before any sink attached.
+   * This is mainly intended to be used by the TestKit allowing it to attach a TestSink to it.
    */
-  def start()(implicit systemProvider: ClassicActorSystemProvider): Unit
+  @InternalApi
+  private[projection] def mappedSource: Source[Done, _]
+
+  /**
+   * Run the Projection.
+   */
+  def run()(implicit systemProvider: ClassicActorSystemProvider): Unit
 
   /**
    * Stop the projection if it's running.
+   *
+   * @return Future[Done] - the returned Future should return the stream materialized value.
    */
   def stop(): Future[Done]
+
 }

--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/ProjectionTestKit.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/ProjectionTestKit.scala
@@ -4,12 +4,18 @@
 
 package akka.projection.testkit
 
+import akka.Done
+import akka.actor.ActorSystem
 import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.scaladsl.{ ActorTestKit, _ }
+import akka.actor.typed.scaladsl.adapter._
 import akka.annotation.ApiMayChange
 import akka.projection.Projection
-import scala.concurrent.duration._
+import akka.stream.testkit.TestSubscriber
+import akka.stream.testkit.scaladsl.TestSink
+
 import scala.concurrent.Await
+import scala.concurrent.duration._
 
 @ApiMayChange
 object ProjectionTestKit {
@@ -20,31 +26,38 @@ object ProjectionTestKit {
 @ApiMayChange
 final class ProjectionTestKit private[akka] (testKit: ActorTestKit) {
 
-  private implicit val system = testKit.system
-  private implicit val settings: TestKitSettings = TestKitSettings(system)
+  private implicit val settings: TestKitSettings = TestKitSettings(testKit.system)
 
-  def run(proj: Projection[_])(assertFunc: => Unit): Unit =
-    runInternal(proj, assertFunc, settings.SingleExpectDefaultTimeout, 100.millis)
+  def run(projection: Projection[_])(assertFunc: => Unit): Unit =
+    runInternal(projection, assertFunc, settings.SingleExpectDefaultTimeout, 100.millis)
 
-  def run(proj: Projection[_], max: FiniteDuration)(assertFunc: => Unit): Unit =
-    runInternal(proj, assertFunc, max, 100.millis)
+  def run(projection: Projection[_], max: FiniteDuration)(assertFunc: => Unit): Unit =
+    runInternal(projection, assertFunc, max, 100.millis)
 
-  def run(proj: Projection[_], max: FiniteDuration, interval: FiniteDuration)(assertFunc: => Unit): Unit =
-    runInternal(proj, assertFunc, max, interval)
+  def run(projection: Projection[_], max: FiniteDuration, interval: FiniteDuration)(assertFunc: => Unit): Unit =
+    runInternal(projection, assertFunc, max, interval)
 
   private def runInternal(
-      proj: Projection[_],
+      projection: Projection[_],
       assertFunc: => Unit,
       max: FiniteDuration,
       interval: FiniteDuration): Unit = {
 
-    val probe = testKit.createTestProbe[Nothing]("internal-projection-testkit-probe")
+    import testKit.system
 
+    val probe = testKit.createTestProbe[Nothing]("internal-projection-testkit-probe")
     try {
-      proj.start()
+      projection.run()
       probe.awaitAssert(assertFunc, max.dilated, interval)
     } finally {
-      Await.result(proj.stop(), max)
+      Await.result(projection.stop(), max)
     }
   }
+
+  def runWithTestSink[T](projection: Projection[_]): TestSubscriber.Probe[Done] = {
+    implicit val classicSys: ActorSystem = testKit.system.toClassic
+    val sinkProbe = TestSink.probe[Done]
+    projection.mappedSource.runWith(sinkProbe)
+  }
+
 }


### PR DESCRIPTION
This one builds on top of #47. 

It adds the possibility to use the testkit with a TestSink and control the flow of elements passing through the projection. 