### PR TITLE
add last_updated timestamp in offset table

### DIFF
--- a/akka-projection-slick/src/test/scala/akka/projection/slick/OffsetStoreSpec.scala
+++ b/akka-projection-slick/src/test/scala/akka/projection/slick/OffsetStoreSpec.scala
@@ -15,6 +15,7 @@ import akka.persistence.query.Sequence
 import akka.persistence.query.TimeBasedUUID
 import akka.projection.ProjectionId
 import akka.projection.slick.internal.SlickOffsetStore
+import akka.projection.testkit.internal.TestClock
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
@@ -24,12 +25,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import slick.basic.DatabaseConfig
 import slick.jdbc.H2Profile
-import scala.concurrent.Await
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
-
-import akka.projection.slick.internal.SlickOffsetStore
-import akka.projection.testkit.internal.TestClock
 
 object OffsetStoreSpec {
   def config: Config = ConfigFactory.parseString("""

--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/internal/TestClock.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/internal/TestClock.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.projection.testkit.internal
 
 import java.time.Clock

--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/internal/TestClock.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/internal/TestClock.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.projection.testkit.internal
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] class TestClock extends Clock {
+
+  @volatile private var _instant = roundToMillis(Instant.now())
+
+  override def getZone: ZoneId = ZoneOffset.UTC
+
+  override def withZone(zone: ZoneId): Clock =
+    throw new UnsupportedOperationException("withZone not supported")
+
+  override def instant(): Instant =
+    _instant
+
+  def setInstant(newInstant: Instant): Unit =
+    _instant = roundToMillis(newInstant)
+
+  def tick(duration: Duration): Instant = {
+    val newInstant = roundToMillis(_instant.plus(duration))
+    _instant = newInstant
+    newInstant
+  }
+
+  private def roundToMillis(i: Instant): Instant = {
+    // algo taken from java.time.Clock.tick
+    val epochMilli = i.toEpochMilli
+    Instant.ofEpochMilli(epochMilli - Math.floorMod(epochMilli, 1L))
+  }
+
+}


### PR DESCRIPTION
* to be used by back office to see stuck projections

(draft because on top of other PR for the moment, but otherwise ready for review)
