### PR TITLE
Preserve new lines after curly lambda

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -13,6 +13,8 @@ align.openParenCallSite    = false
 optIn.configStyleArguments = false
 danglingParentheses = false
 spaces.inImportCurlyBraces = true
+newlines.afterCurlyLambda = preserve
+
 rewrite.neverInfix.excludeFilters = [
   and
   min

--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
@@ -96,13 +96,17 @@ import akka.stream.scaladsl.Source
 
     val composedSource: Source[Done, NotUsed] = strategy match {
       case AtLeastOnce(1, _) =>
-        source.via(handlerFlow).mapAsync(1) { offset => offsetStore.saveOffset(projectionId, offset) }
+        source.via(handlerFlow).mapAsync(1) { offset =>
+          offsetStore.saveOffset(projectionId, offset)
+        }
       case AtLeastOnce(afterEnvelopes, orAfterDuration) =>
         source
           .via(handlerFlow)
           .groupedWithin(afterEnvelopes, orAfterDuration)
           .collect { case grouped if grouped.nonEmpty => grouped.last }
-          .mapAsync(parallelism = 1) { offset => offsetStore.saveOffset(projectionId, offset) }
+          .mapAsync(parallelism = 1) { offset =>
+            offsetStore.saveOffset(projectionId, offset)
+          }
       case AtMostOnce =>
         source
           .mapAsync(parallelism = 1) {

--- a/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
+++ b/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
@@ -290,7 +290,9 @@ class CassandraProjectionSpec
             projectionId,
             sourceProvider(entityId),
             saveOffsetAfterEnvelopes = 2,
-            saveOffsetAfterDuration = 1.minute) { envelope => repository.concatToText(envelope.id, envelope.message) }
+            saveOffsetAfterDuration = 1.minute) { envelope =>
+            repository.concatToText(envelope.id, envelope.message)
+          }
 
       projectionTestKit.run(projection) {
         withClue("checking: all values were concatenated") {
@@ -322,7 +324,9 @@ class CassandraProjectionSpec
           projectionId,
           TestSourceProvider(source),
           saveOffsetAfterEnvelopes = 10,
-          saveOffsetAfterDuration = 1.minute) { envelope => repository.concatToText(envelope.id, envelope.message) }
+          saveOffsetAfterDuration = 1.minute) { envelope =>
+          repository.concatToText(envelope.id, envelope.message)
+        }
 
       val sinkProbe = projectionTestKit.runWithTestSink(projection)
       eventually {
@@ -330,13 +334,17 @@ class CassandraProjectionSpec
       }
       sinkProbe.request(1000)
 
-      (1 to 15).foreach { n => sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n")) }
+      (1 to 15).foreach { n =>
+        sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
+      }
       eventually {
         repository.findById(entityId).futureValue.get.text should include("elem-15")
       }
       offsetStore.readOffset[Long](projectionId).futureValue.get shouldBe 10L
 
-      (16 to 22).foreach { n => sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n")) }
+      (16 to 22).foreach { n =>
+        sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
+      }
       eventually {
         repository.findById(entityId).futureValue.get.text should include("elem-22")
       }
@@ -361,7 +369,9 @@ class CassandraProjectionSpec
           projectionId,
           TestSourceProvider(source),
           saveOffsetAfterEnvelopes = 10,
-          saveOffsetAfterDuration = 2.seconds) { envelope => repository.concatToText(envelope.id, envelope.message) }
+          saveOffsetAfterDuration = 2.seconds) { envelope =>
+          repository.concatToText(envelope.id, envelope.message)
+        }
 
       val sinkProbe = projectionTestKit.runWithTestSink(projection)
       eventually {
@@ -369,13 +379,17 @@ class CassandraProjectionSpec
       }
       sinkProbe.request(1000)
 
-      (1 to 15).foreach { n => sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n")) }
+      (1 to 15).foreach { n =>
+        sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
+      }
       eventually {
         repository.findById(entityId).futureValue.get.text should include("elem-15")
       }
       offsetStore.readOffset[Long](projectionId).futureValue.get shouldBe 10L
 
-      (16 to 17).foreach { n => sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n")) }
+      (16 to 17).foreach { n =>
+        sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
+      }
       eventually {
         offsetStore.readOffset[Long](projectionId).futureValue.get shouldBe 17L
       }

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
@@ -97,7 +97,9 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
 
         case AtLeastOnce(afterEnvelopes, orAfterDuration) =>
           Flow[Envelope]
-            .mapAsync(1) { env => processEnvelope(env).map(_ => sourceProvider.extractOffset(env)) }
+            .mapAsync(1) { env =>
+              processEnvelope(env).map(_ => sourceProvider.extractOffset(env))
+            }
             .groupedWithin(afterEnvelopes, orAfterDuration)
             .collect { case grouped if grouped.nonEmpty => grouped.last }
             .mapAsync(parallelism = 1)(storeOffset)

--- a/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
+++ b/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
@@ -161,7 +161,8 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
 
       val slickProjection =
         SlickProjection.exactlyOnce(projectionId, sourceProvider = sourceProvider(entityId), databaseConfig = dbConfig) {
-          envelope => repository.concatToText(envelope.id, envelope.message)
+          envelope =>
+            repository.concatToText(envelope.id, envelope.message)
         }
 
       projectionTestKit.run(slickProjection) {
@@ -217,7 +218,9 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
         SlickProjection.exactlyOnce(
           projectionId = projectionId,
           sourceProvider = sourceProvider(entityId),
-          databaseConfig = dbConfig) { envelope => repository.concatToText(envelope.id, envelope.message) }
+          databaseConfig = dbConfig) { envelope =>
+          repository.concatToText(envelope.id, envelope.message)
+        }
 
       projectionTestKit.run(slickProjection) {
         withClue("checking: all values were concatenated") {
@@ -275,7 +278,9 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
         SlickProjection.exactlyOnce(
           projectionId = projectionId,
           sourceProvider = sourceProvider(entityId),
-          databaseConfig = dbConfig) { envelope => repository.concatToText(envelope.id, envelope.message) }
+          databaseConfig = dbConfig) { envelope =>
+          repository.concatToText(envelope.id, envelope.message)
+        }
 
       projectionTestKit.run(slickProjection) {
         withClue("checking: all values were concatenated") {
@@ -328,7 +333,9 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
         SlickProjection.exactlyOnce(
           projectionId = projectionId,
           sourceProvider = sourceProvider(entityId),
-          databaseConfig = dbConfig) { envelope => repository.concatToText(envelope.id, envelope.message) }
+          databaseConfig = dbConfig) { envelope =>
+          repository.concatToText(envelope.id, envelope.message)
+        }
 
       projectionTestKit.run(slickProjection) {
         withClue("checking: all values were concatenated") {
@@ -488,7 +495,9 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
           sourceProvider = sourceProvider(entityId),
           databaseConfig = dbConfig,
           saveOffsetAfterEnvelopes = 2,
-          saveOffsetAfterDuration = 1.minute) { envelope => repository.concatToText(envelope.id, envelope.message) }
+          saveOffsetAfterDuration = 1.minute) { envelope =>
+          repository.concatToText(envelope.id, envelope.message)
+        }
 
       projectionTestKit.run(slickProjection) {
         withClue("checking: all values were concatenated") {
@@ -521,7 +530,9 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
           sourceProvider = TestSourceProvider(source),
           databaseConfig = dbConfig,
           saveOffsetAfterEnvelopes = 10,
-          saveOffsetAfterDuration = 1.minute) { envelope => repository.concatToText(envelope.id, envelope.message) }
+          saveOffsetAfterDuration = 1.minute) { envelope =>
+          repository.concatToText(envelope.id, envelope.message)
+        }
 
       val sinkProbe = projectionTestKit.runWithTestSink(slickProjection)
       eventually {
@@ -529,13 +540,17 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       }
       sinkProbe.request(1000)
 
-      (1 to 15).foreach { n => sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n")) }
+      (1 to 15).foreach { n =>
+        sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
+      }
       eventually {
         dbConfig.db.run(repository.findById(entityId)).futureValue.value.text should include("elem-15")
       }
       offsetStore.readOffset[Long](projectionId).futureValue.value shouldBe 10L
 
-      (16 to 22).foreach { n => sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n")) }
+      (16 to 22).foreach { n =>
+        sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
+      }
       eventually {
         dbConfig.db.run(repository.findById(entityId)).futureValue.value.text should include("elem-22")
       }
@@ -561,7 +576,9 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
           sourceProvider = TestSourceProvider(source),
           databaseConfig = dbConfig,
           saveOffsetAfterEnvelopes = 10,
-          saveOffsetAfterDuration = 2.seconds) { envelope => repository.concatToText(envelope.id, envelope.message) }
+          saveOffsetAfterDuration = 2.seconds) { envelope =>
+          repository.concatToText(envelope.id, envelope.message)
+        }
 
       val sinkProbe = projectionTestKit.runWithTestSink(slickProjection)
       eventually {
@@ -569,13 +586,17 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       }
       sinkProbe.request(1000)
 
-      (1 to 15).foreach { n => sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n")) }
+      (1 to 15).foreach { n =>
+        sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
+      }
       eventually {
         dbConfig.db.run(repository.findById(entityId)).futureValue.value.text should include("elem-15")
       }
       offsetStore.readOffset[Long](projectionId).futureValue.value shouldBe 10L
 
-      (16 to 17).foreach { n => sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n")) }
+      (16 to 17).foreach { n =>
+        sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
+      }
       eventually {
         offsetStore.readOffset[Long](projectionId).futureValue.value shouldBe 17L
       }


### PR DESCRIPTION
* formated first with scalafmt v2.1.0
* reformatted with v2.4.2 and newlines.afterCurlyLambda = preserve