### PR TITLE
add atLeastOnce in SlickProjection, #24

### DIFF
--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
@@ -115,6 +115,4 @@ import akka.stream.scaladsl.Source
     composedSource
   }
 
-  // FIXME
-  def processEnvelope(envelope: Envelope)(implicit ec: ExecutionContext): Future[Done] = ???
 }

--- a/akka-projection-core/src/main/scala/akka/projection/Projection.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/Projection.scala
@@ -28,14 +28,6 @@ trait Projection[Envelope] {
   def projectionId: ProjectionId
 
   /**
-   * The method wrapping the user EventHandler function.
-   *
-   * @return A [[scala.concurrent.Future]] that represents the asynchronous completion of the user EventHandler
-   *         function.
-   */
-  def processEnvelope(envelope: Envelope)(implicit ec: ExecutionContext): Future[Done]
-
-  /**
    * INTERNAL API
    *
    * This method returns the projection Source mapped with `processEnvelope`, but before any sink attached.

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/SlickProjection.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/SlickProjection.scala
@@ -4,6 +4,8 @@
 
 package akka.projection.slick
 
+import scala.concurrent.duration.FiniteDuration
+
 import akka.Done
 import akka.annotation.ApiMayChange
 import akka.projection.{ Projection, ProjectionId }
@@ -12,15 +14,36 @@ import akka.stream.scaladsl.Source
 import slick.basic.DatabaseConfig
 import slick.dbio.DBIO
 import slick.jdbc.JdbcProfile
-
 import scala.reflect.ClassTag
 
+@ApiMayChange
 object SlickProjection {
-  @ApiMayChange
-  def transactional[Offset, Envelope, P <: JdbcProfile: ClassTag](
+
+  def exactlyOnce[Offset, Envelope, P <: JdbcProfile: ClassTag](
       projectionId: ProjectionId,
       sourceProvider: Option[Offset] => Source[Envelope, _],
       offsetExtractor: Envelope => Offset,
       databaseConfig: DatabaseConfig[P])(eventHandler: Envelope => DBIO[Done]): Projection[Envelope] =
-    new SlickProjectionImpl(projectionId, sourceProvider, offsetExtractor, databaseConfig, eventHandler)
+    new SlickProjectionImpl(
+      projectionId,
+      sourceProvider,
+      offsetExtractor,
+      databaseConfig,
+      SlickProjectionImpl.ExactlyOnce,
+      eventHandler)
+
+  def atLeastOnce[Offset, Envelope, P <: JdbcProfile: ClassTag](
+      projectionId: ProjectionId,
+      sourceProvider: Option[Offset] => Source[Envelope, _],
+      offsetExtractor: Envelope => Offset,
+      databaseConfig: DatabaseConfig[P],
+      saveOffsetAfterEnvelopes: Int,
+      saveOffsetAfterDuration: FiniteDuration)(eventHandler: Envelope => DBIO[Done]): Projection[Envelope] =
+    new SlickProjectionImpl(
+      projectionId,
+      sourceProvider,
+      offsetExtractor,
+      databaseConfig,
+      SlickProjectionImpl.AtLeastOnce(saveOffsetAfterEnvelopes, saveOffsetAfterDuration),
+      eventHandler)
 }

--- a/akka-projection-testkit/src/test/scala/akka/projection/testkit/ProjectionTestKitSpec.scala
+++ b/akka-projection-testkit/src/test/scala/akka/projection/testkit/ProjectionTestKitSpec.scala
@@ -144,14 +144,13 @@ class ProjectionTestKitSpec extends ScalaTestWithActorTestKit with AnyWordSpecLi
       promiseToStop.completeWith(done)
     }
 
-    override def processEnvelope(envelope: Int)(implicit ec: ExecutionContext): Future[Done] = {
-      if (predicate(envelope)) concat(envelope)
+    private def processElement(elt: Int): Future[Done] = {
+      if (predicate(elt)) concat(elt)
       Future.successful(Done)
     }
 
     private[projection] def mappedSource()(implicit systemProvider: ClassicActorSystemProvider): Source[Done, _] = {
-      implicit val dispatcher: ExecutionContext = systemProvider.classicSystem.dispatcher
-      src.via(killSwitch.flow).mapAsync(1)(envelope => processEnvelope(envelope))
+      src.via(killSwitch.flow).mapAsync(1)(elt => processElement(elt))
     }
 
     private def concat(envelope: Int) = {


### PR DESCRIPTION
* offset not stored in same transaction as user handler
* usage would be to benefit from batching of offsets
  * which is probably a very small advantage for jdbc
* it can be more interesting when we add support for user handler
  that is not storing in db but the offset should be stored in db, created issue https://github.com/akka/akka-projection/issues/68 for that

References #24
