### PR TITLE
Move example to Kafka project as integration test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,7 @@ lazy val kafka =
     .settings(Test / parallelExecution := false)
     .dependsOn(core)
     .dependsOn(testkit % "test->test")
+    .dependsOn(slick % "test->test;test->compile")
 
 lazy val examples = project
   .settings(Dependencies.examples)


### PR DESCRIPTION
I moved the current example back to the Kafka project as a integration test. I updated the increment count logic so the count occurs atomically within an update statement.  I'll add some more test cases later.

Fixes #109 

