### PR TITLE
Use testcontainers for Cassandra impl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ script:
   - jabba install ${JDK:=adopt@~1.8-0}
   - jabba use ${JDK:=adopt@~1.8-0}
   - java -version
-  - docker-compose up -d cassandra
   - sbt -jvm-opts .jvmopts-travis "$CMD"
 
 jobs:

--- a/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraOffsetStoreSpec.scala
+++ b/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraOffsetStoreSpec.scala
@@ -18,7 +18,10 @@ import akka.projection.cassandra.internal.CassandraOffsetStore
 import akka.stream.alpakka.cassandra.scaladsl.CassandraSessionRegistry
 import org.scalatest.wordspec.AnyWordSpecLike
 
-class CassandraOffsetStoreSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
+class CassandraOffsetStoreSpec
+    extends ScalaTestWithActorTestKit(ContainerSessionProvider.Config)
+    with AnyWordSpecLike
+    with LogCapturing {
 
   private val session = CassandraSessionRegistry(system).sessionFor("akka.projection.cassandra")
   private implicit val ec: ExecutionContext = system.executionContext

--- a/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
+++ b/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
@@ -108,7 +108,10 @@ object CassandraProjectionSpec {
 
 }
 
-class CassandraProjectionSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
+class CassandraProjectionSpec
+    extends ScalaTestWithActorTestKit(ContainerSessionProvider.Config)
+    with AnyWordSpecLike
+    with LogCapturing {
 
   import CassandraProjectionSpec._
 

--- a/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
+++ b/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
@@ -27,6 +27,10 @@ import akka.stream.alpakka.cassandra.scaladsl.CassandraSessionRegistry
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.TestPublisher
 import akka.stream.testkit.scaladsl.TestSource
+import org.scalatest.concurrent.PatienceConfiguration
+import org.scalatest.time.Millis
+import org.scalatest.time.Seconds
+import org.scalatest.time.Span
 import org.scalatest.wordspec.AnyWordSpecLike
 
 object CassandraProjectionSpec {
@@ -111,9 +115,12 @@ object CassandraProjectionSpec {
 class CassandraProjectionSpec
     extends ScalaTestWithActorTestKit(ContainerSessionProvider.Config)
     with AnyWordSpecLike
-    with LogCapturing {
+    with LogCapturing
+    with PatienceConfiguration {
 
   import CassandraProjectionSpec._
+
+  override implicit def patienceConfig = PatienceConfig(timeout = Span(30, Seconds), interval = Span(100, Millis))
 
   private val session = CassandraSessionRegistry(system).sessionFor("akka.projection.cassandra")
   private implicit val ec: ExecutionContext = system.executionContext

--- a/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/ContainerSessionProvider.scala
+++ b/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/ContainerSessionProvider.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.cassandra
+
+import java.net.InetSocketAddress
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.util.Try
+
+import akka.stream.alpakka.cassandra.CqlSessionProvider
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint
+import com.dimafeng.testcontainers.CassandraContainer
+
+/**
+ * Use testcontainers to lazily provide a single CqlSession for all Alpakka Cassandra tests
+ */
+final class ContainerSessionProvider extends CqlSessionProvider {
+  import ContainerSessionProvider._
+
+  override def connect()(implicit ec: ExecutionContext): Future[CqlSession] = started.future.map { _ =>
+    CqlSession.builder
+      .addContactEndPoint(
+        new DefaultEndPoint(
+          InetSocketAddress
+            .createUnresolved(
+              container.cassandraContainer.getContainerIpAddress,
+              container.cassandraContainer.getFirstMappedPort.intValue())))
+      .withLocalDatacenter("datacenter1")
+      .build()
+  }
+}
+
+object ContainerSessionProvider {
+  private lazy val container: CassandraContainer = CassandraContainer()
+  private lazy val started = Promise[Unit].complete(Try(container.start()))
+
+  val Config =
+    """
+       akka.projection.cassandra.session-provider = "akka.projection.cassandra.ContainerSessionProvider"
+    """
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,6 +17,7 @@ object Dependencies {
     val alpakka = "2.0.0-RC2"
     val slick = "3.3.2"
     val scalaTest = "3.1.1"
+    val testContainersScala = "0.36.1"
   }
 
   object Compile {
@@ -37,6 +38,9 @@ object Dependencies {
     val scalaTest = "org.scalatest" %% "scalatest" % Versions.scalaTest % sbt.Test
     val h2Driver = "com.h2database" % "h2" % "1.4.200" % sbt.Test
     val logback = "ch.qos.logback" % "logback-classic" % "1.2.3" % sbt.Test
+    val testContainers = "com.dimafeng" %% "testcontainers-scala-scalatest" % Versions.testContainersScala % sbt.Test
+    val cassandraContainer =
+      "com.dimafeng" %% "testcontainers-scala-cassandra" % Versions.testContainersScala % sbt.Test
   }
 
   private val deps = libraryDependencies
@@ -52,5 +56,10 @@ object Dependencies {
     deps ++= Seq(Compile.slick, Test.akkaTypedTestkit, Test.h2Driver, Test.logback)
 
   val cassandra =
-    deps ++= Seq(Compile.alpakkaCassandra, Test.akkaTypedTestkit, Test.logback)
+    deps ++= Seq(
+        Compile.alpakkaCassandra,
+        Test.akkaTypedTestkit,
+        Test.logback,
+        Test.testContainers,
+        Test.cassandraContainer)
 }


### PR DESCRIPTION
Use `testcontainers-scala` to spin up a Cassandra container automatically for Cassandra tests.

References #55
