### PR TITLE
Speedup CassandraProjectionSpec, #64

### DIFF
--- a/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
+++ b/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
@@ -7,6 +7,7 @@ package akka.projection.cassandra
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
 
+import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
@@ -17,8 +18,6 @@ import akka.Done
 import akka.NotUsed
 import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import scala.annotation.tailrec
-
 import akka.projection.ProjectionId
 import akka.projection.cassandra.internal.CassandraOffsetStore
 import akka.projection.cassandra.scaladsl.CassandraProjection
@@ -28,11 +27,9 @@ import akka.stream.alpakka.cassandra.scaladsl.CassandraSession
 import akka.stream.alpakka.cassandra.scaladsl.CassandraSessionRegistry
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.TestSubscriber
 import akka.stream.testkit.scaladsl.TestSource
 import org.scalatest.wordspec.AnyWordSpecLike
-import scala.util.Try
-
-import akka.stream.testkit.TestSubscriber
 
 object CassandraProjectionSpec {
   case class Envelope(id: String, offset: Long, message: String)

--- a/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
+++ b/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
@@ -7,18 +7,18 @@ package akka.projection.slick
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
 
+import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
 import akka.Done
 import akka.NotUsed
-import scala.annotation.tailrec
-
 import akka.projection.ProjectionId
 import akka.projection.scaladsl.SourceProvider
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.TestSubscriber
 import akka.stream.testkit.scaladsl.TestSource
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
@@ -30,8 +30,6 @@ import org.slf4j.LoggerFactory
 import slick.basic.DatabaseConfig
 import slick.dbio.DBIOAction
 import slick.jdbc.H2Profile
-
-import akka.stream.testkit.TestSubscriber
 
 object SlickProjectionSpec {
   def config: Config = ConfigFactory.parseString("""


### PR DESCRIPTION
* from 45s to 11s
* One part is the tests that are waiting for stream failure, but they
  will always wait 3 sec for the assert function to timeout. Better
  to use SinkProbe since we only care about the stream failure.
* The second part was the too long interval in PatienceConfig. Decent
  value already defined by ScalaTestWithActorTestKit.

References #64
