### PR TITLE
Recovery strategies when handler fails to process, #17

### DIFF
--- a/akka-projection-core/src/main/scala/akka/projection/HandlerRecovery.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/HandlerRecovery.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.projection
 
 import akka.util.JavaDurationConverters._

--- a/akka-projection-core/src/main/scala/akka/projection/HandlerRecovery.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/HandlerRecovery.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.projection
+
+import akka.util.JavaDurationConverters._
+import scala.concurrent.duration.FiniteDuration
+
+import akka.annotation.InternalApi
+
+trait HandlerRecovery[Envelope] {
+
+  /**
+   * Override this to define the error handler strategy when processing an `Envelope` fails.
+   * By default it will immediately give up and fail the stream.
+   */
+  def onFailure(envelope: Envelope, throwable: Throwable): HandlerRecoveryStrategy = {
+    HandlerRecoveryStrategy.fail
+  }
+}
+
+/**
+ * Error handling strategy for when processing an `Envelope` fails. Defined in the `Handler` by
+ * overriding [[HandlerRecovery.onFailure]].
+ */
+sealed trait HandlerRecoveryStrategy
+
+object HandlerRecoveryStrategy {
+  import Internal._
+
+  /**
+   * If the first attempt to invoke the handler fails it will immediately give up
+   * and fail the stream.
+   */
+  def fail: HandlerRecoveryStrategy = Fail
+
+  /**
+   * If the first attempt to invoke the handler fails it will immediately give up,
+   * discard the element and continue with next.
+   */
+  def skip: HandlerRecoveryStrategy = Skip
+
+  /**
+   * Scala API: If the first attempt to invoke the handler fails it will retry invoking the handler with the
+   * same envelope this number of `retries` with the `delay` between each attempt. It will give up
+   * and fail the stream if all attempts fail.
+   */
+  def retryAndFail(retries: Int, delay: FiniteDuration): HandlerRecoveryStrategy =
+    if (retries < 1) fail else RetryAndFail(retries, delay)
+
+  /**
+   * Java API: If the first attempt to invoke the handler fails it will retry invoking the handler with the
+   * same envelope this number of `retries` with the `delay` between each attempt. It will give up
+   * and fail the stream if all attempts fail.
+   */
+  def retryAndFail(retries: Int, delay: java.time.Duration): HandlerRecoveryStrategy =
+    retryAndFail(retries, delay.asScala)
+
+  /**
+   * Scala API: If the first attempt to invoke the handler fails it will retry invoking the handler with the
+   * same envelope this number of `retries` with the `delay` between each attempt. It will give up,
+   * discard the element and continue with next if all attempts fail.
+   */
+  def retryAndSkip(retries: Int, delay: FiniteDuration): HandlerRecoveryStrategy =
+    if (retries < 1) fail else RetryAndSkip(retries, delay)
+
+  /**
+   * Java API: If the first attempt to invoke the handler fails it will retry invoking the handler with the
+   * same envelope this number of `retries` with the `delay` between each attempt. It will give up,
+   * discard the element and continue with next if all attempts fail.
+   */
+  def retryAndSkip(retries: Int, delay: java.time.Duration): HandlerRecoveryStrategy =
+    retryAndSkip(retries, delay.asScala)
+
+  /**
+   * INTERNAL API: placed here instead of the `internal` package because of sealed trait
+   */
+  @InternalApi private[akka] object Internal {
+    case object Fail extends HandlerRecoveryStrategy
+    case object Skip extends HandlerRecoveryStrategy
+    final case class RetryAndFail(retries: Int, delay: FiniteDuration) extends HandlerRecoveryStrategy {
+      require(retries > 0, "retries must be > 0")
+    }
+    final case class RetryAndSkip(retries: Int, delay: FiniteDuration) extends HandlerRecoveryStrategy {
+      require(retries > 0, "retries must be > 0")
+    }
+  }
+}

--- a/akka-projection-core/src/main/scala/akka/projection/internal/HandlerRecoveryImpl.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/HandlerRecoveryImpl.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.projection.internal
 
 import scala.concurrent.Future

--- a/akka-projection-core/src/main/scala/akka/projection/internal/HandlerRecoveryImpl.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/HandlerRecoveryImpl.scala
@@ -106,8 +106,7 @@ import akka.projection.HandlerRecoveryStrategy
                 retries + 1,
                 exception)
             }
-            futDone
-
+            retried.recoverWith(_ => futDone)
         }
     }
   }

--- a/akka-projection-core/src/main/scala/akka/projection/internal/HandlerRecoveryImpl.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/HandlerRecoveryImpl.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.projection.internal
+
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+import akka.Done
+import akka.actor.ClassicActorSystemProvider
+import akka.annotation.InternalApi
+import akka.event.LoggingAdapter
+import akka.pattern.after
+import akka.pattern.retry
+import akka.projection.HandlerRecovery
+import akka.projection.HandlerRecoveryStrategy
+import akka.projection.scaladsl.SourceProvider
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object HandlerRecoveryImpl {
+
+  private val futDone = Future.successful(Done)
+
+  def applyUserRecovery[Offset, Envelope](
+      handler: HandlerRecovery[Envelope],
+      envelope: Envelope,
+      sourceProvider: SourceProvider[Offset, Envelope],
+      logger: LoggingAdapter,
+      futureCallback: () => Future[Done])(implicit systemProvider: ClassicActorSystemProvider): Future[Done] = {
+    import HandlerRecoveryStrategy.Internal._
+
+    implicit val scheduler = systemProvider.classicSystem.scheduler
+    implicit val dispatcher = systemProvider.classicSystem.dispatcher
+
+    val tryFutureCallback: () => Future[Done] = { () =>
+      try {
+        futureCallback()
+      } catch {
+        case NonFatal(e) =>
+          // in case the callback throws instead of returning failed Future
+          Future.failed(e)
+      }
+    }
+
+    // this will count as one attempt
+    val firstAttempt = tryFutureCallback()
+
+    firstAttempt.recoverWith {
+      case err =>
+        val failedOffset = sourceProvider.extractOffset(envelope)
+
+        handler.onFailure(envelope, err) match {
+          case Fail =>
+            logger.error(
+              cause = err,
+              template =
+                "Failed to process envelope with offset [{}]. Projection will stop as defined by recovery strategy.",
+              failedOffset)
+            firstAttempt
+
+          case Skip =>
+            logger.warning(
+              "Failed to process envelope with offset [{}]. " +
+              "Envelope will be skipped as defined by recovery strategy. Exception: {}",
+              failedOffset,
+              err)
+            futDone
+
+          case RetryAndFail(retries, delay) =>
+            logger.error(
+              cause = err,
+              template = "First attempt to process envelope with offset [{}] failed. Will retry [{}] time(s).",
+              failedOffset,
+              retries)
+
+            // retries - 1 because retry() is based on attempts
+            // first attempt is performed immediately and therefore we must first delay
+            val retied = after(delay, scheduler)(retry(tryFutureCallback, retries - 1, delay))
+            retied.failed.foreach { exception =>
+              logger.error(
+                cause = exception,
+                template =
+                  "Failed to process envelope with offset [{}] after [{}] attempts. " +
+                  "Projection will stop as defined by recovery strategy.",
+                failedOffset,
+                retries + 1)
+            }
+            retied
+
+          case RetryAndSkip(retries, delay) =>
+            logger.error(
+              cause = err,
+              template = "First attempt to process envelope with offset [{}] failed. Will retry [{}] time(s).",
+              failedOffset,
+              retries)
+
+            // retries - 1 because retry() is based on attempts
+            // first attempt is performed immediately and therefore we must first delay
+            val retied = after(delay, scheduler)(retry(tryFutureCallback, retries - 1, delay))
+            retied.failed.foreach { exception =>
+              logger.warning(
+                "Failed to process envelope with offset [{}] after [{}] attempts. " +
+                "Envelope will be skipped as defined by recovery strategy. Last exception: {}",
+                failedOffset,
+                retries + 1,
+                exception)
+            }
+            futDone
+
+        }
+    }
+  }
+
+}

--- a/akka-projection-core/src/main/scala/akka/projection/javadsl/Handler.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/javadsl/Handler.scala
@@ -7,8 +7,10 @@ package akka.projection.javadsl
 import java.util.concurrent.CompletionStage
 
 import akka.Done
+import akka.annotation.ApiMayChange
 import akka.projection.HandlerRecovery
 
+@ApiMayChange
 object Handler {
 
   /** Handler that can be define from a simple function */
@@ -29,6 +31,7 @@ object Handler {
  * guarantees between the invocations are handled automatically, i.e. no volatile or
  * other concurrency primitives are needed for managing the state.
  */
+@ApiMayChange
 abstract class Handler[Envelope] extends HandlerRecovery[Envelope] {
   def process(envelope: Envelope): CompletionStage[Done]
 }

--- a/akka-projection-core/src/main/scala/akka/projection/javadsl/Handler.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/javadsl/Handler.scala
@@ -7,6 +7,18 @@ package akka.projection.javadsl
 import java.util.concurrent.CompletionStage
 
 import akka.Done
+import akka.projection.HandlerRecovery
+
+object Handler {
+
+  /** Handler that can be define from a simple function */
+  private class HandlerFunction[Envelope](handler: Envelope => CompletionStage[Done]) extends Handler[Envelope] {
+    override def process(envelope: Envelope): CompletionStage[Done] = handler(envelope)
+  }
+
+  def fromFunction[Envelope](handler: Envelope => CompletionStage[Done]): Handler[Envelope] =
+    new HandlerFunction(handler)
+}
 
 /**
  * Implement this interface for the Envelope handler in the `Projection`. Some projections
@@ -17,6 +29,6 @@ import akka.Done
  * guarantees between the invocations are handled automatically, i.e. no volatile or
  * other concurrency primitives are needed for managing the state.
  */
-trait Handler[Envelope] {
+abstract class Handler[Envelope] extends HandlerRecovery[Envelope] {
   def process(envelope: Envelope): CompletionStage[Done]
 }

--- a/akka-projection-core/src/main/scala/akka/projection/scaladsl/Handler.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/scaladsl/Handler.scala
@@ -7,8 +7,10 @@ package akka.projection.scaladsl
 import scala.concurrent.Future
 
 import akka.Done
+import akka.annotation.ApiMayChange
+import akka.projection.HandlerRecovery
 
-object Handler {
+@ApiMayChange object Handler {
 
   /** Handler that can be define from a simple function */
   private class HandlerFunction[Envelope](handler: Envelope => Future[Done]) extends Handler[Envelope] {
@@ -26,7 +28,10 @@ object Handler {
  * It is invoked by the `Projection` machinery one envelope at a time and visibility
  * guarantees between the invocations are handled automatically, i.e. no volatile or
  * other concurrency primitives are needed for managing the state.
+ *
+ * Error handling strategy for when processing an `Envelope` fails can be defined in the `Handler` by
+ * overriding [[HandlerRecovery.onFailure]].
  */
-trait Handler[Envelope] {
+@ApiMayChange trait Handler[Envelope] extends HandlerRecovery[Envelope] {
   def process(envelope: Envelope): Future[Done]
 }

--- a/akka-projection-core/src/test/resources/logback-test.xml
+++ b/akka-projection-core/src/test/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!-- Silence initial setup logging from Logback -->
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+  <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />
+
+  <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >
+    <appender-ref ref="STDOUT"/>
+  </logger>
+
+  <root level="DEBUG">
+    <appender-ref ref="CapturingAppender" />
+  </root>
+</configuration>

--- a/akka-projection-core/src/test/scala/akka/projection/internal/HandlerRecoveryImplSpec.scala
+++ b/akka-projection-core/src/test/scala/akka/projection/internal/HandlerRecoveryImplSpec.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.internal
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import akka.Done
+import akka.actor.testkit.typed.TestException
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.scaladsl.adapter._
+import akka.event.Logging
+import akka.projection.HandlerRecoveryStrategy
+import akka.projection.scaladsl.Handler
+import akka.projection.scaladsl.SourceProvider
+import akka.stream.scaladsl.Source
+import org.scalatest.wordspec.AnyWordSpecLike
+
+object HandlerRecoveryImplSpec {
+  final case class Envelope(offset: Long, message: String)
+
+  class FailHandler(recoveryStrategy: HandlerRecoveryStrategy, failOnOffset: Long) extends Handler[Envelope] {
+    private val _attempts = new AtomicInteger()
+    def attempts: Int = _attempts.get
+
+    override def process(envelope: Envelope): Future[Done] = {
+      if (envelope.offset == failOnOffset) {
+        _attempts.incrementAndGet()
+        throw TestException(s"Fail on $failOnOffset after $attempts attempts")
+      } else {
+        Future.successful(Done)
+      }
+    }
+
+    override def onFailure(envelope: Envelope, throwable: Throwable): HandlerRecoveryStrategy = recoveryStrategy
+  }
+
+  class TestSourceProvider extends SourceProvider[Long, Envelope] {
+    override def source(offset: Option[Long]): Source[Envelope, _] = throw new UnsupportedOperationException
+
+    override def extractOffset(envelope: Envelope): Long = envelope.offset
+  }
+}
+
+class HandlerRecoveryImplSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
+  import HandlerRecoveryImplSpec._
+
+  private val logger = Logging(system.toClassic, getClass)
+  private val sourceProvider = new TestSourceProvider
+  private val env3 = Envelope(offset = 3, "c")
+
+  "HandlerRecovery" must {
+    "fail" in {
+      val handler = new FailHandler(HandlerRecoveryStrategy.fail, failOnOffset = 3)
+      val result =
+        HandlerRecoveryImpl.applyUserRecovery(handler, env3, sourceProvider, logger, () => handler.process(env3))
+      result.failed.futureValue.getClass shouldBe classOf[TestException]
+      handler.attempts shouldBe 1
+    }
+
+    "skip" in {
+      val handler = new FailHandler(HandlerRecoveryStrategy.skip, failOnOffset = 3)
+      val result =
+        HandlerRecoveryImpl.applyUserRecovery(handler, env3, sourceProvider, logger, () => handler.process(env3))
+      result.futureValue shouldBe Done
+      handler.attempts shouldBe 1
+    }
+
+    "retryAndFail 1" in {
+      val handler = new FailHandler(HandlerRecoveryStrategy.retryAndFail(1, 10.millis), failOnOffset = 3)
+      val result =
+        HandlerRecoveryImpl.applyUserRecovery(handler, env3, sourceProvider, logger, () => handler.process(env3))
+      result.failed.futureValue.getClass shouldBe classOf[TestException]
+      handler.attempts shouldBe 2
+    }
+
+    "retryAndFail 3" in {
+      val handler = new FailHandler(HandlerRecoveryStrategy.retryAndFail(3, 10.millis), failOnOffset = 3)
+      val result =
+        HandlerRecoveryImpl.applyUserRecovery(handler, env3, sourceProvider, logger, () => handler.process(env3))
+      result.failed.futureValue.getClass shouldBe classOf[TestException]
+      handler.attempts shouldBe 4
+    }
+
+    "retryAndFail after delay" in {
+      val handler = new FailHandler(HandlerRecoveryStrategy.retryAndFail(1, 1.second), failOnOffset = 3)
+      val result =
+        HandlerRecoveryImpl.applyUserRecovery(handler, env3, sourceProvider, logger, () => handler.process(env3))
+      // first attempt is immediately
+      handler.attempts shouldBe 1
+      // retries after delay
+      Thread.sleep(100)
+      handler.attempts shouldBe 1
+      result.failed.futureValue.getClass shouldBe classOf[TestException]
+      handler.attempts shouldBe 2
+    }
+
+    "retryAndSkip 1" in {
+      val handler = new FailHandler(HandlerRecoveryStrategy.retryAndSkip(1, 10.millis), failOnOffset = 3)
+      val result =
+        HandlerRecoveryImpl.applyUserRecovery(handler, env3, sourceProvider, logger, () => handler.process(env3))
+      result.futureValue shouldBe Done
+      handler.attempts shouldBe 2
+    }
+
+    "retryAndSkip 3" in {
+      val handler = new FailHandler(HandlerRecoveryStrategy.retryAndSkip(3, 10.millis), failOnOffset = 3)
+      val result =
+        HandlerRecoveryImpl.applyUserRecovery(handler, env3, sourceProvider, logger, () => handler.process(env3))
+      result.futureValue shouldBe Done
+      handler.attempts shouldBe 4
+    }
+  }
+}

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
@@ -10,21 +10,15 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration.FiniteDuration
-import scala.util.Failure
-import scala.util.control.NonFatal
 
 import akka.Done
 import akka.actor.ClassicActorSystemProvider
 import akka.annotation.InternalApi
 import akka.event.Logging
-import akka.pattern._
 import akka.projection.Projection
 import akka.projection.ProjectionId
+import akka.projection.internal.HandlerRecoveryImpl
 import akka.projection.scaladsl.SourceProvider
-import akka.projection.slick.Fail
-import akka.projection.slick.RetryAndFail
-import akka.projection.slick.RetryAndSkip
-import akka.projection.slick.Skip
 import akka.projection.slick.SlickHandler
 import akka.stream.KillSwitches
 import akka.stream.scaladsl.Flow
@@ -83,134 +77,14 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
       implicit systemProvider: ClassicActorSystemProvider): Source[Done, _] = {
 
     import databaseConfig.profile.api._
-    implicit val scheduler = systemProvider.classicSystem.scheduler
-    implicit val dispatcher = systemProvider.classicSystem.dispatcher
 
     // TODO: add a LogSource for projection when we have a name and key
     val logger = Logging(systemProvider.classicSystem, this.getClass)
 
-    val futDone = Future.successful(Done)
+    implicit val dispatcher = systemProvider.classicSystem.dispatcher
 
-    def applyUserRecovery(envelope: Envelope)(futureCallback: () => Future[Done]) = {
-
-      // this will count as one attempt
-      val firstAttempt = futureCallback()
-
-      firstAttempt.recoverWith {
-        case NonFatal(err) =>
-          val failedOffset = sourceProvider.extractOffset(envelope)
-
-          handler.onFailure(envelope, err) match {
-            case Fail =>
-              logger.error(
-                cause = err,
-                template =
-                  "Failed to process envelope with offset [{}]. Projection will stop as defined by recovery strategy.",
-                failedOffset)
-              firstAttempt
-
-            case Skip =>
-              logger.warning(
-                template =
-                  "Failed to process envelope with offset [{}]. Envelope will be skipped as defined by recovery strategy. Exception {}({})",
-                failedOffset,
-                err.getClass.getSimpleName,
-                err.getMessage)
-              futDone
-
-            case RetryAndFail(retries, delay) =>
-              val totalRetries = retries - 1
-              logger.error(
-                cause = err,
-                template = "Failed to process envelope with offset [{}] failed. Will retry {} time(s).",
-                failedOffset,
-                totalRetries)
-
-              // less one attempt
-              val retied = retry(futureCallback, totalRetries, delay)
-              retied.onComplete {
-                case Failure(exception) =>
-                  logger.error(
-                    cause = exception,
-                    template =
-                      "Failed to process envelope with offset [{}] after {} retries. Projection will stop as defined by recovery strategy.",
-                    failedOffset,
-                    totalRetries)
-                case _ => // do nothing
-              }
-              retied
-
-            case RetryAndSkip(retries, delay) =>
-              // less one attempt
-              val totalRetries = retries - 1
-              logger.warning(
-                template =
-                  "Failed to process envelope with offset [{}] failed. Will retry {} time(s). Exception {}({})",
-                failedOffset,
-                totalRetries,
-                err.getClass.getSimpleName,
-                err.getMessage)
-
-              retry(futureCallback, totalRetries, delay).recoverWith {
-                case NonFatal(exception) =>
-                  logger.warning(
-                    template =
-                      "Failed to process envelope with offset [{}] after {} retries. Envelope will be skipped as defined by recovery strategy. Last exception {}({})",
-                    failedOffset,
-                    totalRetries,
-                    exception.getClass.getSimpleName,
-                    exception.getMessage)
-                  futDone
-              }
-          }
-      }
-    }
-
-    def aroundUserHandler(env: Envelope)(handlerFunc: Envelope => slick.dbio.DBIO[Done]) = {
-      try {
-        handlerFunc(env)
-      } catch {
-        case NonFatal(err) =>
-          handler.onFailure(env, err) match {
-
-            case Fail =>
-              logger.warning(
-                template =
-                  "An exception was thrown from inside the handler function while processing envelope with offset [{}]. Projection will stop as defined by recovery strategy.",
-                sourceProvider.extractOffset(env),
-                err.getClass.getSimpleName,
-                err.getMessage)
-              throw err
-
-            case Skip =>
-              logger.warning(
-                template =
-                  "An exception was thrown from inside the handler function while processing envelope with offset [{}]. Envelope will be skipped as defined by recovery strategy. Exception {}({})",
-                sourceProvider.extractOffset(env),
-                err.getClass.getSimpleName,
-                err.getMessage)
-              slick.dbio.DBIO.successful(Done)
-
-            case _: RetryAndSkip =>
-              logger.warning(
-                template =
-                  "An exception was thrown from inside the handler function while processing envelope with offset [{}]. This won't be retried. Envelope will be skipped as defined by recovery strategy. Exception {}({})",
-                sourceProvider.extractOffset(env),
-                err.getClass.getSimpleName,
-                err.getMessage)
-              slick.dbio.DBIO.successful(Done)
-
-            case _: RetryAndFail =>
-              logger.warning(
-                template =
-                  "An exception was thrown from inside the handler function while processing envelope with offset [{}]. This won't be retried. Projection will stop as defined by recovery strategy.",
-                sourceProvider.extractOffset(env),
-                err.getClass.getSimpleName,
-                err.getMessage)
-              throw err
-          }
-      }
-    }
+    def applyUserRecovery(envelope: Envelope)(futureCallback: () => Future[Done]): Future[Done] =
+      HandlerRecoveryImpl.applyUserRecovery[Offset, Envelope](handler, envelope, sourceProvider, logger, futureCallback)
 
     def processEnvelopeAndStoreOffsetInSameTransaction(env: Envelope): Future[Done] = {
       // run user function and offset storage on the same transaction
@@ -218,7 +92,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
       val txDBIO =
         offsetStore
           .saveOffset(projectionId, sourceProvider.extractOffset(env))
-          .flatMap(_ => aroundUserHandler(env)(handler.process))
+          .flatMap(_ => handler.process(env))
           .transactionally
 
       applyUserRecovery(env) { () =>
@@ -226,20 +100,9 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
       }
     }
 
-    def processEnvelopeAndStoreOffsetInSeparateTransactions(env: Envelope): Future[Done] = {
-      // user function in one transaction (may be composed of several DBIOAction), and offset save in separate
-      val dbio =
-        aroundUserHandler(env)(handler.process).transactionally
-          .flatMap(_ => offsetStore.saveOffset(projectionId, sourceProvider.extractOffset(env)))
-
-      applyUserRecovery(env) { () =>
-        databaseConfig.db.run(dbio).map(_ => Done)
-      }
-    }
-
     def processEnvelope(env: Envelope): Future[Done] = {
       // user function in one transaction (may be composed of several DBIOAction)
-      val dbio = aroundUserHandler(env)(handler.process).transactionally
+      val dbio = handler.process(env).transactionally
       applyUserRecovery(env) { () =>
         databaseConfig.db.run(dbio).map(_ => Done)
       }
@@ -267,8 +130,11 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
             .mapAsync(1)(processEnvelopeAndStoreOffsetInSameTransaction)
 
         case AtLeastOnce(1, _) =>
-          Flow[Envelope]
-            .mapAsync(1)(processEnvelopeAndStoreOffsetInSeparateTransactions)
+          // optimization of general AtLeastOnce case, still separate transactions for processEnvelope
+          // and storeOffset
+          Flow[Envelope].mapAsync(1) { env =>
+            processEnvelope(env).flatMap(_ => storeOffset(sourceProvider.extractOffset(env)))
+          }
 
         case AtLeastOnce(afterEnvelopes, orAfterDuration) =>
           Flow[Envelope]

--- a/akka-projection-slick/src/test/scala/akka/projection/slick/SlickSpec.scala
+++ b/akka-projection-slick/src/test/scala/akka/projection/slick/SlickSpec.scala
@@ -7,6 +7,7 @@ package akka.projection.slick
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.projection.slick.internal.SlickOffsetStore
 import akka.projection.testkit.scaladsl.ProjectionTestKit
@@ -14,7 +15,7 @@ import com.typesafe.config.Config
 import slick.basic.DatabaseConfig
 import slick.jdbc.H2Profile
 
-abstract class SlickSpec(config: Config) extends ScalaTestWithActorTestKit(config) {
+abstract class SlickSpec(config: Config) extends ScalaTestWithActorTestKit(config) with LogCapturing {
 
   val dbConfig: DatabaseConfig[H2Profile] = DatabaseConfig.forConfig("akka.projection.slick", config)
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -39,7 +39,7 @@ object Common extends AutoPlugin {
         "-unchecked",
         "-deprecation",
         "-language:_",
-        "-Xfatal-warnings",
+        //"-Xfatal-warnings", //FIXME need silencer first
         "-Ywarn-unused",
         "-encoding",
         "UTF-8",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,7 +48,8 @@ object Dependencies {
 
   private val deps = libraryDependencies
 
-  val core = deps ++= Seq(Compile.akkaStream, Compile.akkaPersistenceQuery, Test.scalatest)
+  val core =
+    deps ++= Seq(Compile.akkaStream, Compile.akkaPersistenceQuery, Test.akkaTypedTestkit, Test.logback, Test.scalatest)
 
   val testKit =
     deps ++= Seq(Compile.akkaTypedTestkit, Compile.akkaStreamTestkit, Test.scalatest, Test.scalatestJUnit, Test.junit)


### PR DESCRIPTION
* moved recovery strategies and implementation to core
* used in CassandraProjection (and SlickProjection)
* new unit test of the HandlerRecoveryImpl
* also found and fixed a few bugs
  * problem with at-least-once after 1 in Slick
  * problem with at-most-once in Cassandra, async boundary may cause more than one
    offset to be saved before processing

References #17

Draft because on top of other PR, but ready for review.