### PR TITLE
ProjectionBehavior (scala and java API)

### DIFF
--- a/akka-projection-core/src/main/scala/akka/projection/ProjectionBehavior.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/ProjectionBehavior.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection
+
+import java.util.function.Supplier
+
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.Behaviors
+import scala.jdk.FunctionConverters._
+
+object ProjectionBehavior {
+
+  sealed trait Command
+  object Stop extends Command
+  private object Stopped extends Command
+
+  /**
+   * Java API: creates a ProjectionBehavior for the passed projections.
+   *
+   * Projections can only be started once, therefore a [[Supplier]] is required. On restart, a new projection instance will be created.
+   */
+  def create[Envelope](projectionFactory: Supplier[Projection[Envelope]]): Behavior[ProjectionBehavior.Command] =
+    apply(projectionFactory.asScala)
+
+  /**
+   * Java API: The top message used to stop the projection.
+   */
+  def stopMessage(): Command = Stop
+
+  /**
+   * Scala API: creates a ProjectionBehavior for the passed projections.
+   *
+   * Projections can only be started once, therefore a factory function [[() => Projection]] is required.
+   * On restart, a new projection instance will be created.
+   */
+  def apply[Envelope](projectionFactory: () => Projection[Envelope]): Behavior[ProjectionBehavior.Command] = {
+
+    def started(projection: Projection[Envelope]): Behavior[Command] =
+      Behaviors.setup[Command] { ctx =>
+
+        ctx.log.info("Starting projection [{}]", projection.projectionId)
+        projection.run()(ctx.system)
+
+        Behaviors.receiveMessagePartial {
+          case Stop =>
+            ctx.log.debug("Projection [{}] is being stopped", projection.projectionId)
+            val stoppedFut = projection.stop()(ctx.executionContext)
+            // we send a Stopped for whatever completes the Future
+            // Success or Failure, doesn't matter, since the internal stream is by then stopped
+            ctx.pipeToSelf(stoppedFut)(_ => Stopped)
+            stopping(projection.projectionId)
+        }
+      }
+
+    def stopping(projectionId: ProjectionId): Behavior[Command] =
+      Behaviors.receive {
+        case (ctx, Stopped) =>
+          ctx.log.debug("Projection [{}] stopped", projectionId)
+          Behaviors.stopped
+
+        case (ctx, Stop) =>
+          ctx.log.debug("Projection [{}] is already being stopped", projectionId)
+          Behaviors.same
+      }
+
+    // starting by default
+    started(projectionFactory())
+
+  }
+
+}

--- a/akka-projection-core/src/test/java/akka/projection/ProjectionBehaviorCompileTest.java
+++ b/akka-projection-core/src/test/java/akka/projection/ProjectionBehaviorCompileTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection;
+
+import akka.Done;
+import akka.actor.ClassicActorSystemProvider;
+import akka.actor.testkit.typed.javadsl.ActorTestKit;
+import akka.actor.typed.ActorRef;
+import akka.stream.scaladsl.Source;
+import scala.concurrent.ExecutionContext;
+import scala.concurrent.Future;
+
+/**
+ * Compile test: this class serves only for exercising the Java API.
+ */
+public class ProjectionBehaviorCompileTest {
+
+    public void compileTest() {
+        ActorTestKit testKit = ActorTestKit.create();
+        ActorRef<ProjectionBehavior.Command> ref =
+                testKit.spawn(ProjectionBehavior.create(TestProjection::new));
+        ref.tell(ProjectionBehavior.stopMessage());
+        // nobody is calling this method, so not really starting the system,
+        // but we never know
+        testKit.shutdownTestKit();
+    }
+
+    static class TestProjection implements Projection<String> {
+
+        @Override
+        public ProjectionId projectionId() {
+            return null;
+        }
+
+        @Override
+        public Source<Done, ?> mappedSource(ClassicActorSystemProvider systemProvider) {
+            return null;
+        }
+
+        @Override
+        public void run(ClassicActorSystemProvider systemProvider) {
+
+        }
+
+        @Override
+        public Future<Done> stop(ExecutionContext ec) {
+            return null;
+        }
+    }
+}

--- a/akka-projection-core/src/test/scala/akka/projection/ProjectionBehaviorSpec.scala
+++ b/akka-projection-core/src/test/scala/akka/projection/ProjectionBehaviorSpec.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.Promise
+
+import akka.Done
+import akka.NotUsed
+import akka.actor.ClassicActorSystemProvider
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.stream.KillSwitches
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import org.scalatest.wordspec.AnyWordSpecLike
+
+object ProjectionBehaviorSpec {
+
+  sealed trait ProbeMessage
+  case object StartObserved extends ProbeMessage
+  case class Consumed(n: Int, currentState: String) extends ProbeMessage
+  case object StopObserved extends ProbeMessage
+
+  /*
+   * This TestProjection has a internal state that we can use to prove that on restart,
+   * the actor is taking a new projection instance.
+   */
+  case class TestProjection(src: Source[Int, NotUsed], testProbe: TestProbe[ProbeMessage], failToStop: Boolean = false)
+      extends Projection[Int] {
+
+    private val strBuffer = new StringBuffer("")
+    override def projectionId: ProjectionId = ProjectionId("test-projection-with-internal-state", "00")
+
+    private val killSwitch = KillSwitches.shared(projectionId.id)
+    private val promiseToStop = Promise[Done]
+
+    override def run()(implicit systemProvider: ClassicActorSystemProvider): Unit = {
+      testProbe.ref ! StartObserved
+      val done = mappedSource.runWith(Sink.ignore)
+      promiseToStop.completeWith(done)
+    }
+
+    private def process(i: Int): Future[Done] = {
+      concat(i)
+      testProbe.ref ! Consumed(i, strBuffer.toString)
+      Future.successful(Done)
+    }
+
+    private[projection] def mappedSource()(implicit systemProvider: ClassicActorSystemProvider): Source[Done, _] = {
+      src.via(killSwitch.flow).mapAsync(1)(i => process(i))
+    }
+
+    private def concat(i: Int) = {
+      if (strBuffer.toString.isEmpty) strBuffer.append(i)
+      else strBuffer.append("-").append(i)
+    }
+
+    override def stop()(implicit ec: ExecutionContext): Future[Done] = {
+      val stopFut =
+        if (failToStop) {
+          // this simulates a failure when stopping the stream
+          // for the ProjectionBehavior the effect is the same
+          Future.failed(new RuntimeException("failed to stop properly"))
+        } else {
+          killSwitch.shutdown()
+          promiseToStop.future
+        }
+      stopFut.onComplete(_ => testProbe.ref ! StopObserved)
+      stopFut
+    }
+  }
+}
+class ProjectionBehaviorSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
+
+  import ProjectionBehaviorSpec._
+
+  "A ProjectionBehavior" must {
+
+    "start immediately on demand" in {
+
+      val testProbe = testKit.createTestProbe[ProbeMessage]()
+      val src = Source(1 to 2)
+      testKit.spawn(ProjectionBehavior(() => TestProjection(src, testProbe)))
+
+      testProbe.expectMessage(StartObserved)
+      testProbe.expectMessage(Consumed(1, "1"))
+      testProbe.expectMessage(Consumed(2, "1-2"))
+      // good, things are flowing
+
+    }
+
+    "stop after receiving stop message" in {
+
+      val testProbe = testKit.createTestProbe[ProbeMessage]()
+      val src = Source(1 to 2)
+      val projectionRef = testKit.spawn(ProjectionBehavior(() => TestProjection(src, testProbe)))
+
+      testProbe.expectMessage(StartObserved)
+      testProbe.expectMessage(Consumed(1, "1"))
+      testProbe.expectMessage(Consumed(2, "1-2"))
+      // good, things are flowing
+
+      projectionRef ! ProjectionBehavior.Stop
+      testProbe.expectMessage(StopObserved)
+
+      testProbe.expectTerminated(projectionRef)
+
+    }
+
+    "also stop when stopping underlying stream results in failure" in {
+
+      val testProbe = testKit.createTestProbe[ProbeMessage]()
+      val src = Source(1 to 2)
+      val projectionRef = testKit.spawn(ProjectionBehavior(() => TestProjection(src, testProbe, failToStop = true)))
+
+      testProbe.expectMessage(StartObserved)
+      testProbe.expectMessage(Consumed(1, "1"))
+      testProbe.expectMessage(Consumed(2, "1-2"))
+      // good, things are flowing
+
+      // this Stop will crash the actor
+      projectionRef ! ProjectionBehavior.Stop
+      testProbe.expectMessage(StopObserved)
+
+      testProbe.expectTerminated(projectionRef)
+
+    }
+  }
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,6 +23,7 @@ object Dependencies {
   }
 
   object Compile {
+    val akkaActorTyped = "com.typesafe.akka" %% "akka-actor-typed" % Versions.akka
     val akkaStream = "com.typesafe.akka" %% "akka-stream" % Versions.akka
     val akkaPersistenceQuery = "com.typesafe.akka" %% "akka-persistence-query" % Versions.akka
 
@@ -38,7 +39,10 @@ object Dependencies {
   }
 
   object Test {
+
     val akkaTypedTestkit = Compile.akkaTypedTestkit % sbt.Test
+    val akkaStreamTestkit = Compile.akkaStreamTestkit % sbt.Test
+
     val scalatest = "org.scalatest" %% "scalatest" % Versions.scalaTest % sbt.Test
     val scalatestJUnit = "org.scalatestplus" %% "junit-4-12" % (Versions.scalaTest + ".0") % sbt.Test
     val junit = "junit" % "junit" % Versions.junit % sbt.Test
@@ -47,7 +51,7 @@ object Dependencies {
     val testContainers = "com.dimafeng" %% "testcontainers-scala-scalatest" % Versions.testContainersScala % sbt.Test
     val cassandraContainer =
       "com.dimafeng" %% "testcontainers-scala-cassandra" % Versions.testContainersScala % sbt.Test
-    val akkaStreamTestkit = Compile.akkaStreamTestkit % sbt.Test
+
     val alpakkaKafkaTestkit = "com.typesafe.akka" %% "akka-stream-kafka-testkit" % Versions.alpakkaKafka % sbt.Test
   }
 
@@ -63,6 +67,7 @@ object Dependencies {
   val core =
     deps ++= Seq(
         Compile.akkaStream,
+        Compile.akkaActorTyped,
         // akka-persistence-query is only needed for OffsetSerialization, but that is always used together
         // with more specific modules, such as akka-projection-cassandra, which defines the required
         // dependency on akka-persistence-query


### PR DESCRIPTION
This supersedes #99 as we realised that the we don't need (for now) a new API around the daemon.  