### PR TITLE
Experiment with Handler being a function

### DIFF
--- a/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
+++ b/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
@@ -167,14 +167,11 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       }
 
       val slickProjection =
-        SlickProjection.exactlyOnce(
-          projectionId,
-          sourceProvider = sourceProvider(entityId),
-          databaseConfig = dbConfig,
-          // build event handler from simple lambda
-          handler = SlickHandler[Envelope] { envelope =>
+        SlickProjection.exactlyOnce(projectionId, sourceProvider = sourceProvider(entityId), databaseConfig = dbConfig) {
+          envelope =>
+            // build event handler from simple lambda
             repository.concatToText(envelope.id, envelope.message)
-          })
+        }
 
       projectionTestKit.run(slickProjection) {
         withClue("check - all values were concatenated") {
@@ -198,7 +195,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       }
 
       val bogusEventHandler = new SlickHandler[Envelope] {
-        override def handle(envelope: Envelope): slick.dbio.DBIO[Done] =
+        override def apply(envelope: Envelope): slick.dbio.DBIO[Done] =
           if (envelope.offset == 4L) DBIOAction.failed(new RuntimeException("fail on fourth envelope"))
           else repository.concatToText(envelope.id, envelope.message)
 
@@ -239,7 +236,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
         private var _attempts = 0
         def attempts = _attempts
 
-        override def handle(envelope: Envelope): slick.dbio.DBIO[Done] =
+        override def apply(envelope: Envelope): slick.dbio.DBIO[Done] =
           if (envelope.offset == 4L) {
             _attempts += 1
             DBIOAction.failed(new RuntimeException("fail on fourth envelope"))
@@ -284,7 +281,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
         private var _attempts = 0
         def attempts = _attempts
 
-        override def handle(envelope: Envelope): slick.dbio.DBIO[Done] =
+        override def apply(envelope: Envelope): slick.dbio.DBIO[Done] =
           if (envelope.offset == 4L) {
             _attempts += 1
             DBIOAction.failed(new RuntimeException(streamFailureMsg))
@@ -334,7 +331,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
 
       val streamFailureMsg = "fail on fourth envelope"
       val bogusEventHandler = new SlickHandler[Envelope] {
-        override def handle(envelope: Envelope): slick.dbio.DBIO[Done] =
+        override def apply(envelope: Envelope): slick.dbio.DBIO[Done] =
           if (envelope.offset == 4L) DBIOAction.failed(new RuntimeException(streamFailureMsg))
           else repository.concatToText(envelope.id, envelope.message)
       }
@@ -366,7 +363,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
 
       // re-run projection without failing function
       val eventHandler = new SlickHandler[Envelope] {
-        override def handle(envelope: Envelope): slick.dbio.DBIO[Done] =
+        override def apply(envelope: Envelope): slick.dbio.DBIO[Done] =
           repository.concatToText(envelope.id, envelope.message)
       }
       val slickProjection =
@@ -396,7 +393,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       val streamFailureMsg = "fail on fourth envelope"
 
       val bogusEventHandler = new SlickHandler[Envelope] {
-        override def handle(envelope: Envelope): slick.dbio.DBIO[Done] =
+        override def apply(envelope: Envelope): slick.dbio.DBIO[Done] =
           if (envelope.offset == 4L) DBIOAction.failed(new RuntimeException(streamFailureMsg))
           else repository.concatToText(envelope.id, envelope.message)
       }
@@ -428,7 +425,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
 
       // re-run projection without failing function
       val eventHandler = new SlickHandler[Envelope] {
-        override def handle(envelope: Envelope): slick.dbio.DBIO[Done] =
+        override def apply(envelope: Envelope): slick.dbio.DBIO[Done] =
           repository.concatToText(envelope.id, envelope.message)
       }
       val slickProjection =
@@ -456,7 +453,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       val projectionId = genRandomProjectionId()
 
       val bogusEventHandler = new SlickHandler[Envelope] {
-        override def handle(envelope: Envelope): slick.dbio.DBIO[Done] =
+        override def apply(envelope: Envelope): slick.dbio.DBIO[Done] =
           if (envelope.offset == 4L) repository.updateWithNullValue(envelope.id)
           else repository.concatToText(envelope.id, envelope.message)
       }
@@ -487,7 +484,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
 
       // re-run projection without failing function
       val eventHandler = new SlickHandler[Envelope] {
-        override def handle(envelope: Envelope): slick.dbio.DBIO[Done] =
+        override def apply(envelope: Envelope): slick.dbio.DBIO[Done] =
           repository.concatToText(envelope.id, envelope.message)
       }
       val slickProjection =
@@ -523,7 +520,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       }
 
       val eventHandler = new SlickHandler[Envelope] {
-        override def handle(envelope: Envelope): slick.dbio.DBIO[Done] =
+        override def apply(envelope: Envelope): slick.dbio.DBIO[Done] =
           repository.concatToText(envelope.id, envelope.message)
       }
       val slickProjection =
@@ -557,7 +554,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       }
 
       val eventHandler = new SlickHandler[Envelope] {
-        override def handle(envelope: Envelope): slick.dbio.DBIO[Done] =
+        override def apply(envelope: Envelope): slick.dbio.DBIO[Done] =
           if (envelope.offset == 4L) DBIOAction.failed(new RuntimeException("fail on fourth envelope"))
           else repository.concatToText(envelope.id, envelope.message)
 
@@ -595,7 +592,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       }
 
       val eventHandler = new SlickHandler[Envelope] {
-        override def handle(envelope: Envelope): slick.dbio.DBIO[Done] =
+        override def apply(envelope: Envelope): slick.dbio.DBIO[Done] =
           if (envelope.offset == 4L) DBIOAction.failed(new RuntimeException("fail on fourth envelope"))
           else repository.concatToText(envelope.id, envelope.message)
 
@@ -630,7 +627,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       val streamFailureMsg = "fail on fourth envelope"
 
       val bogusEventHandler = new SlickHandler[Envelope] {
-        override def handle(envelope: Envelope): slick.dbio.DBIO[Done] =
+        override def apply(envelope: Envelope): slick.dbio.DBIO[Done] =
           if (envelope.offset == 4L) DBIOAction.failed(new RuntimeException(streamFailureMsg))
           else repository.concatToText(envelope.id, envelope.message)
       }
@@ -665,7 +662,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       // re-run projection without failing function
 
       val eventHandler = new SlickHandler[Envelope] {
-        override def handle(envelope: Envelope): slick.dbio.DBIO[Done] =
+        override def apply(envelope: Envelope): slick.dbio.DBIO[Done] =
           repository.concatToText(envelope.id, envelope.message)
       }
       val slickProjection =
@@ -697,7 +694,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       val streamFailureMsg = "fail on fourth envelope"
 
       val bogusEventHandler = new SlickHandler[Envelope] {
-        override def handle(envelope: Envelope): slick.dbio.DBIO[Done] =
+        override def apply(envelope: Envelope): slick.dbio.DBIO[Done] =
           if (envelope.offset == 4L) DBIOAction.failed(new RuntimeException(streamFailureMsg))
           else repository.concatToText(envelope.id, envelope.message)
       }
@@ -732,7 +729,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       // re-run projection without failing function
 
       val eventHandler = new SlickHandler[Envelope] {
-        override def handle(envelope: Envelope): slick.dbio.DBIO[Done] =
+        override def apply(envelope: Envelope): slick.dbio.DBIO[Done] =
           repository.concatToText(envelope.id, envelope.message)
       }
       val slickProjection =
@@ -770,7 +767,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       }
 
       val eventHandler = new SlickHandler[Envelope] {
-        override def handle(envelope: Envelope): slick.dbio.DBIO[Done] =
+        override def apply(envelope: Envelope): slick.dbio.DBIO[Done] =
           repository.concatToText(envelope.id, envelope.message)
       }
       val slickProjection =
@@ -819,7 +816,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       }
 
       val eventHandler = new SlickHandler[Envelope] {
-        override def handle(envelope: Envelope): slick.dbio.DBIO[Done] =
+        override def apply(envelope: Envelope): slick.dbio.DBIO[Done] =
           repository.concatToText(envelope.id, envelope.message)
       }
       val slickProjection =


### PR DESCRIPTION
@seglo, this one is build on top of #82 

The handler implements a function `Envelope => DBIO[Done]`

Because of type inference, I had to double `exactlyOnce` method. I think that this approach can generate confusion. 

We need to have: 

```scala
// for simple function
SlickProjection.exactlyOnce(projectionId, sourceProvider = sourceProvider(entityId), databaseConfig = dbConfig) {
  envelope =>
    // build event handler from simple lambda
    repository.concatToText(envelope.id, envelope.message)
}
```
and then 

```scala
SlickProjection.exactlyOnce(
  projectionId,
  sourceProvider = sourceProvider(entityId),
  databaseConfig = dbConfig,
  eventHandler)
```

The following isn't possible unless we add all the types in `atLeastOnce`. Hence the overload of `atLeastOnce`. 

```scala
SlickProjection.exactlyOnce(
  projectionId,
  sourceProvider = sourceProvider(entityId),
  databaseConfig = dbConfig,
  {
  envelope =>
    // build event handler from simple lambda
    repository.concatToText(envelope.id, envelope.message)
}
)
```

I think the convenience on the companion object added [here](https://github.com/akka/akka-projection/pull/82/files#diff-175dcc731a49c092a289be844456b9a2R48-R51) is slightly better. Less variants and almost same result.