### PR TITLE
Cassandra Projection, #21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ script:
   - jabba install ${JDK:=adopt@~1.8-0}
   - jabba use ${JDK:=adopt@~1.8-0}
   - java -version
+  - docker-compose up -d cassandra
   - sbt -jvm-opts .jvmopts-travis "$CMD"
 
 jobs:
@@ -63,6 +64,9 @@ stages:
   # runs on main repo master commits and version-tagged commits
   - name: publish
     if: repo = akka/akka-projection AND ( ( branch = master AND type = push ) OR tag =~ ^v )
+
+after_failure:
+  - docker-compose logs
 
 before_cache:
   - find $HOME/.ivy2 -name "ivydata-*.properties" -delete

--- a/akka-projection-cassandra/src/main/resources/reference.conf
+++ b/akka-projection-cassandra/src/main/resources/reference.conf
@@ -1,0 +1,22 @@
+akka.projection.cassandra {
+  # The implementation of `akka.stream.alpakka.cassandra.CqlSessionProvider`
+  # used for creating the `CqlSession`.
+  # It may optionally have a constructor with an `ClassicActorSystemProvider` and `Config` parameters.
+  session-provider = "akka.stream.alpakka.cassandra.DefaultSessionProvider"
+
+  # Configure Akka Discovery by setting a service name
+  service-discovery {
+    name = ""
+    lookup-timeout = 1 s
+  }
+
+  # The ExecutionContext to use for the session tasks and future composition.
+  session-dispatcher = "akka.actor.default-dispatcher"
+
+  # Full config path to the Datastax Java driver's configuration section.
+  # When connecting to more than one Cassandra cluster different session configuration can be
+  # defined with this property.
+  # See https://docs.datastax.com/en/developer/java-driver/latest/manual/core/configuration/#quick-overview
+  # and https://docs.datastax.com/en/developer/java-driver/latest/manual/core/configuration/reference/
+  datastax-java-driver-config = "datastax-java-driver"
+}

--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/CassandraOffsetStore.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/CassandraOffsetStore.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.projection.cassandra
 
 import scala.concurrent.Future

--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/CassandraOffsetStore.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/CassandraOffsetStore.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.projection.cassandra
+
+import scala.concurrent.Future
+
+import akka.Done
+import akka.annotation.ApiMayChange
+import akka.annotation.DoNotInherit
+import akka.projection.ProjectionId
+
+@ApiMayChange
+@DoNotInherit
+trait CassandraOffsetStore {
+
+  // FIXME compared to slick.OffsetStore this has the Cassandra prefix in the name?
+
+  def readOffset[Offset](projectionId: ProjectionId): Future[Option[Offset]]
+
+  def saveOffset[Offset](projectionId: ProjectionId, offset: Offset): Future[Done]
+
+  def createKeyspaceAndTable(): Future[Done]
+}

--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraOffsetStoreImpl.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraOffsetStoreImpl.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.projection.cassandra.internal
 
 import java.util.UUID

--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraOffsetStoreImpl.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraOffsetStoreImpl.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.projection.cassandra.internal
+
+import java.util.UUID
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import akka.Done
+import akka.annotation.InternalApi
+import akka.persistence.query
+import akka.projection.ProjectionId
+import akka.projection.cassandra.CassandraOffsetStore
+import akka.stream.alpakka.cassandra.scaladsl.CassandraSession
+import com.datastax.oss.driver.api.core.cql.Row
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object CassandraOffsetStoreImpl {
+  private val StringManifest = "STR"
+  private val LongManifest = "LNG"
+  private val IntManifest = "INT"
+  private val SequenceManifest = "SEQ"
+  private val TimeBasedUUIDManifest = "TBU"
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] class CassandraOffsetStoreImpl(session: CassandraSession)(implicit ec: ExecutionContext)
+    extends CassandraOffsetStore {
+  import CassandraOffsetStoreImpl._
+
+  // FIXME make keyspace and table names configurable
+  val keyspace = "akka_projection"
+  val table = "offset_store"
+
+  override def readOffset[Offset](projectionId: ProjectionId): Future[Option[Offset]] = {
+    session
+      .selectOne(s"SELECT offset, manifest FROM $keyspace.$table WHERE projection_id = ?", projectionId.id)
+      .map(fromRowToOffset)
+  }
+
+  def saveOffset[Offset](projectionId: ProjectionId, offset: Offset): Future[Done] = {
+    val (offsetStr, manifest) = stringOffsetAndManifest(offset)
+    session.executeWrite(
+      s"INSERT INTO $keyspace.$table (projection_id, offset, manifest) VALUES (?, ?, ?)",
+      projectionId.id,
+      offsetStr,
+      manifest)
+  }
+
+  /**
+   * Deserialize an offset from a result row.
+   * The offset is converted from its string representation to its real type.
+   */
+  private def fromRowToOffset[Offset](maybeRow: Option[Row]): Option[Offset] = {
+    maybeRow match {
+      case Some(row) =>
+        val offsetStr = row.getString("offset")
+        val manifest = row.getString("manifest")
+        val offset = (manifest match {
+          case StringManifest        => offsetStr
+          case LongManifest          => offsetStr.toLong
+          case IntManifest           => offsetStr.toInt
+          case SequenceManifest      => query.Offset.sequence(offsetStr.toLong)
+          case TimeBasedUUIDManifest => query.Offset.timeBasedUUID(UUID.fromString(offsetStr))
+        }).asInstanceOf[Offset]
+        Some(offset)
+      case None =>
+        None
+    }
+  }
+
+  /**
+   * Convert the offset to a tuple (String, String) where the first element is
+   * the String representation of the offset and the second its manifest
+   */
+  private def stringOffsetAndManifest[Offset](offset: Offset): (String, String) = {
+    offset match {
+      case s: String                => s -> StringManifest
+      case l: Long                  => l.toString -> LongManifest
+      case i: Int                   => i.toString -> IntManifest
+      case seq: query.Sequence      => seq.value.toString -> SequenceManifest
+      case tbu: query.TimeBasedUUID => tbu.value.toString -> TimeBasedUUIDManifest
+      case _                        => throw new IllegalArgumentException(s"Unsupported offset type, found [${offset.getClass.getName}]")
+    }
+  }
+
+  override def createKeyspaceAndTable(): Future[Done] = {
+    session
+      .executeDDL(
+        s"CREATE KEYSPACE IF NOT EXISTS $keyspace WITH REPLICATION = { 'class' : 'SimpleStrategy','replication_factor':1 }")
+      .flatMap(_ => session.executeDDL(s"""
+        |CREATE TABLE IF NOT EXISTS $keyspace.$table (
+        |  projection_id text,
+        |  offset text,
+        |  manifest text,
+        |  PRIMARY KEY (projection_id))
+        """.stripMargin.trim))
+  }
+
+}

--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.projection.cassandra.internal
 
 import java.util.concurrent.atomic.AtomicBoolean

--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
@@ -87,17 +87,13 @@ import akka.stream.scaladsl.Source
 
     val composedSource =
       if (saveOffsetAfterElements == 1) {
-        source.via(handlerFlow).mapAsync(1) { offset =>
-          offsetStore.saveOffset(projectionId, offset)
-        }
+        source.via(handlerFlow).mapAsync(1) { offset => offsetStore.saveOffset(projectionId, offset) }
       } else {
         source
           .via(handlerFlow)
           .groupedWithin(saveOffsetAfterElements, saveOffsetAfterDuration)
           .collect { case grouped if grouped.nonEmpty => grouped.last }
-          .mapAsync(parallelism = 1) { offset =>
-            offsetStore.saveOffset(projectionId, offset)
-          }
+          .mapAsync(parallelism = 1) { offset => offsetStore.saveOffset(projectionId, offset) }
       }
 
     composedSource

--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.projection.cassandra.internal
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.duration.FiniteDuration
+
+import akka.Done
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
+import akka.annotation.InternalApi
+import akka.projection.Projection
+import akka.projection.ProjectionId
+import akka.stream.KillSwitches
+import akka.stream.alpakka.cassandra.scaladsl.CassandraSessionRegistry
+import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] class CassandraProjectionImpl[Offset, StreamElement](
+    override val projectionId: ProjectionId,
+    sourceProvider: Option[Offset] => Source[StreamElement, _],
+    offsetExtractor: StreamElement => Offset,
+    saveOffsetAfterNumberOfEvents: Int,
+    saveOffsetAfterDuration: FiniteDuration,
+    handler: StreamElement => Future[Done])
+    extends Projection[StreamElement] {
+
+  private val killSwitch = KillSwitches.shared(projectionId.toString)
+  private val promiseToStop: Promise[Done] = Promise()
+  private val started = new AtomicBoolean(false)
+
+  override def run()(implicit systemProvider: ClassicActorSystemProvider): Unit = {
+    if (started.compareAndSet(false, true)) {
+      implicit val system: ActorSystem = systemProvider.classicSystem
+
+      val done = mappedSource().runWith(Sink.ignore)
+      promiseToStop.completeWith(done)
+    }
+  }
+
+  override def stop()(implicit ec: ExecutionContext): Future[Done] = {
+    if (started.get()) {
+      killSwitch.shutdown()
+      promiseToStop.future
+    } else {
+      Future.failed(new IllegalStateException(s"Projection [$projectionId] not started yet!"))
+    }
+  }
+
+  override private[projection] def mappedSource()(
+      implicit systemProvider: ClassicActorSystemProvider): Source[Done, _] = {
+    val system: ActorSystem = systemProvider.classicSystem
+    // FIXME maybe use the session-dispatcher config
+    implicit val ec: ExecutionContext = system.dispatcher
+
+    // FIXME make the sessionConfigPath configurable so that it can use same session as akka.persistence.cassandra or alpakka.cassandra
+    val sessionConfigPath = "akka.projection.cassandra"
+    // FIXME session look could be moved to CassandraOffsetStoreImpl if that's better
+    val session = CassandraSessionRegistry(system).sessionFor(sessionConfigPath)
+
+    val offsetStore = new CassandraOffsetStoreImpl(session)
+
+    val lastKnownOffset: Future[Option[Offset]] = offsetStore.readOffset(projectionId)
+
+    val source: Source[(Offset, StreamElement), NotUsed] =
+      Source
+        .futureSource(lastKnownOffset.map(sourceProvider))
+        .via(killSwitch.flow)
+        .map(element => offsetExtractor(element) -> element)
+        .mapMaterializedValue(_ => NotUsed)
+
+    val handlerFlow: Flow[(Offset, StreamElement), Offset, NotUsed] =
+      Flow[(Offset, StreamElement)].mapAsync(parallelism = 1) {
+        case (offset, element) => handler(element).map(_ => offset)
+      }
+
+    val composedSource =
+      if (saveOffsetAfterNumberOfEvents == 1) {
+        source.via(handlerFlow).mapAsync(1) { offset => offsetStore.saveOffset(projectionId, offset) }
+      } else {
+        source
+          .via(handlerFlow)
+          .groupedWithin(saveOffsetAfterNumberOfEvents, saveOffsetAfterDuration)
+          .collect { case grouped if grouped.nonEmpty => grouped.last }
+          .mapAsync(parallelism = 1) { offset => offsetStore.saveOffset(projectionId, offset) }
+      }
+
+    composedSource
+  }
+
+  // FIXME
+  def processElement(elt: StreamElement)(implicit ec: ExecutionContext): Future[Done] = ???
+}

--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/scaladsl/CassandraProjection.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/scaladsl/CassandraProjection.scala
@@ -20,13 +20,13 @@ object CassandraProjection {
       projectionId: ProjectionId,
       sourceProvider: Option[Offset] => Source[StreamElement, _],
       offsetExtractor: StreamElement => Offset,
-      saveOffsetAfterNumberOfEvents: Int,
+      saveOffsetAfterElements: Int,
       saveOffsetAfterDuration: FiniteDuration)(handler: StreamElement => Future[Done]): Projection[StreamElement] =
     new CassandraProjectionImpl(
       projectionId,
       sourceProvider,
       offsetExtractor,
-      saveOffsetAfterNumberOfEvents,
+      saveOffsetAfterElements,
       saveOffsetAfterDuration,
       handler)
 }

--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/scaladsl/CassandraProjection.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/scaladsl/CassandraProjection.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.projection.cassandra.scaladsl
 
 import scala.concurrent.Future

--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/scaladsl/CassandraProjection.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/scaladsl/CassandraProjection.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.projection.cassandra.scaladsl
+
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+
+import akka.Done
+import akka.annotation.ApiMayChange
+import akka.projection.Projection
+import akka.projection.ProjectionId
+import akka.projection.cassandra.internal.CassandraProjectionImpl
+import akka.stream.scaladsl.Source
+
+@ApiMayChange
+object CassandraProjection {
+
+  def atLeastOnce[Offset, StreamElement](
+      projectionId: ProjectionId,
+      sourceProvider: Option[Offset] => Source[StreamElement, _],
+      offsetExtractor: StreamElement => Offset,
+      saveOffsetAfterNumberOfEvents: Int,
+      saveOffsetAfterDuration: FiniteDuration)(handler: StreamElement => Future[Done]): Projection[StreamElement] =
+    new CassandraProjectionImpl(
+      projectionId,
+      sourceProvider,
+      offsetExtractor,
+      saveOffsetAfterNumberOfEvents,
+      saveOffsetAfterDuration,
+      handler)
+}

--- a/akka-projection-cassandra/src/test/resources/logback-test.xml
+++ b/akka-projection-cassandra/src/test/resources/logback-test.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!-- Silence initial setup logging from Logback -->
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+  <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />
+
+  <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >
+    <appender-ref ref="STDOUT"/>
+  </logger>
+
+  <logger name="org.apache.cassandra" level="ERROR" />
+  <logger name="com.datastax" level="INFO" />
+  <logger name="io.netty" level="ERROR" />
+
+  <root level="DEBUG">
+    <appender-ref ref="CapturingAppender" />
+  </root>
+</configuration>

--- a/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraOffsetStoreSpec.scala
+++ b/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraOffsetStoreSpec.scala
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.projection.cassandra
+
+import java.util.UUID
+
+import scala.concurrent.ExecutionContext
+import scala.util.Try
+
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.persistence.query.Sequence
+import akka.persistence.query.TimeBasedUUID
+import akka.projection.ProjectionId
+import akka.projection.cassandra.internal.CassandraOffsetStoreImpl
+import akka.stream.alpakka.cassandra.scaladsl.CassandraSessionRegistry
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class CassandraOffsetStoreSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
+
+  private val session = CassandraSessionRegistry(system).sessionFor("akka.projection.cassandra")
+  private implicit val ec: ExecutionContext = system.executionContext
+  private val offsetStore = new CassandraOffsetStoreImpl(session)
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    // reason for setSchemaMetadataEnabled is that it speed up tests
+    session.underlying().map(_.setSchemaMetadataEnabled(false)).futureValue
+    offsetStore.createKeyspaceAndTable().futureValue
+    session.underlying().map(_.setSchemaMetadataEnabled(null)).futureValue
+  }
+
+  override protected def afterAll(): Unit = {
+    Try(session.executeDDL(s"DROP keyspace ${offsetStore.keyspace}").futureValue)
+    super.afterAll()
+  }
+
+  "The Cassandra OffsetStore" must {
+
+    "create and update offsets" in {
+      val projectionId = ProjectionId("projection-with-long", "00")
+
+      withClue("check - save offset 1L") {
+        offsetStore.saveOffset(projectionId, 1L).futureValue
+      }
+
+      withClue("check - read offset") {
+        val offset = offsetStore.readOffset[Long](projectionId).futureValue.get
+        offset shouldBe 1L
+      }
+
+      withClue("check - save offset 2L") {
+        offsetStore.saveOffset(projectionId, 2L).futureValue
+      }
+
+      withClue("check - read offset after overwrite") {
+        val offset = offsetStore.readOffset[Long](projectionId).futureValue.get
+        offset shouldBe 2L // yep, saveOffset overwrites previous
+      }
+
+    }
+
+    "save and retrieve offsets of type Long" in {
+      val projectionId = ProjectionId("projection-with-long", "00")
+
+      withClue("check - save offset") {
+        offsetStore.saveOffset(projectionId, 1L).futureValue
+      }
+
+      withClue("check - read offset") {
+        val offset = offsetStore.readOffset[Long](projectionId).futureValue.get
+        offset shouldBe 1L
+      }
+
+    }
+
+    "save and retrieve offsets of type java.lang.Long" in {
+      val projectionId = ProjectionId("projection-with-java-long", "00")
+
+      withClue("check - save offset") {
+        offsetStore.saveOffset(projectionId, java.lang.Long.valueOf(1L)).futureValue
+      }
+
+      withClue("check - read offset") {
+        val offset = offsetStore.readOffset[java.lang.Long](projectionId).futureValue.get
+        offset shouldBe 1L
+      }
+    }
+
+    "save and retrieve offsets of type Int" in {
+      val projectionId = ProjectionId("projection-with-int", "00")
+
+      withClue("check - save offset") {
+        offsetStore.saveOffset(projectionId, 1).futureValue
+      }
+
+      withClue("check - read offset") {
+        val offset = offsetStore.readOffset[Int](projectionId).futureValue.get
+        offset shouldBe 1
+      }
+
+    }
+
+    "save and retrieve offsets of type java.lang.Integer" in {
+      val projectionId = ProjectionId("projection-with-java-int", "00")
+
+      withClue("check - save offset") {
+        offsetStore.saveOffset(projectionId, java.lang.Integer.valueOf(1)).futureValue
+      }
+
+      withClue("check - read offset") {
+        val offset = offsetStore.readOffset[java.lang.Integer](projectionId).futureValue.get
+        offset shouldBe 1
+      }
+    }
+
+    "save and retrieve offsets of type String" in {
+
+      val projectionId = ProjectionId("projection-with-String", "00")
+
+      val randOffset = UUID.randomUUID().toString
+      withClue("check - save offset") {
+        offsetStore.saveOffset(projectionId, randOffset).futureValue
+      }
+
+      withClue("check - read offset") {
+        val offset = offsetStore.readOffset[String](projectionId).futureValue.get
+        offset shouldBe randOffset
+      }
+    }
+
+    "save and retrieve offsets of type akka.persistence.query.Sequence" in {
+
+      val projectionId = ProjectionId("projection-with-akka-seq", "00")
+
+      val seqOffset = Sequence(1L)
+      withClue("check - save offset") {
+        offsetStore.saveOffset(projectionId, seqOffset).futureValue
+      }
+
+      withClue("check - read offset") {
+        val offset = offsetStore.readOffset[Sequence](projectionId).futureValue.get
+        offset shouldBe seqOffset
+      }
+    }
+
+    "save and retrieve offsets of type akka.persistence.query.TimeBasedUUID" in {
+
+      val projectionId = ProjectionId("projection-with-akka-seq", "00")
+
+      val timeOffset = TimeBasedUUID(UUID.fromString("49225740-2019-11ea-a752-ffae2393b6e4")) //2019-12-16T15:32:36.148Z[UTC]
+      withClue("check - save offset") {
+        offsetStore.saveOffset(projectionId, timeOffset).futureValue
+      }
+
+      withClue("check - read offset") {
+        val offset = offsetStore.readOffset[TimeBasedUUID](projectionId).futureValue.get
+        offset shouldBe timeOffset
+      }
+    }
+  }
+}

--- a/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraOffsetStoreSpec.scala
+++ b/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraOffsetStoreSpec.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.projection.cassandra
 
 import java.util.UUID

--- a/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
+++ b/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
@@ -143,8 +143,7 @@ class CassandraProjectionSpec extends ScalaTestWithActorTestKit with AnyWordSpec
       val projection =
         CassandraProjection
           .atLeastOnce[Long, Envelope](projectionId, sourceProvider(entityId), offsetExtractor, 1, Duration.Zero) {
-            envelope =>
-              repository.concatToText(envelope.id, envelope.message)
+            envelope => repository.concatToText(envelope.id, envelope.message)
           }
 
       projectionTestKit.run(projection) {
@@ -200,8 +199,7 @@ class CassandraProjectionSpec extends ScalaTestWithActorTestKit with AnyWordSpec
       val projection =
         CassandraProjection
           .atLeastOnce[Long, Envelope](projectionId, sourceProvider(entityId), offsetExtractor, 1, Duration.Zero) {
-            envelope =>
-              repository.concatToText(envelope.id, envelope.message)
+            envelope => repository.concatToText(envelope.id, envelope.message)
           }
 
       projectionTestKit.run(projection) {
@@ -230,8 +228,7 @@ class CassandraProjectionSpec extends ScalaTestWithActorTestKit with AnyWordSpec
 
       val projection =
         CassandraProjection.atLeastOnce[Long, Envelope](projectionId, _ => source, offsetExtractor, 10, 1.minute) {
-          envelope =>
-            repository.concatToText(envelope.id, envelope.message)
+          envelope => repository.concatToText(envelope.id, envelope.message)
         }
 
       val sinkProbe = projectionTestKit.runWithTestSink(projection)
@@ -240,17 +237,13 @@ class CassandraProjectionSpec extends ScalaTestWithActorTestKit with AnyWordSpec
       }
       sinkProbe.request(1000)
 
-      (1 to 15).foreach { n =>
-        sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
-      }
+      (1 to 15).foreach { n => sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n")) }
       eventually {
         repository.findById(entityId).futureValue.get.text should include("elem-15")
       }
       offsetStore.readOffset[Long](projectionId).futureValue.get shouldBe 10L
 
-      (16 to 22).foreach { n =>
-        sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
-      }
+      (16 to 22).foreach { n => sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n")) }
       eventually {
         repository.findById(entityId).futureValue.get.text should include("elem-22")
       }
@@ -272,8 +265,7 @@ class CassandraProjectionSpec extends ScalaTestWithActorTestKit with AnyWordSpec
 
       val projection =
         CassandraProjection.atLeastOnce[Long, Envelope](projectionId, _ => source, offsetExtractor, 10, 2.seconds) {
-          envelope =>
-            repository.concatToText(envelope.id, envelope.message)
+          envelope => repository.concatToText(envelope.id, envelope.message)
         }
 
       val sinkProbe = projectionTestKit.runWithTestSink(projection)
@@ -282,17 +274,13 @@ class CassandraProjectionSpec extends ScalaTestWithActorTestKit with AnyWordSpec
       }
       sinkProbe.request(1000)
 
-      (1 to 15).foreach { n =>
-        sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
-      }
+      (1 to 15).foreach { n => sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n")) }
       eventually {
         repository.findById(entityId).futureValue.get.text should include("elem-15")
       }
       offsetStore.readOffset[Long](projectionId).futureValue.get shouldBe 10L
 
-      (16 to 17).foreach { n =>
-        sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
-      }
+      (16 to 17).foreach { n => sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n")) }
       eventually {
         offsetStore.readOffset[Long](projectionId).futureValue.get shouldBe 17L
       }

--- a/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
+++ b/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.projection.cassandra
+
+import java.util.UUID
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.util.Try
+
+import akka.Done
+import akka.NotUsed
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.projection.ProjectionId
+import akka.projection.cassandra.internal.CassandraOffsetStoreImpl
+import akka.projection.cassandra.scaladsl.CassandraProjection
+import akka.projection.testkit.ProjectionTestKit
+import akka.stream.alpakka.cassandra.scaladsl.CassandraSession
+import akka.stream.alpakka.cassandra.scaladsl.CassandraSessionRegistry
+import akka.stream.scaladsl.Source
+import org.scalatest.wordspec.AnyWordSpecLike
+
+object CassandraProjectionSpec {
+  case class Envelope(id: String, offset: Long, message: String)
+
+  def offsetExtractor(env: Envelope): Long = env.offset
+
+  def sourceProvider(id: String)(offset: Option[Long]): Source[Envelope, NotUsed] = {
+    val elements =
+      List(
+        Envelope(id, 1L, "abc"),
+        Envelope(id, 2L, "def"),
+        Envelope(id, 3L, "ghi"),
+        Envelope(id, 4L, "jkl"),
+        Envelope(id, 5L, "mno"),
+        Envelope(id, 6L, "pqr"))
+
+    val src = Source.fromIterator(() => elements.iterator)
+
+    offset match {
+      case Some(o) => src.dropWhile(_.offset <= o)
+      case _       => src
+    }
+  }
+
+  // test model is as simple as a text that gets other string concatenated to it
+  case class ConcatStr(id: String, text: String) {
+    def concat(newMsg: String): ConcatStr = copy(text = text + "|" + newMsg)
+  }
+
+  class TestRepository(session: CassandraSession)(implicit val ec: ExecutionContext) {
+    val keyspace = "test"
+    val table = "test_model"
+
+    def concatToText(id: String, payload: String)(implicit ec: ExecutionContext): Future[Done.type] = {
+      for {
+        concatStr <- findById(id).map {
+          case Some(concatStr) => concatStr.concat(payload)
+          case _               => ConcatStr(id, payload)
+        }
+        _ <- session.executeWrite(s"INSERT INTO $keyspace.$table (id, concatenated) VALUES (?, ?)", id, concatStr.text)
+      } yield Done
+    }
+
+    def findById(id: String): Future[Option[ConcatStr]] = {
+      session.selectOne(s"SELECT concatenated FROM $keyspace.$table WHERE id = ?", id).map {
+        case Some(row) => Some(ConcatStr(id, row.getString("concatenated")))
+        case None      => None
+      }
+    }
+
+    def readValue(id: String): Future[String] = {
+      findById(id).map {
+        case Some(concatStr) => concatStr.text
+        case _               => "N/A"
+      }
+    }
+
+    def createKeyspaceAndTable(): Future[Done] = {
+      session
+        .executeDDL(
+          s"CREATE KEYSPACE IF NOT EXISTS $keyspace WITH REPLICATION = { 'class' : 'SimpleStrategy','replication_factor':1 }")
+        .flatMap(_ => session.executeDDL(s"""
+        |CREATE TABLE IF NOT EXISTS $keyspace.$table (
+        |  id text,
+        |  concatenated text,
+        |  PRIMARY KEY (id))
+        """.stripMargin.trim))
+    }
+  }
+
+}
+
+class CassandraProjectionSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
+
+  import CassandraProjectionSpec._
+
+  private val session = CassandraSessionRegistry(system).sessionFor("akka.projection.cassandra")
+  private implicit val ec: ExecutionContext = system.executionContext
+  private val offsetStore = new CassandraOffsetStoreImpl(session)
+  private val repository = new TestRepository(session)
+  private val projectionTestKit = new ProjectionTestKit(testKit)
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    offsetStore.createKeyspaceAndTable().futureValue
+    repository.createKeyspaceAndTable().futureValue
+  }
+
+  override protected def afterAll(): Unit = {
+    // reason for setSchemaMetadataEnabled is that it speed up tests
+    Try(session.underlying().map(_.setSchemaMetadataEnabled(false)).futureValue)
+    Try(session.executeDDL(s"DROP keyspace ${offsetStore.keyspace}").futureValue)
+    Try(session.executeDDL(s"DROP keyspace ${repository.keyspace}").futureValue)
+    Try(session.underlying().map(_.setSchemaMetadataEnabled(null)).futureValue)
+    super.afterAll()
+  }
+
+  private def genRandomProjectionId() =
+    ProjectionId(UUID.randomUUID().toString, UUID.randomUUID().toString)
+
+  "A Cassandra projection" must {
+
+    "persist projection and offset" in {
+      val entityId = UUID.randomUUID().toString
+      val projectionId = genRandomProjectionId()
+
+      withClue("check - offset is empty") {
+        val offsetOpt = offsetStore.readOffset[Long](projectionId).futureValue
+        offsetOpt shouldBe empty
+      }
+
+      val projection =
+        CassandraProjection
+          .atLeastOnce[Long, Envelope](projectionId, sourceProvider(entityId), offsetExtractor, 1, Duration.Zero) {
+            envelope => repository.concatToText(envelope.id, envelope.message)
+          }
+
+      projectionTestKit.run(projection) {
+        withClue("check - all values were concatenated") {
+          val concatStr = repository.findById(entityId).futureValue.get
+          concatStr.text shouldBe "abc|def|ghi|jkl|mno|pqr"
+        }
+      }
+      withClue("check - all offsets were seen") {
+        val offset = offsetStore.readOffset[Long](projectionId).futureValue.get
+        offset shouldBe 6L
+      }
+    }
+
+    "restart from previous offset - handler throwing an exception" in {
+      val entityId = UUID.randomUUID().toString
+      val projectionId = genRandomProjectionId()
+
+      val streamFailureMsg = "fail on fourth element"
+      val failingProjection =
+        CassandraProjection
+          .atLeastOnce[Long, Envelope](projectionId, sourceProvider(entityId), offsetExtractor, 1, Duration.Zero) {
+            envelope =>
+              if (envelope.offset == 4L) throw new RuntimeException(streamFailureMsg)
+              repository.concatToText(envelope.id, envelope.message)
+          }
+
+      withClue("check - offset is empty") {
+        val offsetOpt = offsetStore.readOffset[Long](projectionId).futureValue
+        offsetOpt shouldBe empty
+      }
+
+      val streamFailure =
+        intercept[RuntimeException] {
+          projectionTestKit.run(failingProjection) {
+            fail("fail assertFunc, we want to capture the stream failure")
+          }
+        }
+
+      withClue("check: projection failed with stream failure") {
+        streamFailure.getMessage shouldBe streamFailureMsg
+      }
+      withClue("check: projection is consumed up to third") {
+        val concatStr = repository.findById(entityId).futureValue.get
+        concatStr.text shouldBe "abc|def|ghi"
+      }
+      withClue("check: last seen offset is 3L") {
+        val offset = offsetStore.readOffset[Long](projectionId).futureValue.get
+        offset shouldBe 3L
+      }
+
+      // re-run projection without failing function
+      val projection =
+        CassandraProjection
+          .atLeastOnce[Long, Envelope](projectionId, sourceProvider(entityId), offsetExtractor, 1, Duration.Zero) {
+            envelope => repository.concatToText(envelope.id, envelope.message)
+          }
+
+      projectionTestKit.run(projection) {
+        withClue("checking: all values were concatenated") {
+          val concatStr = repository.findById(entityId).futureValue.get
+          concatStr.text shouldBe "abc|def|ghi|jkl|mno|pqr"
+        }
+      }
+
+      withClue("check: all offsets were seen") {
+        val offset = offsetStore.readOffset[Long](projectionId).futureValue.get
+        offset shouldBe 6L
+      }
+    }
+  }
+}

--- a/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
+++ b/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.projection.cassandra
 
 import java.util.UUID

--- a/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
+++ b/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
@@ -76,9 +76,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
           projectionId,
           sourceProvider = sourceProvider(entityId),
           offsetExtractor = offsetExtractor,
-          databaseConfig = dbConfig) { envelope =>
-          repository.concatToText(envelope.id, envelope.message)
-        }
+          databaseConfig = dbConfig) { envelope => repository.concatToText(envelope.id, envelope.message) }
 
       projectionTestKit.run(slickProjection) {
         withClue("check - all values were concatenated") {
@@ -140,9 +138,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
           projectionId = projectionId,
           sourceProvider = sourceProvider(entityId),
           offsetExtractor = offsetExtractor,
-          databaseConfig = dbConfig) { envelope =>
-          repository.concatToText(envelope.id, envelope.message)
-        }
+          databaseConfig = dbConfig) { envelope => repository.concatToText(envelope.id, envelope.message) }
 
       projectionTestKit.run(slickProjection) {
         withClue("checking: all values were concatenated") {
@@ -205,9 +201,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
           projectionId = projectionId,
           sourceProvider = sourceProvider(entityId),
           offsetExtractor = offsetExtractor,
-          databaseConfig = dbConfig) { envelope =>
-          repository.concatToText(envelope.id, envelope.message)
-        }
+          databaseConfig = dbConfig) { envelope => repository.concatToText(envelope.id, envelope.message) }
 
       projectionTestKit.run(slickProjection) {
         withClue("checking: all values were concatenated") {
@@ -265,9 +259,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
           projectionId = projectionId,
           sourceProvider = sourceProvider(entityId),
           offsetExtractor = offsetExtractor,
-          databaseConfig = dbConfig) { envelope =>
-          repository.concatToText(envelope.id, envelope.message)
-        }
+          databaseConfig = dbConfig) { envelope => repository.concatToText(envelope.id, envelope.message) }
 
       projectionTestKit.run(slickProjection) {
         withClue("checking: all values were concatenated") {

--- a/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
+++ b/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
@@ -76,7 +76,9 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
           projectionId,
           sourceProvider = sourceProvider(entityId),
           offsetExtractor = offsetExtractor,
-          databaseConfig = dbConfig) { envelope => repository.concatToText(envelope.id, envelope.message) }
+          databaseConfig = dbConfig) { envelope =>
+          repository.concatToText(envelope.id, envelope.message)
+        }
 
       projectionTestKit.run(slickProjection) {
         withClue("check - all values were concatenated") {
@@ -138,7 +140,9 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
           projectionId = projectionId,
           sourceProvider = sourceProvider(entityId),
           offsetExtractor = offsetExtractor,
-          databaseConfig = dbConfig) { envelope => repository.concatToText(envelope.id, envelope.message) }
+          databaseConfig = dbConfig) { envelope =>
+          repository.concatToText(envelope.id, envelope.message)
+        }
 
       projectionTestKit.run(slickProjection) {
         withClue("checking: all values were concatenated") {
@@ -201,7 +205,9 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
           projectionId = projectionId,
           sourceProvider = sourceProvider(entityId),
           offsetExtractor = offsetExtractor,
-          databaseConfig = dbConfig) { envelope => repository.concatToText(envelope.id, envelope.message) }
+          databaseConfig = dbConfig) { envelope =>
+          repository.concatToText(envelope.id, envelope.message)
+        }
 
       projectionTestKit.run(slickProjection) {
         withClue("checking: all values were concatenated") {
@@ -259,7 +265,9 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
           projectionId = projectionId,
           sourceProvider = sourceProvider(entityId),
           offsetExtractor = offsetExtractor,
-          databaseConfig = dbConfig) { envelope => repository.concatToText(envelope.id, envelope.message) }
+          databaseConfig = dbConfig) { envelope =>
+          repository.concatToText(envelope.id, envelope.message)
+        }
 
       projectionTestKit.run(slickProjection) {
         withClue("checking: all values were concatenated") {
@@ -289,7 +297,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
         Envelope(id, 5L, "mno"),
         Envelope(id, 6L, "pqr"))
 
-    val src = Source.fromIterator(() => elements.iterator)
+    val src = Source(elements)
 
     offset match {
       case Some(o) => src.dropWhile(_.offset <= o)

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,13 @@ lazy val slick = Project(id = "akka-projection-slick", base = file("akka-project
   .dependsOn(core)
   .dependsOn(testkit % "test->test")
 
+// provides offset storage backed by a Cassandra table
+lazy val cassandra = Project(id = "akka-projection-cassandra", base = file("akka-projection-cassandra"))
+  .settings(Dependencies.cassandra)
+  .settings(Test / parallelExecution := false)
+  .dependsOn(core)
+  .dependsOn(testkit % "test->test")
+
 lazy val docs = project
   .enablePlugins(AkkaParadoxPlugin, ParadoxSitePlugin, PreprocessPlugin, PublishRsyncPlugin)
   .dependsOn(core, testkit)
@@ -54,8 +61,7 @@ lazy val docs = project
         // Scala
         "scaladoc.scala.base_url" -> s"https://www.scala-lang.org/api/${scalaBinaryVersion.value}.x/",
         "scaladoc.akka.projection.base_url" -> s"/${(Preprocess / siteSubdirName).value}/",
-        "javadoc.akka.projection.base_url" -> ""
-      ), // no Javadoc is published
+        "javadoc.akka.projection.base_url" -> ""), // no Javadoc is published
     paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
     ApidocPlugin.autoImport.apidocRootPackage := "akka",
     resolvers += Resolver.jcenterRepo,
@@ -64,7 +70,7 @@ lazy val docs = project
     apidocRootPackage := "akka")
 
 lazy val root = Project(id = "akka-projection", base = file("."))
-  .aggregate(core, testkit, slick, docs)
+  .aggregate(core, testkit, slick, cassandra, docs)
   .enablePlugins(ScalaUnidocPlugin)
   .disablePlugins(SitePlugin)
 

--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,8 @@ lazy val docs = project
         // Scala
         "scaladoc.scala.base_url" -> s"https://www.scala-lang.org/api/${scalaBinaryVersion.value}.x/",
         "scaladoc.akka.projection.base_url" -> s"/${(Preprocess / siteSubdirName).value}/",
-        "javadoc.akka.projection.base_url" -> ""), // no Javadoc is published
+        "javadoc.akka.projection.base_url" -> ""
+      ), // no Javadoc is published
     paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
     ApidocPlugin.autoImport.apidocRootPackage := "akka",
     resolvers += Resolver.jcenterRepo,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  cassandra:
+    image: cassandra:latest
+    ports:
+      - "9042:9042"

--- a/docker-files/cassandra.yaml
+++ b/docker-files/cassandra.yaml
@@ -1,0 +1,913 @@
+# Cassandra storage config YAML
+
+# NOTE:
+#   See http://wiki.apache.org/cassandra/StorageConfiguration for
+#   full explanations of configuration directives
+# /NOTE
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+cluster_name: 'Test Cluster'
+
+# This defines the number of tokens randomly assigned to this node on the ring
+# The more tokens, relative to other nodes, the larger the proportion of data
+# that this node will store. You probably want all nodes to have the same number
+# of tokens assuming they have equal hardware capability.
+#
+# If you leave this unspecified, Cassandra will use the default of 1 token for legacy compatibility,
+# and will use the initial_token as described below.
+#
+# Specifying initial_token will override this setting on the node's initial start,
+# on subsequent starts, this setting will apply even if initial token is set.
+#
+# If you already have a cluster with 1 token per node, and wish to migrate to
+# multiple tokens per node, see http://wiki.apache.org/cassandra/Operations
+num_tokens: 256
+
+# initial_token allows you to specify tokens manually.  While you can use # it with
+# vnodes (num_tokens > 1, above) -- in which case you should provide a
+# comma-separated list -- it's primarily used when adding nodes # to legacy clusters
+# that do not have vnodes enabled.
+# initial_token:
+
+# See http://wiki.apache.org/cassandra/HintedHandoff
+# May either be "true" or "false" to enable globally, or contain a list
+# of data centers to enable per-datacenter.
+# hinted_handoff_enabled: DC1,DC2
+hinted_handoff_enabled: true
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
+max_hint_window_in_ms: 10800000 # 3 hours
+# Maximum throttle in KBs per second, per delivery thread.  This will be
+# reduced proportionally to the number of nodes in the cluster.  (If there
+# are two nodes in the cluster, each delivery thread will use the maximum
+# rate; if there are three, each will throttle to half of the maximum,
+# since we expect two nodes to be delivering hints simultaneously.)
+hinted_handoff_throttle_in_kb: 1024
+# Number of threads with which to deliver hints;
+# Consider increasing this number when you have multi-dc deployments, since
+# cross-dc handoff tends to be slower
+max_hints_delivery_threads: 2
+
+# Maximum throttle in KBs per second, total. This will be
+# reduced proportionally to the number of nodes in the cluster.
+batchlog_replay_throttle_in_kb: 1024
+
+# Authentication backend, implementing IAuthenticator; used to identify users
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+# PasswordAuthenticator}.
+#
+# - AllowAllAuthenticator performs no checks - set it to disable authentication.
+# - PasswordAuthenticator relies on username/password pairs to authenticate
+#   users. It keeps usernames and hashed passwords in system_auth.credentials table.
+#   Please increase system_auth keyspace replication factor if you use this authenticator.
+#   If using PasswordAuthenticator, CassandraRoleManager must also be used (see below)
+authenticator: AllowAllAuthenticator
+
+# Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+# CassandraAuthorizer}.
+#
+# - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+# - CassandraAuthorizer stores permissions in system_auth.permissions table. Please
+#   increase system_auth keyspace replication factor if you use this authorizer.
+authorizer: AllowAllAuthorizer
+
+# Part of the Authentication & Authorization backend, implementing IRoleManager; used
+# to maintain grants and memberships between roles.
+# Out of the box, Cassandra provides org.apache.cassandra.auth.CassandraRoleManager,
+# which stores role information in the system_auth keyspace. Most functions of the
+# IRoleManager require an authenticated login, so unless the configured IAuthenticator
+# actually implements authentication, most of this functionality will be unavailable.
+#
+# - CassandraRoleManager stores role data in the system_auth keyspace. Please
+#   increase system_auth keyspace replication factor if you use this role manager.
+role_manager: CassandraRoleManager
+
+# Validity period for roles cache (fetching permissions can be an
+# expensive operation depending on the authorizer). Granted roles are cached for
+# authenticated sessions in AuthenticatedUser and after the period specified
+# here, become eligible for (async) reload.
+# Defaults to 2000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthenticator.
+roles_validity_in_ms: 2000
+
+# Refresh interval for roles cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If roles_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as roles_validity_in_ms.
+# roles_update_interval_in_ms: 1000
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 2000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+permissions_validity_in_ms: 2000
+
+# Refresh interval for permissions cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If permissions_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as permissions_validity_in_ms.
+# permissions_update_interval_in_ms: 1000
+
+# The partitioner is responsible for distributing groups of rows (by
+# partition key) across nodes in the cluster.  You should leave this
+# alone for new clusters.  The partitioner can NOT be changed without
+# reloading all data, so when upgrading you should set this to the
+# same partitioner you were already using.
+#
+# Besides Murmur3Partitioner, partitioners included for backwards
+# compatibility include RandomPartitioner, ByteOrderedPartitioner, and
+# OrderPreservingPartitioner.
+#
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+# Directories where Cassandra should store data on disk.  Cassandra
+# will spread data evenly across them, subject to the granularity of
+# the configured compaction strategy.
+# If not set, the default directory is $CASSANDRA_HOME/data/data.
+# data_file_directories:
+#     - /var/lib/cassandra/data
+
+# commit log.  when running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+# If not set, the default directory is $CASSANDRA_HOME/data/commitlog.
+# commitlog_directory: /var/lib/cassandra/commitlog
+
+# policy for data disk failures:
+# die: shut down gossip and client transports and kill the JVM for any fs errors or
+#      single-sstable errors, so the node can be replaced.
+# stop_paranoid: shut down gossip and client transports even for single-sstable errors,
+#                kill the JVM for errors during startup.
+# stop: shut down gossip and client transports, leaving the node effectively dead, but
+#       can still be inspected via JMX, kill the JVM for errors during startup.
+# best_effort: stop using the failed disk and respond to requests based on
+#              remaining available sstables.  This means you WILL see obsolete
+#              data at CL.ONE!
+# ignore: ignore fatal errors and let requests fail, as in pre-1.2 Cassandra
+disk_failure_policy: stop
+
+# policy for commit disk failures:
+# die: shut down gossip and Thrift and kill the JVM, so the node can be replaced.
+# stop: shut down gossip and Thrift, leaving the node effectively dead, but
+#       can still be inspected via JMX.
+# stop_commit: shutdown the commit log, letting writes collect but
+#              continuing to service reads, as in pre-2.0.5 Cassandra
+# ignore: ignore fatal errors and let the batches fail
+commit_failure_policy: stop
+
+# Maximum size of the key cache in memory.
+#
+# Each key cache hit saves 1 seek and each row cache hit saves 2 seeks at the
+# minimum, sometimes more. The key cache is fairly tiny for the amount of
+# time it saves, so it's worthwhile to use it at large numbers.
+# The row cache saves even more time, but must contain the entire row,
+# so it is extremely space-intensive. It's best to only use the
+# row cache if you have hot rows or static rows.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(5% of Heap (in MB), 100MB)). Set to 0 to disable key cache.
+key_cache_size_in_mb:
+
+# Duration in seconds after which Cassandra should
+# save the key cache. Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 14400 or 4 hours.
+key_cache_save_period: 14400
+
+# Number of keys from the key cache to save
+# Disabled by default, meaning all keys are going to be saved
+# key_cache_keys_to_save: 100
+
+# Row cache implementation class name.
+# Available implementations:
+#   org.apache.cassandra.cache.OHCProvider                Fully off-heap row cache implementation (default).
+#   org.apache.cassandra.cache.SerializingCacheProvider   This is the row cache implementation availabile
+#                                                         in previous releases of Cassandra.
+# row_cache_class_name: org.apache.cassandra.cache.OHCProvider
+
+# Maximum size of the row cache in memory.
+# Please note that OHC cache implementation requires some additional off-heap memory to manage
+# the map structures and some in-flight memory during operations before/after cache entries can be
+# accounted against the cache capacity. This overhead is usually small compared to the whole capacity.
+# Do not specify more memory that the system can afford in the worst usual situation and leave some
+# headroom for OS block level cache. Do never allow your system to swap.
+#
+# Default value is 0, to disable row caching.
+row_cache_size_in_mb: 0
+
+# Duration in seconds after which Cassandra should save the row cache.
+# Caches are saved to saved_caches_directory as specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 0 to disable saving the row cache.
+row_cache_save_period: 0
+
+# Number of keys from the row cache to save.
+# Specify 0 (which is the default), meaning all keys are going to be saved
+# row_cache_keys_to_save: 100
+
+# Maximum size of the counter cache in memory.
+#
+# Counter cache helps to reduce counter locks' contention for hot counter cells.
+# In case of RF = 1 a counter cache hit will cause Cassandra to skip the read before
+# write entirely. With RF > 1 a counter cache hit will still help to reduce the duration
+# of the lock hold, helping with hot counter cell updates, but will not allow skipping
+# the read entirely. Only the local (clock, count) tuple of a counter cell is kept
+# in memory, not the whole counter, so it's relatively cheap.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(2.5% of Heap (in MB), 50MB)). Set to 0 to disable counter cache.
+# NOTE: if you perform counter deletes and rely on low gcgs, you should disable the counter cache.
+counter_cache_size_in_mb:
+
+# Duration in seconds after which Cassandra should
+# save the counter cache (keys only). Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Default is 7200 or 2 hours.
+counter_cache_save_period: 7200
+
+# Number of keys from the counter cache to save
+# Disabled by default, meaning all keys are going to be saved
+# counter_cache_keys_to_save: 100
+
+# saved caches
+# If not set, the default directory is $CASSANDRA_HOME/data/saved_caches.
+# saved_caches_directory: /var/lib/cassandra/saved_caches
+
+# commitlog_sync may be either "periodic" or "batch."
+#
+# When in batch mode, Cassandra won't ack writes until the commit log
+# has been fsynced to disk.  It will wait
+# commitlog_sync_batch_window_in_ms milliseconds between fsyncs.
+# This window should be kept short because the writer threads will
+# be unable to do extra work while waiting.  (You may need to increase
+# concurrent_writes for the same reason.)
+#
+# commitlog_sync: batch
+# commitlog_sync_batch_window_in_ms: 2
+#
+# the other option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period_in_ms
+# milliseconds.
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+commitlog_segment_size_in_mb: 32
+
+# Compression to apply to the commit log. If omitted, the commit log
+# will be written uncompressed.  LZ4, Snappy, and Deflate compressors
+# are supported.
+#commitlog_compression:
+#   - class_name: LZ4Compressor
+#     parameters:
+#         -
+
+# any class that implements the SeedProvider interface and has a
+# constructor that takes a Map<String, String> of parameters will do.
+seed_provider:
+  # Addresses of hosts that are deemed contact points.
+  # Cassandra nodes use this list of hosts to find each other and learn
+  # the topology of the ring.  You must change this if you are running
+  # multiple nodes!
+  - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+    parameters:
+      # seeds is actually a comma-delimited list of addresses.
+      # Ex: "<ip1>,<ip2>,<ip3>"
+      - seeds: "172.19.0.2"
+
+# For workloads with more data than can fit in memory, Cassandra's
+# bottleneck will be reads that need to fetch data from
+# disk. "concurrent_reads" should be set to (16 * number_of_drives) in
+# order to allow the operations to enqueue low enough in the stack
+# that the OS and drives can reorder them. Same applies to
+# "concurrent_counter_writes", since counter writes read the current
+# values before incrementing and writing them back.
+#
+# On the other hand, since writes are almost never IO bound, the ideal
+# number of "concurrent_writes" is dependent on the number of cores in
+# your system; (8 * number_of_cores) is a good rule of thumb.
+concurrent_reads: 32
+concurrent_writes: 32
+concurrent_counter_writes: 32
+
+# Total memory to use for sstable-reading buffers.  Defaults to
+# the smaller of 1/4 of heap or 512MB.
+# file_cache_size_in_mb: 512
+
+# Total permitted memory to use for memtables. Cassandra will stop
+# accepting writes when the limit is exceeded until a flush completes,
+# and will trigger a flush based on memtable_cleanup_threshold
+# If omitted, Cassandra will set both to 1/4 the size of the heap.
+# memtable_heap_space_in_mb: 2048
+# memtable_offheap_space_in_mb: 2048
+
+# Ratio of occupied non-flushing memtable size to total permitted size
+# that will trigger a flush of the largest memtable. Larger mct will
+# mean larger flushes and hence less compaction, but also less concurrent
+# flush activity which can make it difficult to keep your disks fed
+# under heavy write load.
+#
+# memtable_cleanup_threshold defaults to 1 / (memtable_flush_writers + 1)
+# memtable_cleanup_threshold: 0.11
+
+# Specify the way Cassandra allocates and manages memtable memory.
+# Options are:
+#   heap_buffers:    on heap nio buffers
+#   offheap_buffers: off heap (direct) nio buffers
+#   offheap_objects: native memory, eliminating nio buffer heap overhead
+memtable_allocation_type: heap_buffers
+
+# Total space to use for commit logs on disk.
+#
+# If space gets above this value, Cassandra will flush every dirty CF
+# in the oldest segment and remove it.  So a small total commitlog space
+# will tend to cause more flush activity on less-active columnfamilies.
+#
+# The default value is the smaller of 8192, and 1/4 of the total space
+# of the commitlog volume.
+#
+# commitlog_total_space_in_mb: 8192
+
+# This sets the amount of memtable flush writer threads.  These will
+# be blocked by disk io, and each one will hold a memtable in memory
+# while blocked.
+#
+# memtable_flush_writers defaults to the smaller of (number of disks,
+# number of cores), with a minimum of 2 and a maximum of 8.
+#
+# If your data directories are backed by SSD, you should increase this
+# to the number of cores.
+#memtable_flush_writers: 8
+
+# A fixed memory pool size in MB for for SSTable index summaries. If left
+# empty, this will default to 5% of the heap size. If the memory usage of
+# all index summaries exceeds this limit, SSTables with low read rates will
+# shrink their index summaries in order to meet this limit.  However, this
+# is a best-effort process. In extreme conditions Cassandra may need to use
+# more than this amount of memory.
+index_summary_capacity_in_mb:
+
+# How frequently index summaries should be resampled.  This is done
+# periodically to redistribute memory from the fixed-size pool to sstables
+# proportional their recent read rates.  Setting to -1 will disable this
+# process, leaving existing index summaries at their current sampling level.
+index_summary_resize_interval_in_minutes: 60
+
+# Whether to, when doing sequential writing, fsync() at intervals in
+# order to force the operating system to flush the dirty
+# buffers. Enable this to avoid sudden dirty buffer flushing from
+# impacting read latencies. Almost always a good idea on SSDs; not
+# necessarily on platters.
+trickle_fsync: false
+trickle_fsync_interval_in_kb: 10240
+
+# TCP port, for commands and data
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+storage_port: 7000
+
+# SSL port, for encrypted communication.  Unused unless enabled in
+# encryption_options
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+ssl_storage_port: 7001
+
+# Address or interface to bind to and tell other Cassandra nodes to connect to.
+# You _must_ change this if you want multiple nodes to be able to communicate!
+#
+# Set listen_address OR listen_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+#
+# Leaving it blank leaves it up to InetAddress.getLocalHost(). This
+# will always do the Right Thing _if_ the node is properly configured
+# (hostname, name resolution, etc), and the Right Thing is to use the
+# address associated with the hostname (it might not be).
+#
+# Setting listen_address to 0.0.0.0 is always wrong.
+#
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using listen_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+listen_address: 172.19.0.2
+# listen_interface: eth0
+# listen_interface_prefer_ipv6: false
+
+# Address to broadcast to other Cassandra nodes
+# Leaving this blank will set it to the same value as listen_address
+broadcast_address: 172.19.0.2
+
+# When using multiple physical network interfaces, set this
+# to true to listen on broadcast_address in addition to
+# the listen_address, allowing nodes to communicate in both
+# interfaces.
+# Ignore this property if the network configuration automatically
+# routes  between the public and private networks such as EC2.
+# listen_on_broadcast_address: false
+
+# Internode authentication backend, implementing IInternodeAuthenticator;
+# used to allow/disallow connections from peer nodes.
+# internode_authenticator: org.apache.cassandra.auth.AllowAllInternodeAuthenticator
+
+# Whether to start the native transport server.
+# Please note that the address on which the native transport is bound is the
+# same as the rpc_address. The port however is different and specified below.
+start_native_transport: true
+# port for the CQL native transport to listen for clients on
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+native_transport_port: 9042
+# The maximum threads for handling requests when the native transport is used.
+# This is similar to rpc_max_threads though the default differs slightly (and
+# there is no native_transport_min_threads, idle threads will always be stopped
+# after 30 seconds).
+# native_transport_max_threads: 128
+#
+# The maximum size of allowed frame. Frame (requests) larger than this will
+# be rejected as invalid. The default is 256MB.
+# native_transport_max_frame_size_in_mb: 256
+
+# The maximum number of concurrent client connections.
+# The default is -1, which means unlimited.
+# native_transport_max_concurrent_connections: -1
+
+# The maximum number of concurrent client connections per source ip.
+# The default is -1, which means unlimited.
+# native_transport_max_concurrent_connections_per_ip: -1
+
+# Whether to start the thrift rpc server.
+start_rpc: false
+
+# The address or interface to bind the Thrift RPC service and native transport
+# server to.
+#
+# Set rpc_address OR rpc_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+#
+# Leaving rpc_address blank has the same effect as on listen_address
+# (i.e. it will be based on the configured hostname of the node).
+#
+# Note that unlike listen_address, you can specify 0.0.0.0, but you must also
+# set broadcast_rpc_address to a value other than 0.0.0.0.
+#
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+#
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+rpc_address: 0.0.0.0
+# rpc_interface: eth1
+# rpc_interface_prefer_ipv6: false
+
+# port for Thrift to listen for clients on
+rpc_port: 9160
+
+# RPC address to broadcast to drivers and other Cassandra nodes. This cannot
+# be set to 0.0.0.0. If left blank, this will be set to the value of
+# rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
+# be set.
+broadcast_rpc_address: 172.19.0.2
+
+# enable or disable keepalive on rpc/native connections
+rpc_keepalive: true
+
+# Cassandra provides two out-of-the-box options for the RPC Server:
+#
+# sync  -> One thread per thrift connection. For a very large number of clients, memory
+#          will be your limiting factor. On a 64 bit JVM, 180KB is the minimum stack size
+#          per thread, and that will correspond to your use of virtual memory (but physical memory
+#          may be limited depending on use of stack space).
+#
+# hsha  -> Stands for "half synchronous, half asynchronous." All thrift clients are handled
+#          asynchronously using a small number of threads that does not vary with the amount
+#          of thrift clients (and thus scales well to many clients). The rpc requests are still
+#          synchronous (one thread per active request). If hsha is selected then it is essential
+#          that rpc_max_threads is changed from the default value of unlimited.
+#
+# The default is sync because on Windows hsha is about 30% slower.  On Linux,
+# sync/hsha performance is about the same, with hsha of course using less memory.
+#
+# Alternatively,  can provide your own RPC server by providing the fully-qualified class name
+# of an o.a.c.t.TServerFactory that can create an instance of it.
+rpc_server_type: sync
+
+# Uncomment rpc_min|max_thread to set request pool size limits.
+#
+# Regardless of your choice of RPC server (see above), the number of maximum requests in the
+# RPC thread pool dictates how many concurrent requests are possible (but if you are using the sync
+# RPC server, it also dictates the number of clients that can be connected at all).
+#
+# The default is unlimited and thus provides no protection against clients overwhelming the server. You are
+# encouraged to set a maximum that makes sense for you in production, but do keep in mind that
+# rpc_max_threads represents the maximum number of client requests this server may execute concurrently.
+#
+# rpc_min_threads: 16
+# rpc_max_threads: 2048
+
+# uncomment to set socket buffer sizes on rpc connections
+# rpc_send_buff_size_in_bytes:
+# rpc_recv_buff_size_in_bytes:
+
+# Uncomment to set socket buffer size for internode communication
+# Note that when setting this, the buffer size is limited by net.core.wmem_max
+# and when not setting it it is defined by net.ipv4.tcp_wmem
+# See:
+# /proc/sys/net/core/wmem_max
+# /proc/sys/net/core/rmem_max
+# /proc/sys/net/ipv4/tcp_wmem
+# /proc/sys/net/ipv4/tcp_wmem
+# and: man tcp
+# internode_send_buff_size_in_bytes:
+# internode_recv_buff_size_in_bytes:
+
+# Frame size for thrift (maximum message length).
+thrift_framed_transport_size_in_mb: 15
+
+# Set to true to have Cassandra create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# keyspace data.  Removing these links is the operator's
+# responsibility.
+incremental_backups: false
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Cassandra won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+snapshot_before_compaction: false
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: true
+
+# When executing a scan, within or across a partition, we need to keep the
+# tombstones seen in memory so we can return them to the coordinator, which
+# will use them to make sure other replicas also know about the deleted rows.
+# With workloads that generate a lot of tombstones, this can cause performance
+# problems and even exaust the server heap.
+# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# Adjust the thresholds here if you understand the dangers and want to
+# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
+# using the StorageService mbean.
+tombstone_warn_threshold: 1000
+tombstone_failure_threshold: 100000
+
+# Granularity of the collation index of rows within a partition.
+# Increase if your rows are large, or if you have a very large
+# number of rows per partition.  The competing goals are these:
+#   1) a smaller granularity means more index entries are generated
+#      and looking up rows withing the partition by collation column
+#      is faster
+#   2) but, Cassandra will keep the collation index in memory for hot
+#      rows (as part of the key cache), so a larger granularity means
+#      you can cache more hot rows
+column_index_size_in_kb: 64
+
+
+# Log WARN on any batch size exceeding this value. 5kb per batch by default.
+# Caution should be taken on increasing the size of this threshold as it can lead to node instability.
+batch_size_warn_threshold_in_kb: 20
+
+# Fail any batch exceeding this value. 50kb (10x warn threshold) by default.
+batch_size_fail_threshold_in_kb: 200
+
+# Log WARN on any batches not of type LOGGED than span across more partitions than this limit
+unlogged_batch_across_partitions_warn_threshold: 10
+
+# Number of simultaneous compactions to allow, NOT including
+# validation "compactions" for anti-entropy repair.  Simultaneous
+# compactions can help preserve read performance in a mixed read/write
+# workload, by mitigating the tendency of small sstables to accumulate
+# during a single long running compactions. The default is usually
+# fine and if you experience problems with compaction running too
+# slowly or too fast, you should look at
+# compaction_throughput_mb_per_sec first.
+#
+# concurrent_compactors defaults to the smaller of (number of disks,
+# number of cores), with a minimum of 2 and a maximum of 8.
+#
+# If your data directories are backed by SSD, you should increase this
+# to the number of cores.
+#concurrent_compactors: 1
+
+# Throttles compaction to the given total throughput across the entire
+# system. The faster you insert data, the faster you need to compact in
+# order to keep the sstable count down, but in general, setting this to
+# 16 to 32 times the rate you are inserting data is more than sufficient.
+# Setting this to 0 disables throttling. Note that this account for all types
+# of compaction, including validation compaction.
+compaction_throughput_mb_per_sec: 16
+
+# Log a warning when compacting partitions larger than this value
+compaction_large_partition_warning_threshold_mb: 100
+
+# When compacting, the replacement sstable(s) can be opened before they
+# are completely written, and used in place of the prior sstables for
+# any range that has been written. This helps to smoothly transfer reads
+# between the sstables, reducing page cache churn and keeping hot rows hot
+sstable_preemptive_open_interval_in_mb: 50
+
+# Throttles all outbound streaming file transfers on this node to the
+# given total throughput in Mbps. This is necessary because Cassandra does
+# mostly sequential IO when streaming data during bootstrap or repair, which
+# can lead to saturating the network connection and degrading rpc performance.
+# When unset, the default is 200 Mbps or 25 MB/s.
+# stream_throughput_outbound_megabits_per_sec: 200
+
+# Throttles all streaming file transfer between the datacenters,
+# this setting allows users to throttle inter dc stream throughput in addition
+# to throttling all network stream traffic as configured with
+# stream_throughput_outbound_megabits_per_sec
+# When unset, the default is 200 Mbps or 25 MB/s
+# inter_dc_stream_throughput_outbound_megabits_per_sec: 200
+
+# How long the coordinator should wait for read operations to complete
+read_request_timeout_in_ms: 5000
+# How long the coordinator should wait for seq or index scans to complete
+range_request_timeout_in_ms: 10000
+# How long the coordinator should wait for writes to complete
+write_request_timeout_in_ms: 2000
+# How long the coordinator should wait for counter writes to complete
+counter_write_request_timeout_in_ms: 5000
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+cas_contention_timeout_in_ms: 1000
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+truncate_request_timeout_in_ms: 60000
+# The default timeout for other, miscellaneous operations
+request_timeout_in_ms: 10000
+
+# Enable operation timeout information exchange between nodes to accurately
+# measure request timeouts.  If disabled, replicas will assume that requests
+# were forwarded to them instantly by the coordinator, which means that
+# under overload conditions we will waste that much extra time processing
+# already-timed-out requests.
+#
+# Warning: before enabling this property make sure to ntp is installed
+# and the times are synchronized between the nodes.
+cross_node_timeout: false
+
+# Set socket timeout for streaming operation.
+# The stream session is failed if no data/ack is received by any of the participants
+# within that period, which means this should also be sufficient to stream a large
+# sstable or rebuild table indexes.
+# Default value is 86400000ms, which means stale streams timeout after 24 hours.
+# A value of zero means stream sockets should never time out.
+# streaming_socket_timeout_in_ms: 86400000
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+
+# endpoint_snitch -- Set this to a class that implements
+# IEndpointSnitch.  The snitch has two functions:
+# - it teaches Cassandra enough about your network topology to route
+#   requests efficiently
+# - it allows Cassandra to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Cassandra will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# CASSANDRA WILL NOT ALLOW YOU TO SWITCH TO AN INCOMPATIBLE SNITCH
+# ONCE DATA IS INSERTED INTO THE CLUSTER.  This would cause data loss.
+# This means that if you start with the default SimpleSnitch, which
+# locates every node on "rack1" in "datacenter1", your only options
+# if you need to add another datacenter are GossipingPropertyFileSnitch
+# (and the older PFS).  From there, if you want to migrate to an
+# incompatible snitch like Ec2Snitch you can do it by adding new nodes
+# under Ec2Snitch (which will locate them in a new "datacenter") and
+# decommissioning the old ones.
+#
+# Out of the box, Cassandra provides
+#  - SimpleSnitch:
+#    Treats Strategy order as proximity. This can improve cache
+#    locality when disabling read repair.  Only appropriate for
+#    single-datacenter deployments.
+#  - GossipingPropertyFileSnitch
+#    This should be your go-to snitch for production use.  The rack
+#    and datacenter for the local node are defined in
+#    cassandra-rackdc.properties and propagated to other nodes via
+#    gossip.  If cassandra-topology.properties exists, it is used as a
+#    fallback, allowing migration from the PropertyFileSnitch.
+#  - PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#  - Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region. Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#  - Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Cassandra will switch to the private IP after
+#    establishing a connection.)
+#  - RackInferringSnitch:
+#    Proximity is determined by rack and data center, which are
+#    assumed to correspond to the 3rd and 2nd octet of each node's IP
+#    address, respectively.  Unless this happens to match your
+#    deployment conventions, this is best used as an example of
+#    writing a custom Snitch class and is provided in that spirit.
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+endpoint_snitch: SimpleSnitch
+
+# controls how often to perform the more expensive part of host score
+# calculation
+dynamic_snitch_update_interval_in_ms: 100
+# controls how often to reset all host scores, allowing a bad host to
+# possibly recover
+dynamic_snitch_reset_interval_in_ms: 600000
+# if set greater than zero and read_repair_chance is < 1.0, this will allow
+# 'pinning' of replicas to hosts in order to increase cache capacity.
+# The badness threshold will control how much worse the pinned host has to be
+# before the dynamic snitch will prefer other replicas over it.  This is
+# expressed as a double which represents a percentage.  Thus, a value of
+# 0.2 means Cassandra would continue to prefer the static snitch values
+# until the pinned host was 20% worse than the fastest.
+dynamic_snitch_badness_threshold: 0.1
+
+# request_scheduler -- Set this to a class that implements
+# RequestScheduler, which will schedule incoming client requests
+# according to the specific policy. This is useful for multi-tenancy
+# with a single Cassandra cluster.
+# NOTE: This is specifically for requests from the client and does
+# not affect inter node communication.
+# org.apache.cassandra.scheduler.NoScheduler - No scheduling takes place
+# org.apache.cassandra.scheduler.RoundRobinScheduler - Round robin of
+# client requests to a node with a separate queue for each
+# request_scheduler_id. The scheduler is further customized by
+# request_scheduler_options as described below.
+request_scheduler: org.apache.cassandra.scheduler.NoScheduler
+
+# Scheduler Options vary based on the type of scheduler
+# NoScheduler - Has no options
+# RoundRobin
+#  - throttle_limit -- The throttle_limit is the number of in-flight
+#                      requests per client.  Requests beyond
+#                      that limit are queued up until
+#                      running requests can complete.
+#                      The value of 80 here is twice the number of
+#                      concurrent_reads + concurrent_writes.
+#  - default_weight -- default_weight is optional and allows for
+#                      overriding the default which is 1.
+#  - weights -- Weights are optional and will default to 1 or the
+#               overridden default_weight. The weight translates into how
+#               many requests are handled during each turn of the
+#               RoundRobin, based on the scheduler id.
+#
+# request_scheduler_options:
+#    throttle_limit: 80
+#    default_weight: 5
+#    weights:
+#      Keyspace1: 1
+#      Keyspace2: 5
+
+# request_scheduler_id -- An identifier based on which to perform
+# the request scheduling. Currently the only valid option is keyspace.
+# request_scheduler_id: keyspace
+
+# Enable or disable inter-node encryption
+# Default settings are TLS v1, RSA 1024-bit keys (it is imperative that
+# users generate their own keys) TLS_RSA_WITH_AES_128_CBC_SHA as the cipher
+# suite for authentication, key exchange and encryption of the actual data transfers.
+# Use the DHE/ECDHE ciphers if running in FIPS 140 compliant mode.
+# NOTE: No custom encryption options are enabled at the moment
+# The available internode options are : all, none, dc, rack
+#
+# If set to dc cassandra will encrypt the traffic between the DCs
+# If set to rack cassandra will encrypt the traffic between the racks
+#
+# The passwords used in these options must match the passwords used when generating
+# the keystore and truststore.  For instructions on generating these files, see:
+# http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
+#
+server_encryption_options:
+  internode_encryption: none
+  keystore: conf/.keystore
+  keystore_password: cassandra
+  truststore: conf/.truststore
+  truststore_password: cassandra
+  # More advanced defaults below:
+  # protocol: TLS
+  # algorithm: SunX509
+  # store_type: JKS
+  # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
+  # require_client_auth: false
+
+# enable or disable client/server encryption.
+client_encryption_options:
+  enabled: false
+  # If enabled and optional is set to true encrypted and unencrypted connections are handled.
+  optional: false
+  keystore: conf/.keystore
+  keystore_password: cassandra
+  # require_client_auth: false
+  # Set trustore and truststore_password if require_client_auth is true
+  # truststore: conf/.truststore
+  # truststore_password: cassandra
+  # More advanced defaults below:
+  # protocol: TLS
+  # algorithm: SunX509
+  # store_type: JKS
+  # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
+
+# internode_compression controls whether traffic between nodes is
+# compressed.
+# can be:  all  - all traffic is compressed
+#          dc   - traffic between different datacenters is compressed
+#          none - nothing is compressed.
+internode_compression: all
+
+# Enable or disable tcp_nodelay for inter-dc communication.
+# Disabling it will result in larger (but fewer) network packets being sent,
+# reducing overhead from the TCP protocol itself, at the cost of increasing
+# latency if you block for cross-datacenter responses.
+inter_dc_tcp_nodelay: false
+
+# TTL for different trace types used during logging of the repair process.
+tracetype_query_ttl: 86400
+tracetype_repair_ttl: 604800
+
+# By default, Cassandra logs GC Pauses greater than 200 ms at INFO level
+# This threshold can be adjusted to minimize logging if necessary
+# gc_log_threshold_in_ms: 200
+
+# GC Pauses greater than gc_warn_threshold_in_ms will be logged at WARN level
+# If unset, all GC Pauses greater than gc_log_threshold_in_ms will log at
+# INFO level
+# Adjust the threshold based on your application throughput requirement
+# gc_warn_threshold_in_ms: 1000
+
+# UDFs (user defined functions) are disabled by default.
+# As of Cassandra 2.2, there is no security manager or anything else in place that
+# prevents execution of evil code. CASSANDRA-9402 will fix this issue for Cassandra 3.0.
+# This will inherently be backwards-incompatible with any 2.2 UDF that perform insecure
+# operations such as opening a socket or writing to the filesystem.
+enable_user_defined_functions: false
+
+# The default Windows kernel timer and scheduling resolution is 15.6ms for power conservation.
+# Lowering this value on Windows can provide much tighter latency and better throughput, however
+# some virtualized environments may see a negative performance impact from changing this setting
+# below their system default. The sysinternals 'clockres' tool can confirm your system's default
+# setting.
+windows_timer_interval: 1
+
+# Coalescing Strategies #
+# Coalescing multiples messages turns out to significantly boost message processing throughput (think doubling or more).
+# On bare metal, the floor for packet processing throughput is high enough that many applications won't notice, but in
+# virtualized environments, the point at which an application can be bound by network packet processing can be
+# surprisingly low compared to the throughput of task processing that is possible inside a VM. It's not that bare metal
+# doesn't benefit from coalescing messages, it's that the number of packets a bare metal network interface can process
+# is sufficient for many applications such that no load starvation is experienced even without coalescing.
+# There are other benefits to coalescing network messages that are harder to isolate with a simple metric like messages
+# per second. By coalescing multiple tasks together, a network thread can process multiple messages for the cost of one
+# trip to read from a socket, and all the task submission work can be done at the same time reducing context switching
+# and increasing cache friendliness of network message processing.
+# See CASSANDRA-8692 for details.
+
+# Strategy to use for coalescing messages in OutboundTcpConnection.
+# Can be fixed, movingaverage, timehorizon (default), disabled.
+# You can also specify a subclass of CoalescingStrategies.CoalescingStrategy by name.
+# otc_coalescing_strategy: TIMEHORIZON
+
+# How many microseconds to wait for coalescing. For fixed strategy this is the amount of time after the first
+# message is received before it will be sent with any accompanying messages. For moving average this is the
+# maximum amount of time that will be waited as well as the interval at which messages must arrive on average
+# for coalescing to be enabled.
+# otc_coalescing_window_us: 200
+
+# Do not try to coalesce messages if we already got that many messages. This should be more than 2 and less than 128.
+# otc_coalescing_enough_coalesced_messages: 8

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,6 +14,7 @@ object Dependencies {
 
   object Versions {
     val akka = "2.6.4"
+    val alpakka = "2.0.0-RC2"
     val slick = "3.3.2"
     val scalaTest = "3.1.1"
   }
@@ -27,6 +28,8 @@ object Dependencies {
     val akkaStreamTestkit = "com.typesafe.akka" %% "akka-stream-testkit" % Versions.akka
 
     val slick = "com.typesafe.slick" %% "slick" % Versions.slick
+
+    val alpakkaCassandra = "com.lightbend.akka" %% "akka-stream-alpakka-cassandra" % Versions.alpakka
   }
 
   object Test {
@@ -44,4 +47,7 @@ object Dependencies {
 
   val slick =
     deps ++= Seq(Compile.slick, Compile.akkaPersistenceQuery, Test.akkaTypedTestkit, Test.h2Driver, Test.logback)
+
+  val cassandra =
+    deps ++= Seq(Compile.alpakkaCassandra, Compile.akkaPersistenceQuery, Test.akkaTypedTestkit, Test.logback)
 }


### PR DESCRIPTION
* CassandraProjection
  * only added atLeastOnce to start with, will add atMostOnce and grouped in separate PR
* CassandraOffsetStore
  * offset stored as string and manifest, similar to Slick OffsetStore
* tests very similar to Slick tests, credit to @renatocaval

Ready for review, but marked as Draft because it's on top of https://github.com/akka/akka-projection/pull/35
If you start reviewing before that PR is merged you can ignore everything in akka-projection-core and akka-projection-slick. I didn't change any of that here.

References #21
