### PR TITLE
RunningProjection and isolated internal state

### DIFF
--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
@@ -190,7 +190,7 @@ import akka.stream.scaladsl.Source
   }
 
   private class CassandraRunningProjection(source: Source[Done, _], killSwitch: SharedKillSwitch)(
-      implicit val systemProvider: ClassicActorSystemProvider)
+      implicit systemProvider: ClassicActorSystemProvider)
       extends RunningProjection {
 
     private val futureDone = source.run()

--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/scaladsl/CassandraProjection.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/scaladsl/CassandraProjection.scala
@@ -40,7 +40,7 @@ object CassandraProjection {
       projectionId,
       sourceProvider,
       CassandraProjectionImpl.AtLeastOnce(saveOffsetAfterEnvelopes, saveOffsetAfterDuration),
-      projectionSettingsOpt = None,
+      settingsOpt = None,
       handler)
 
   /**
@@ -56,6 +56,6 @@ object CassandraProjection {
       projectionId,
       sourceProvider,
       CassandraProjectionImpl.AtMostOnce,
-      projectionSettingsOpt = None,
+      settingsOpt = None,
       handler)
 }

--- a/akka-projection-core/src/main/scala/akka/projection/Projection.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/Projection.scala
@@ -72,12 +72,6 @@ private[projection] trait RunningProjection {
 
   /**
    * INTERNAL API
-   */
-  @InternalApi
-  private[projection] def systemProvider: ClassicActorSystemProvider
-
-  /**
-   * INTERNAL API
    *
    * Stop the projection if it's running.
    * @return Future[Done] - the returned Future should return the stream materialized value.

--- a/akka-projection-core/src/main/scala/akka/projection/Projection.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/Projection.scala
@@ -30,6 +30,8 @@ trait Projection[Envelope] {
 
   def projectionId: ProjectionId
 
+  def withSettings(settings: ProjectionSettings): Projection[Envelope]
+
   /**
    * INTERNAL API
    *
@@ -46,14 +48,15 @@ trait Projection[Envelope] {
   @InternalApi
   private[projection] def run()(implicit systemProvider: ClassicActorSystemProvider): RunningProjection
 
-  def withSettings(projectionSettings: ProjectionSettings): Projection[Envelope]
-
 }
 
 /**
+ * INTERNAL API
+ *
  * Helper to wrap the projection source with a RestartSource using the provided settings.
  */
-object RunningProjection {
+@InternalApi
+private[projection] object RunningProjection {
   def withBackoff(source: Source[Done, _], settings: ProjectionSettings): Source[Done, _] =
     RestartSource
       .onFailuresWithBackoff(settings.minBackoff, settings.maxBackoff, settings.randomFactor, settings.maxRestarts) {

--- a/akka-projection-core/src/test/java/akka/projection/ProjectionBehaviorCompileTest.java
+++ b/akka-projection-core/src/test/java/akka/projection/ProjectionBehaviorCompileTest.java
@@ -9,8 +9,6 @@ import akka.actor.ClassicActorSystemProvider;
 import akka.actor.testkit.typed.javadsl.ActorTestKit;
 import akka.actor.typed.ActorRef;
 import akka.stream.scaladsl.Source;
-import scala.concurrent.ExecutionContext;
-import scala.concurrent.Future;
 
 /**
  * Compile test: this class serves only for exercising the Java API.
@@ -20,7 +18,7 @@ public class ProjectionBehaviorCompileTest {
     public void compileTest() {
         ActorTestKit testKit = ActorTestKit.create();
         ActorRef<ProjectionBehavior.Command> ref =
-                testKit.spawn(ProjectionBehavior.create(TestProjection::new));
+                testKit.spawn(ProjectionBehavior.create(new TestProjection()));
         ref.tell(ProjectionBehavior.stopMessage());
         // nobody is calling this method, so not really starting the system,
         // but we never know
@@ -40,14 +38,11 @@ public class ProjectionBehaviorCompileTest {
         }
 
         @Override
-        public void run(ClassicActorSystemProvider systemProvider) {
-
-        }
-
-        @Override
-        public Future<Done> stop(ExecutionContext ec) {
+        public RunningProjection run(ClassicActorSystemProvider systemProvider) {
             return null;
         }
+
+
 
         @Override
         public Projection<String> withSettings(ProjectionSettings projectionSettings) {

--- a/akka-projection-core/src/test/java/akka/projection/ProjectionBehaviorCompileTest.java
+++ b/akka-projection-core/src/test/java/akka/projection/ProjectionBehaviorCompileTest.java
@@ -45,7 +45,7 @@ public class ProjectionBehaviorCompileTest {
 
 
         @Override
-        public Projection<String> withSettings(ProjectionSettings projectionSettings) {
+        public Projection<String> withSettings(ProjectionSettings settings) {
             // no need for ProjectionSettings in tests
             return this;
         }

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/SlickProjection.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/SlickProjection.scala
@@ -42,7 +42,7 @@ object SlickProjection {
       sourceProvider,
       databaseConfig,
       SlickProjectionImpl.ExactlyOnce,
-      projectionSettingsOpt = None,
+      settingsOpt = None,
       handler)
 
   /**
@@ -63,7 +63,7 @@ object SlickProjection {
       sourceProvider,
       databaseConfig,
       SlickProjectionImpl.AtLeastOnce(saveOffsetAfterEnvelopes, saveOffsetAfterDuration),
-      projectionSettingsOpt = None,
+      settingsOpt = None,
       handler)
 
 }

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
@@ -175,7 +175,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
   }
 
   private class SlickRunningProjection(source: Source[Done, _], killSwitch: SharedKillSwitch)(
-      implicit val systemProvider: ClassicActorSystemProvider)
+      implicit systemProvider: ClassicActorSystemProvider)
       extends RunningProjection {
 
     private val futureDone = source.run()

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
@@ -4,8 +4,6 @@
 
 package akka.projection.slick.internal
 
-import java.util.concurrent.atomic.AtomicBoolean
-
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
@@ -18,12 +16,13 @@ import akka.event.Logging
 import akka.projection.Projection
 import akka.projection.ProjectionId
 import akka.projection.ProjectionSettings
+import akka.projection.RunningProjection
 import akka.projection.internal.HandlerRecoveryImpl
 import akka.projection.scaladsl.SourceProvider
 import akka.projection.slick.SlickHandler
 import akka.stream.KillSwitches
+import akka.stream.SharedKillSwitch
 import akka.stream.scaladsl.Flow
-import akka.stream.scaladsl.RestartSource
 import akka.stream.scaladsl.Source
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
@@ -41,136 +40,157 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
     sourceProvider: SourceProvider[Offset, Envelope],
     databaseConfig: DatabaseConfig[P],
     strategy: SlickProjectionImpl.Strategy,
-    projectionSettingsOpt: Option[ProjectionSettings],
+    settingsOpt: Option[ProjectionSettings],
     handler: SlickHandler[Envelope])
     extends Projection[Envelope] {
   import SlickProjectionImpl._
 
-  private lazy val offsetStore = new SlickOffsetStore(databaseConfig.db, databaseConfig.profile)
-
-  private lazy val killSwitch = KillSwitches.shared(projectionId.id)
-  private lazy val promiseToStop: Promise[Done] = Promise()
-  private lazy val started = new AtomicBoolean(false)
-
-  override def withSettings(projectionSettings: ProjectionSettings): Projection[Envelope] = {
-    new SlickProjectionImpl(projectionId, sourceProvider, databaseConfig, strategy, Option(projectionSettings), handler)
-  }
-
-  override def run()(implicit systemProvider: ClassicActorSystemProvider): Unit = {
-
-    val projectionSettings = projectionSettingsOpt.getOrElse(ProjectionSettings(systemProvider))
-
-    if (this.started.compareAndSet(false, true)) {
-      val done =
-        RestartSource
-          .onFailuresWithBackoff(
-            projectionSettings.minBackoff,
-            projectionSettings.maxBackoff,
-            projectionSettings.randomFactor,
-            projectionSettings.maxRestarts) { () =>
-            mappedSource()
-          }
-          .run()
-      promiseToStop.completeWith(done)
-    }
-  }
-
-  override def stop()(implicit ec: ExecutionContext): Future[Done] = {
-    if (this.started.get()) {
-      killSwitch.shutdown()
-      promiseToStop.future
-    } else {
-      Future.failed(new IllegalStateException(s"Projection [$projectionId] not started yet!"))
-    }
+  override def withSettings(settings: ProjectionSettings): Projection[Envelope] = {
+    new SlickProjectionImpl(projectionId, sourceProvider, databaseConfig, strategy, Option(settings), handler)
   }
 
   /**
    * INTERNAL API
+   * Return a RunningProjection
+   */
+  @InternalApi
+  override private[projection] def run()(implicit systemProvider: ClassicActorSystemProvider): RunningProjection =
+    new InternalProjectionState(
+      offsetStore = new SlickOffsetStore(databaseConfig.db, databaseConfig.profile),
+      settings = settingsOrDefaults).newRunningInstance()
+
+  /**
+   * INTERNAL API
    *
-   * This method returns the projection Source mapped with `processEnvelope`, but before any sink attached.
+   * This method returns the projection Source mapped with user 'handler' function, but before any sink attached.
    * This is mainly intended to be used by the TestKit allowing it to attach a TestSink to it.
    */
   override private[projection] def mappedSource()(
-      implicit systemProvider: ClassicActorSystemProvider): Source[Done, _] = {
+      implicit systemProvider: ClassicActorSystemProvider): Source[Done, _] =
+    new InternalProjectionState(
+      offsetStore = new SlickOffsetStore(databaseConfig.db, databaseConfig.profile),
+      settings = settingsOrDefaults).mappedSource()
 
-    import databaseConfig.profile.api._
+  /*
+   * Build the final ProjectionSettings to use, if currently set to None fallback to values in config file
+   */
+  private def settingsOrDefaults(implicit systemProvider: ClassicActorSystemProvider): ProjectionSettings =
+    settingsOpt.getOrElse(ProjectionSettings(systemProvider))
 
-    // TODO: add a LogSource for projection when we have a name and key
-    val logger = Logging(systemProvider.classicSystem, this.getClass)
+  /*
+   * INTERNAL API
+   * This internal class will hold the KillSwitch that is needed
+   * when building the mappedSource and when running the projection (to stop)
+   */
+  private class InternalProjectionState(offsetStore: SlickOffsetStore[P], settings: ProjectionSettings)(
+      implicit systemProvider: ClassicActorSystemProvider) {
 
-    implicit val dispatcher = systemProvider.classicSystem.dispatcher
+    private val killSwitch = KillSwitches.shared(projectionId.id)
 
-    def applyUserRecovery(envelope: Envelope, offset: Offset)(futureCallback: () => Future[Done]): Future[Done] =
-      HandlerRecoveryImpl.applyUserRecovery[Offset, Envelope](handler, envelope, offset, logger, futureCallback)
+    private[projection] def mappedSource(): Source[Done, _] = {
 
-    def processEnvelopeAndStoreOffsetInSameTransaction(env: Envelope): Future[Done] = {
-      val offset = sourceProvider.extractOffset(env)
-      // run user function and offset storage on the same transaction
-      // any side-effect in user function is at-least-once
-      val txDBIO =
-        offsetStore
-          .saveOffset(projectionId, offset)
-          .flatMap(_ => handler.process(env))
-          .transactionally
+      import databaseConfig.profile.api._
 
-      applyUserRecovery(env, offset) { () =>
-        databaseConfig.db.run(txDBIO).map(_ => Done)
+      // TODO: add a LogSource for projection when we have a name and key
+      val logger = Logging(systemProvider.classicSystem, this.getClass)
+
+      implicit val dispatcher = systemProvider.classicSystem.dispatcher
+
+      def applyUserRecovery(envelope: Envelope, offset: Offset)(futureCallback: () => Future[Done]): Future[Done] =
+        HandlerRecoveryImpl.applyUserRecovery[Offset, Envelope](handler, envelope, offset, logger, futureCallback)
+
+      def processEnvelopeAndStoreOffsetInSameTransaction(env: Envelope): Future[Done] = {
+        val offset = sourceProvider.extractOffset(env)
+        // run user function and offset storage on the same transaction
+        // any side-effect in user function is at-least-once
+        val txDBIO =
+          offsetStore
+            .saveOffset(projectionId, offset)
+            .flatMap(_ => handler.process(env))
+            .transactionally
+
+        applyUserRecovery(env, offset) { () =>
+          databaseConfig.db.run(txDBIO).map(_ => Done)
+        }
       }
-    }
 
-    def processEnvelope(env: Envelope, offset: Offset): Future[Done] = {
-      // user function in one transaction (may be composed of several DBIOAction)
-      val dbio = handler.process(env).transactionally
-      applyUserRecovery(env, offset) { () =>
+      def processEnvelope(env: Envelope, offset: Offset): Future[Done] = {
+        // user function in one transaction (may be composed of several DBIOAction)
+        val dbio = handler.process(env).transactionally
+        applyUserRecovery(env, offset) { () =>
+          databaseConfig.db.run(dbio).map(_ => Done)
+        }
+      }
+
+      def storeOffset(offset: Offset): Future[Done] = {
+        // only one DBIOAction, no need for transactionally
+        val dbio = offsetStore.saveOffset(projectionId, offset)
         databaseConfig.db.run(dbio).map(_ => Done)
       }
-    }
 
-    def storeOffset(offset: Offset): Future[Done] = {
-      // only one DBIOAction, no need for transactionally
-      val dbio = offsetStore.saveOffset(projectionId, offset)
-      databaseConfig.db.run(dbio).map(_ => Done)
-    }
-
-    // -------------------------------------------------------
-    // finally build the source with all parts wired
-    val readOffsets = () => {
-      val offsetsF = offsetStore.readOffset(projectionId)
-      offsetsF.foreach { offset => logger.debug("Starting projection [{}] from offset [{}]", projectionId, offset) }
-      offsetsF
-    }
-
-    val futSource = sourceProvider.source(readOffsets)
-
-    val handlerFlow: Flow[Envelope, Done, _] =
-      strategy match {
-        case ExactlyOnce =>
-          Flow[Envelope]
-            .mapAsync(1)(processEnvelopeAndStoreOffsetInSameTransaction)
-
-        case AtLeastOnce(1, _) =>
-          // optimization of general AtLeastOnce case, still separate transactions for processEnvelope
-          // and storeOffset
-          Flow[Envelope].mapAsync(1) { env =>
-            val offset = sourceProvider.extractOffset(env)
-            processEnvelope(env, offset).flatMap(_ => storeOffset(offset))
-          }
-
-        case AtLeastOnce(afterEnvelopes, orAfterDuration) =>
-          Flow[Envelope]
-            .mapAsync(1) { env =>
-              val offset = sourceProvider.extractOffset(env)
-              processEnvelope(env, offset).map(_ => offset)
-            }
-            .groupedWithin(afterEnvelopes, orAfterDuration)
-            .collect { case grouped if grouped.nonEmpty => grouped.last }
-            .mapAsync(parallelism = 1)(storeOffset)
+      // -------------------------------------------------------
+      // finally build the source with all parts wired
+      val readOffsets = () => {
+        val offsetsF = offsetStore.readOffset(projectionId)
+        offsetsF.foreach { offset => logger.debug("Starting projection [{}] from offset [{}]", projectionId, offset) }
+        offsetsF
       }
 
-    Source
-      .futureSource(futSource)
-      .via(killSwitch.flow)
-      .via(handlerFlow)
+      val futSource = sourceProvider.source(readOffsets)
 
+      val handlerFlow: Flow[Envelope, Done, _] =
+        strategy match {
+          case ExactlyOnce =>
+            Flow[Envelope]
+              .mapAsync(1)(processEnvelopeAndStoreOffsetInSameTransaction)
+
+          case AtLeastOnce(1, _) =>
+            // optimization of general AtLeastOnce case, still separate transactions for processEnvelope
+            // and storeOffset
+            Flow[Envelope].mapAsync(1) { env =>
+              val offset = sourceProvider.extractOffset(env)
+              processEnvelope(env, offset).flatMap(_ => storeOffset(offset))
+            }
+
+          case AtLeastOnce(afterEnvelopes, orAfterDuration) =>
+            Flow[Envelope]
+              .mapAsync(1) { env =>
+                val offset = sourceProvider.extractOffset(env)
+                processEnvelope(env, offset).map(_ => offset)
+              }
+              .groupedWithin(afterEnvelopes, orAfterDuration)
+              .collect { case grouped if grouped.nonEmpty => grouped.last }
+              .mapAsync(parallelism = 1)(storeOffset)
+        }
+
+      Source
+        .futureSource(futSource)
+        .via(killSwitch.flow)
+        .via(handlerFlow)
+
+    }
+
+    private[projection] def newRunningInstance(): RunningProjection =
+      new SlickRunningProjection(RunningProjection.withBackoff(mappedSource(), settings), killSwitch)
   }
+
+  private class SlickRunningProjection(source: Source[Done, _], killSwitch: SharedKillSwitch)(
+      implicit val systemProvider: ClassicActorSystemProvider)
+      extends RunningProjection {
+
+    private val futureDone = source.run()
+
+    /**
+     * INTERNAL API
+     *
+     * Stop the projection if it's running.
+     * @return Future[Done] - the returned Future should return the stream materialized value.
+     */
+    @InternalApi
+    override private[projection] def stop()(implicit ec: ExecutionContext): Future[Done] = {
+      killSwitch.shutdown()
+      futureDone
+    }
+  }
+
 }

--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/javadsl/ProjectionTestKit.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/javadsl/ProjectionTestKit.scala
@@ -47,16 +47,19 @@ final class ProjectionTestKit private[akka] (testKit: ActorTestKit) {
     val probe = testKit.createTestProbe[Nothing]("internal-projection-testkit-probe")
 
     val settingsForTest = ProjectionSettings(system).withBackoff(0.millis, 0.millis, 0.0, 0)
-    val projectionWithTestSettings = projection.withSettings(settingsForTest)
+
+    val running =
+      projection
+        .withSettings(settingsForTest)
+        .run()(testKit.system.classicSystem)
 
     try {
-      projectionWithTestSettings.run()(testKit.system.classicSystem)
       probe.awaitAssert(max, interval, () => {
-        runnable.run();
+        runnable.run()
         Done
       })
     } finally {
-      Await.result(projectionWithTestSettings.stop(), max.asScala)
+      Await.result(running.stop(), max.asScala)
     }
   }
 

--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/scaladsl/ProjectionTestKit.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/scaladsl/ProjectionTestKit.scala
@@ -49,13 +49,15 @@ final class ProjectionTestKit private[akka] (testKit: ActorTestKit) {
     val probe = testKit.createTestProbe[Nothing]("internal-projection-testkit-probe")
 
     val settingsForTest = ProjectionSettings(system).withBackoff(0.millis, 0.millis, 0.0, 0)
-    val projectionWithTestSettings = projection.withSettings(settingsForTest)
+    val running =
+      projection
+        .withSettings(settingsForTest)
+        .run()(testKit.system.classicSystem)
 
     try {
-      projectionWithTestSettings.run()(testKit.system.classicSystem)
       probe.awaitAssert(assertFunc, max.dilated, interval)
     } finally {
-      Await.result(projectionWithTestSettings.stop(), max)
+      Await.result(running.stop(), max)
     }
   }
 

--- a/akka-projection-testkit/src/test/java/akka/projection/testkit/javadsl/ProjectionTestKitTest.java
+++ b/akka-projection-testkit/src/test/java/akka/projection/testkit/javadsl/ProjectionTestKitTest.java
@@ -191,7 +191,7 @@ public class ProjectionTestKitTest extends JUnitSuite {
         }
 
         @Override
-        public Projection<Integer> withSettings(ProjectionSettings projectionSettings) {
+        public Projection<Integer> withSettings(ProjectionSettings settings) {
             // no need for ProjectionSettings in tests
             return this;
         }

--- a/akka-projection-testkit/src/test/scala/akka/projection/testkit/scaladsl/ProjectionTestKitSpec.scala
+++ b/akka-projection-testkit/src/test/scala/akka/projection/testkit/scaladsl/ProjectionTestKitSpec.scala
@@ -136,7 +136,7 @@ class ProjectionTestKitSpec extends ScalaTestWithActorTestKit with AnyWordSpecLi
   case class TestProjection(src: Source[Int, NotUsed], strBuffer: StringBuffer, predicate: Int => Boolean)
       extends Projection[Int] {
 
-    override def withSettings(projectionSettings: ProjectionSettings): Projection[Int] =
+    override def withSettings(settings: ProjectionSettings): Projection[Int] =
       this // no need for ProjectionSettings in tests
 
     override def projectionId: ProjectionId = ProjectionId("test-projection", "00")


### PR DESCRIPTION
@patriknw / @seglo, I have been experimenting with some alternatives for the Projection trait while working on #110. 

This is something that I got working and would like to get feedback to decide if I should continue or not. 

Note, I only refactored the code in core, testkit and slick. 

It has a few advantages:

* backoff is applied by common trait, implementors don't need to deal with it
* once started, a projection can't be started again. To start again, we produce a new instance. Basically, `Projection` becomes a factory for `RunningProjection` (more on that later)
* no AtomicBoolean to track if already started or not

The disadvantage is that it makes it a little tedious to implement a Projection, but it makes it safer. 

For instance, the fact that `Projection` is a factory for `RunningProjection` makes the following code safe:

```scala

// user builds a list of projection using 
// by mapping over list of IDs
val ids = List(1, 2, 3, 4)
val projections: List[Projection] = ids.map(i => Projection(..))

// then when passing it to ShardedDaemon

SharderDaemonProcess(..)..init(
	"my-projection",
    ids.size,
    id -> ProjectionBehavior(() => projections(i))
)
```

We made `ProjectionBehavior` receive a `() => Projection`, but that can still be used wrongly.

With `RunningProjection` it's safe and we can remove `() => Projection`.

```scala
SharderDaemonProcess(..)..init(
	"my-projection",
    ids.size,
    id -> ProjectionBehavior(projections(i))
)
```
