### PR TITLE
Flow as handler

### DIFF
--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/javadsl/CassandraProjection.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/javadsl/CassandraProjection.scala
@@ -88,9 +88,9 @@ object CassandraProjection {
    * semantics.
    *
    * The flow should emit a `Done` element for each completed envelope. The offset of the envelope is carried
-   * in the context of the `FlowWithContext` and is stored in Cassandra if corresponding `Done` is emitted.
+   * in the context of the `FlowWithContext` and is stored in Cassandra when corresponding `Done` is emitted.
    * Since the offset is stored after processing the envelope it means that if the
-   * projection is restarted from previously stored offset some envelopes may be processed more than once.
+   * projection is restarted from previously stored offset then some envelopes may be processed more than once.
    *
    * If the flow filters out envelopes the corresponding offset will not be stored, and such envelope
    * will be processed again if the projection is restarted and no later offset was stored.

--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/scaladsl/CassandraProjection.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/scaladsl/CassandraProjection.scala
@@ -93,9 +93,9 @@ object CassandraProjection {
    * semantics.
    *
    * The flow should emit a `Done` element for each completed envelope. The offset of the envelope is carried
-   * in the context of the `FlowWithContext` and is stored in Cassandra if corresponding `Done` is emitted.
+   * in the context of the `FlowWithContext` and is stored in Cassandra when corresponding `Done` is emitted.
    * Since the offset is stored after processing the envelope it means that if the
-   * projection is restarted from previously stored offset some envelopes may be processed more than once.
+   * projection is restarted from previously stored offset then some envelopes may be processed more than once.
    *
    * If the flow filters out envelopes the corresponding offset will not be stored, and such envelope
    * will be processed again if the projection is restarted and no later offset was stored.

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/SlickProjection.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/SlickProjection.scala
@@ -63,8 +63,8 @@ object SlickProjection {
    * Create a [[Projection]] with at-least-once processing semantics.
    *
    * It stores the offset in a relational database table using Slick after the `handler` has processed the envelope.
-   * This means that if the projection is restarted from previously stored offset some elements may be processed more
-   * than once.
+   * This means that if the projection is restarted from previously stored offset then some elements may be processed
+   * more than once.
    *
    * The offset is stored after a time window, or limited by a number of envelopes, whatever happens first.
    * This window can be defined with [[AtLeastOnceSlickProjection.withSaveOffset]] of the returned
@@ -114,9 +114,9 @@ object SlickProjection {
    * semantics.
    *
    * The flow should emit a `Done` element for each completed envelope. The offset of the envelope is carried
-   * in the context of the `FlowWithContext` and is stored in Cassandra if corresponding `Done` is emitted.
+   * in the context of the `FlowWithContext` and is stored in Cassandra when corresponding `Done` is emitted.
    * Since the offset is stored after processing the envelope it means that if the
-   * projection is restarted from previously stored offset some envelopes may be processed more than once.
+   * projection is restarted from previously stored offset then some envelopes may be processed more than once.
    *
    * If the flow filters out envelopes the corresponding offset will not be stored, and such envelope
    * will be processed again if the projection is restarted and no later offset was stored.

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/SlickProjection.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/SlickProjection.scala
@@ -23,6 +23,7 @@ import akka.projection.slick.internal.SlickProjectionImpl
 import akka.projection.slick.internal.SlickProjectionImpl.AtLeastOnce
 import akka.projection.slick.internal.SlickProjectionImpl.ExactlyOnce
 import akka.projection.slick.internal.SlickProjectionImpl.OffsetStrategy
+import akka.stream.scaladsl.FlowWithContext
 import slick.basic.DatabaseConfig
 import slick.dbio.DBIO
 import slick.jdbc.JdbcProfile
@@ -33,6 +34,9 @@ import slick.jdbc.JdbcProfile
  */
 @ApiMayChange
 object SlickProjection {
+  import SlickProjectionImpl.GroupedHandlerStrategy
+  import SlickProjectionImpl.SingleHandlerStrategy
+  import SlickProjectionImpl.FlowHandlerStrategy
 
   /**
    * Create a [[Projection]] with exactly-once processing semantics.
@@ -51,8 +55,8 @@ object SlickProjection {
       sourceProvider,
       databaseConfig,
       settingsOpt = None,
-      SlickProjectionImpl.ExactlyOnce(),
-      SlickProjectionImpl.SingleHandlerStrategy(handler),
+      ExactlyOnce(),
+      SingleHandlerStrategy(handler),
       NoopStatusObserver)
 
   /**
@@ -77,8 +81,8 @@ object SlickProjection {
       sourceProvider,
       databaseConfig,
       settingsOpt = None,
-      SlickProjectionImpl.AtLeastOnce(),
-      SlickProjectionImpl.SingleHandlerStrategy(handler),
+      AtLeastOnce(),
+      SingleHandlerStrategy(handler),
       NoopStatusObserver)
 
   /**
@@ -101,8 +105,43 @@ object SlickProjection {
       sourceProvider,
       databaseConfig,
       settingsOpt = None,
-      SlickProjectionImpl.ExactlyOnce(),
-      SlickProjectionImpl.GroupedHandlerStrategy(handler),
+      ExactlyOnce(),
+      GroupedHandlerStrategy(handler),
+      NoopStatusObserver)
+
+  /**
+   * Create a [[Projection]] with a [[FlowWithContext]] as the envelope handler. It has at-least-once processing
+   * semantics.
+   *
+   * The flow should emit a `Done` element for each completed envelope. The offset of the envelope is carried
+   * in the context of the `FlowWithContext` and is stored in Cassandra if corresponding `Done` is emitted.
+   * Since the offset is stored after processing the envelope it means that if the
+   * projection is restarted from previously stored offset some envelopes may be processed more than once.
+   *
+   * If the flow filters out envelopes the corresponding offset will not be stored, and such envelope
+   * will be processed again if the projection is restarted and no later offset was stored.
+   *
+   * The flow should not duplicate emitted envelopes (`mapConcat`) with same offset, because then it can result in
+   * that the first offset is stored and when the projection is restarted that offset is considered completed even
+   * though more of the duplicated enveloped were never processed.
+   *
+   * The flow must not reorder elements, because the offsets may be stored in the wrong order and
+   * and when the projection is restarted all envelopes up to the latest stored offset are considered
+   * completed even though some of them may not have been processed. This is the reason the flow is
+   * restricted to `FlowWithContext` rather than ordinary `Flow`.
+   */
+  def atLeastOnceFlow[Offset, Envelope, P <: JdbcProfile: ClassTag](
+      projectionId: ProjectionId,
+      sourceProvider: SourceProvider[Offset, Envelope],
+      databaseConfig: DatabaseConfig[P],
+      handler: FlowWithContext[Envelope, Envelope, Done, Envelope, _]): AtLeastOnceFlowSlickProjection[Envelope] =
+    new SlickProjectionImpl(
+      projectionId,
+      sourceProvider,
+      databaseConfig,
+      settingsOpt = None,
+      offsetStrategy = AtLeastOnce(),
+      handlerStrategy = FlowHandlerStrategy(handler),
       NoopStatusObserver)
 
 }
@@ -137,6 +176,12 @@ trait GroupedSlickProjection[Envelope] extends SlickProjection[Envelope] {
   def withGroup(groupAfterEnvelopes: Int, groupAfterDuration: FiniteDuration): GroupedSlickProjection[Envelope]
 
   def withRecoveryStrategy(recoveryStrategy: HandlerRecoveryStrategy): GroupedSlickProjection[Envelope]
+}
+
+trait AtLeastOnceFlowSlickProjection[Envelope] extends SlickProjection[Envelope] {
+  override def withSettings(settings: ProjectionSettings): AtLeastOnceFlowSlickProjection[Envelope]
+
+  def withSaveOffset(afterEnvelopes: Int, afterDuration: FiniteDuration): AtLeastOnceFlowSlickProjection[Envelope]
 }
 
 trait ExactlyOnceSlickProjection[Envelope] extends SlickProjection[Envelope] {

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
@@ -436,7 +436,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
         op: (String, Seq[(Offset, Envelope)]) => Future[Done],
         logProgressEvery: Int = 5): Future[Done] = {
       val size = batches.size
-      logger.info("Processing [{}] partitioned batches serially", size)
+      logger.debug("Processing [{}] partitioned batches serially", size)
 
       def loop(remaining: List[(String, Seq[(Offset, Envelope)])], n: Int): Future[Done] = {
         remaining match {
@@ -444,7 +444,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
           case (key, batch) :: tail =>
             op(key, batch).flatMap { _ =>
               if (n % logProgressEvery == 0)
-                logger.info("Processed batches [{}] of [{}]", n, size)
+                logger.debug("Processed batches [{}] of [{}]", n, size)
               loop(tail, n + 1)
             }
         }
@@ -454,7 +454,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
 
       result.onComplete {
         case Success(_) =>
-          logger.info("Processing completed of [{}] batches", size)
+          logger.debug("Processing completed of [{}] batches", size)
         case Failure(e) =>
           logger.error(e, "Processing of batches failed")
       }

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
@@ -28,6 +28,7 @@ import akka.projection.StatusObserver
 import akka.projection.internal.HandlerRecoveryImpl
 import akka.projection.scaladsl.HandlerLifecycle
 import akka.projection.scaladsl.SourceProvider
+import akka.projection.slick.AtLeastOnceFlowSlickProjection
 import akka.projection.slick.AtLeastOnceSlickProjection
 import akka.projection.slick.ExactlyOnceSlickProjection
 import akka.projection.slick.GroupedSlickProjection
@@ -40,6 +41,7 @@ import akka.projection.OffsetVerification.VerificationSuccess
 import akka.stream.KillSwitches
 import akka.stream.SharedKillSwitch
 import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.FlowWithContext
 import akka.stream.scaladsl.Source
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
@@ -70,6 +72,10 @@ private[projection] object SlickProjectionImpl {
       extends HandlerStrategy[Envelope] {
     override def lifecycle: HandlerLifecycle = handler
   }
+  final case class FlowHandlerStrategy[Envelope](flowCtx: FlowWithContext[Envelope, Envelope, Done, Envelope, _])
+      extends HandlerStrategy[Envelope] {
+    override val lifecycle: HandlerLifecycle = new HandlerLifecycle {}
+  }
 }
 
 @InternalApi
@@ -84,7 +90,8 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
     extends SlickProjection[Envelope]
     with ExactlyOnceSlickProjection[Envelope]
     with AtLeastOnceSlickProjection[Envelope]
-    with GroupedSlickProjection[Envelope] {
+    with GroupedSlickProjection[Envelope]
+    with AtLeastOnceFlowSlickProjection[Envelope] {
 
   import SlickProjectionImpl._
 
@@ -173,7 +180,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
 
     implicit val executionContext: ExecutionContext = system.executionContext
 
-    val offsetStore = createOffsetStore()
+    val offsetStore: SlickOffsetStore[P] = createOffsetStore()
 
     val killSwitch: SharedKillSwitch = KillSwitches.shared(projectionId.id)
     val abort: Promise[Done] = Promise()
@@ -347,6 +354,10 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
                       processEnvelopesAndStoreOffsetInSameTransaction(grouped.handler, handlerRecovery, group),
                       lastEnvelope)
                   }
+
+              case _: FlowHandlerStrategy[Envelope] =>
+                // not possible, no API for this
+                throw new IllegalStateException("Unsupported combination of exactlyOnce and flow")
             }
 
           case AtLeastOnce(afterEnvelopesOpt, orAfterDurationOpt, recoveryStrategyOpt) =>
@@ -356,33 +367,48 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
             val handlerRecovery =
               HandlerRecoveryImpl[Offset, Envelope](projectionId, recoveryStrategy, logger, statusObserver)
 
-            val handler = handlerStrategy match {
-              case SingleHandlerStrategy(handler) => handler
-              case _                              =>
-                // not possible
+            handlerStrategy match {
+              case SingleHandlerStrategy(handler) =>
+                if (afterEnvelopes == 1) {
+                  // optimization of general AtLeastOnce case, still separate transactions for processEnvelope
+                  // and storeOffset
+                  offsetFlow.mapAsync(1) {
+                    case (offset, env) =>
+                      processEnvelope(handler, handlerRecovery, env, offset).flatMap(_ =>
+                        reportProgress(storeOffset(offset), env))
+                  }
+                } else {
+                  offsetFlow
+                    .mapAsync(1) {
+                      case (offset, env) =>
+                        processEnvelope(handler, handlerRecovery, env, offset).map(_ => offset -> env)
+                    }
+                    .groupedWithin(afterEnvelopes, orAfterDuration)
+                    .collect { case grouped if grouped.nonEmpty => grouped.last }
+                    .mapAsync(parallelism = 1) {
+                      case (offset, env) =>
+                        reportProgress(storeOffset(offset), env)
+                    }
+                }
+
+              case _: GroupedHandlerStrategy[Envelope] =>
+                // not possible, no API for this
                 throw new IllegalStateException("Unsupported combination of atLeastOnce and grouped")
+
+              case f: FlowHandlerStrategy[Envelope] =>
+                val flow: Flow[(Envelope, Envelope), (Done, Envelope), _] = f.flowCtx.asFlow
+                offsetFlow
+                  .map { case (_, env) => env -> env }
+                  .via(flow)
+                  .map { case (_, env) => sourceProvider.extractOffset(env) -> env }
+                  .groupedWithin(afterEnvelopes, orAfterDuration)
+                  .collect { case grouped if grouped.nonEmpty => grouped.last }
+                  .mapAsync(parallelism = 1) {
+                    case (offset, env) =>
+                      reportProgress(storeOffset(offset), env)
+                  }
             }
 
-            if (afterEnvelopes == 1)
-              // optimization of general AtLeastOnce case, still separate transactions for processEnvelope
-              // and storeOffset
-              offsetFlow.mapAsync(1) {
-                case (offset, env) =>
-                  processEnvelope(handler, handlerRecovery, env, offset).flatMap(_ =>
-                    reportProgress(storeOffset(offset), env))
-              }
-            else
-              offsetFlow
-                .mapAsync(1) {
-                  case (offset, env) =>
-                    processEnvelope(handler, handlerRecovery, env, offset).map(_ => offset -> env)
-                }
-                .groupedWithin(afterEnvelopes, orAfterDuration)
-                .collect { case grouped if grouped.nonEmpty => grouped.last }
-                .mapAsync(parallelism = 1) {
-                  case (offset, env) =>
-                    reportProgress(storeOffset(offset), env)
-                }
         }
 
       val composedSource: Source[Done, NotUsed] =

--- a/akka-projection-slick/src/test/resources/logback-test.xml
+++ b/akka-projection-slick/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
     </logger>
 
 
-    <root level="WARN">
+    <root level="DEBUG">
         <appender-ref ref="CapturingAppender" />
     </root>
 </configuration>

--- a/docs/src/main/paradox/cassandra.md
+++ b/docs/src/main/paradox/cassandra.md
@@ -223,9 +223,31 @@ Those methods are also called when the `Projection` is restarted after failure.
 
 ## Processing with Akka Streams
 
-An Akka Streams `Flow` can be used instead of a handler for processing the envelopes with at-least-once semantics.
+An Akka Streams `FlowWithContext` can be used instead of a handler for processing the envelopes with at-least-once
+semantics.
 
-TODO: Implementation in progress, see [PR #119](https://github.com/akka/akka-projection/pull/119)
+Scala
+:  @@snip [CassandraProjectionDocExample.scala](/examples/src/test/scala/docs/cassandra/CassandraProjectionDocExample.scala) { #atLeastOnceFlow }
+
+Java
+:  @@snip [CassandraProjectionDocExample.java](/examples/src/test/java/jdocs/cassandra/CassandraProjectionDocExample.java) { #atLeastOnceFlow }
+
+The flow should emit a `Done` element for each completed envelope. The offset of the envelope is carried
+in the context of the `FlowWithContext` and is stored in Cassandra if corresponding `Done` is emitted.
+Since the offset is stored after processing the envelope it means that if the projection is restarted
+from previously stored offset some envelopes may be processed more than once.
+
+There are a few caveats to be aware of:
+
+* If the flow filters out envelopes the corresponding offset will not be stored, and such envelope
+  will be processed again if the projection is restarted and no later offset was stored.
+* The flow should not duplicate emitted envelopes (`mapConcat`) with same offset, because then it can result in
+  that the first offset is stored and when the projection is restarted that offset is considered completed even
+  though more of the duplicated enveloped were never processed.
+* The flow must not reorder elements, because the offsets may be stored in the wrong order and
+  and when the projection is restarted all envelopes up to the latest stored offset are considered
+  completed even though some of them may not have been processed. This is the reason the flow is
+  restricted to `FlowWithContext` rather than ordinary `Flow`.
 
 ## Schema
 

--- a/docs/src/main/paradox/cassandra.md
+++ b/docs/src/main/paradox/cassandra.md
@@ -233,7 +233,7 @@ Java
 :  @@snip [CassandraProjectionDocExample.java](/examples/src/test/java/jdocs/cassandra/CassandraProjectionDocExample.java) { #atLeastOnceFlow }
 
 The flow should emit a `Done` element for each completed envelope. The offset of the envelope is carried
-in the context of the `FlowWithContext` and is stored in Cassandra if corresponding `Done` is emitted.
+in the context of the `FlowWithContext` and is stored in Cassandra when corresponding `Done` is emitted.
 Since the offset is stored after processing the envelope it means that if the projection is restarted
 from previously stored offset some envelopes may be processed more than once.
 

--- a/docs/src/main/paradox/slick.md
+++ b/docs/src/main/paradox/slick.md
@@ -123,6 +123,31 @@ You can override the `start` and `stop` methods of the @apidoc[SlickHandler] to 
 before first envelope is processed and resource cleanup when the projection is stopped.
 Those methods are also called when the `Projection` is restarted after failure.
 
+## Processing with Akka Streams
+
+An Akka Streams `FlowWithContext` can be used instead of a handler for processing the envelopes with at-least-once
+semantics.
+
+Scala
+:  @@snip [SlickProjectionDocExample.scala](/examples/src/test/scala/docs/slick/SlickProjectionDocExample.scala) { #atLeastOnceFlow }
+
+The flow should emit a `Done` element for each completed envelope. The offset of the envelope is carried
+in the context of the `FlowWithContext` and is stored in the database if corresponding `Done` is emitted.
+Since the offset is stored after processing the envelope it means that if the projection is restarted
+from previously stored offset some envelopes may be processed more than once.
+
+There are a few caveats to be aware of:
+
+* If the flow filters out envelopes the corresponding offset will not be stored, and such envelope
+  will be processed again if the projection is restarted and no later offset was stored.
+* The flow should not duplicate emitted envelopes (`mapConcat`) with same offset, because then it can result in
+  that the first offset is stored and when the projection is restarted that offset is considered completed even
+  though more of the duplicated enveloped were never processed.
+* The flow must not reorder elements, because the offsets may be stored in the wrong order and
+  and when the projection is restarted all envelopes up to the latest stored offset are considered
+  completed even though some of them may not have been processed. This is the reason the flow is
+  restricted to `FlowWithContext` rather than ordinary `Flow`.
+
 ## Schema
 
 The database schema for the offset storage table:

--- a/docs/src/main/paradox/slick.md
+++ b/docs/src/main/paradox/slick.md
@@ -132,7 +132,7 @@ Scala
 :  @@snip [SlickProjectionDocExample.scala](/examples/src/test/scala/docs/slick/SlickProjectionDocExample.scala) { #atLeastOnceFlow }
 
 The flow should emit a `Done` element for each completed envelope. The offset of the envelope is carried
-in the context of the `FlowWithContext` and is stored in the database if corresponding `Done` is emitted.
+in the context of the `FlowWithContext` and is stored in the database when corresponding `Done` is emitted.
 Since the offset is stored after processing the envelope it means that if the projection is restarted
 from previously stored offset some envelopes may be processed more than once.
 

--- a/examples/src/test/java/jdocs/cassandra/CassandraProjectionDocExample.java
+++ b/examples/src/test/java/jdocs/cassandra/CassandraProjectionDocExample.java
@@ -7,8 +7,10 @@ package jdocs.cassandra;
 import java.time.Duration;
 
 import akka.Done;
+import akka.NotUsed;
 import akka.actor.typed.ActorSystem;
 import akka.actor.typed.javadsl.Behaviors;
+import akka.stream.javadsl.FlowWithContext;
 import jdocs.eventsourced.ShoppingCart;
 
 //#daemon-imports
@@ -164,8 +166,45 @@ public interface CassandraProjectionDocExample {
 
   }
 
+  public static void illustrateAtLeastOnceFlow() {
+    ActorSystem<Void> system = ActorSystem.create(Behaviors.empty(), "Example");
 
-   static class IllustrateRunningWithShardedDaemon {
+    SourceProvider<Offset, EventEnvelope<ShoppingCart.Event>> sourceProvider =
+      EventSourcedProvider.eventsByTag(system, CassandraReadJournal.Identifier(), "carts-1");
+
+    //#atLeastOnceFlow
+
+    Logger logger = LoggerFactory.getLogger("example");
+
+    FlowWithContext<EventEnvelope<ShoppingCart.Event>, EventEnvelope<ShoppingCart.Event>, Done, EventEnvelope<ShoppingCart.Event>, NotUsed> flow =
+      FlowWithContext.<EventEnvelope<ShoppingCart.Event>, EventEnvelope<ShoppingCart.Event>> create()
+      .map(EventEnvelope::event)
+      .map(event -> {
+        if (event instanceof ShoppingCart.CheckedOut) {
+          ShoppingCart.CheckedOut checkedOut = (ShoppingCart.CheckedOut) event;
+          logger.info("Shopping cart {} was checked out at {}", checkedOut.cartId, checkedOut.eventTime);
+        } else {
+          logger.debug("Shopping cart {} changed by {}", event.getCartId(), event);
+        }
+        return Done.getInstance();
+      });
+
+    int saveOffsetAfterEnvelopes = 100;
+    Duration saveOffsetAfterDuration = Duration.ofMillis(500);
+
+    Projection<EventEnvelope<ShoppingCart.Event>> projection =
+      CassandraProjection.atLeastOnceFlow(
+        ProjectionId.of("shopping-carts", "carts-1"),
+        sourceProvider,
+        flow
+      )
+      .withSaveOffset(saveOffsetAfterEnvelopes, saveOffsetAfterDuration);
+    //#atLeastOnceFlow
+
+  }
+
+
+  static class IllustrateRunningWithShardedDaemon {
 
     ActorSystem<Void> system = ActorSystem.create(Behaviors.empty(), "Example");
 


### PR DESCRIPTION
On top of #118 

When adding support for grouped envelopes I realized that adding support for `Flow` is simple.

TODO:

* [x] javadsl
* [x] Slick
* [x] Docs

Refs https://github.com/akka/akka-projection/issues/145