### PR TITLE
reference docs for KafkaSourceProvider

### DIFF
--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraOffsetStore.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraOffsetStore.scala
@@ -9,10 +9,12 @@ import java.time.Instant
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+
 import akka.Done
 import akka.annotation.InternalApi
+import akka.projection.MergeableOffset
 import akka.projection.ProjectionId
-import akka.projection.internal.{ MergeableOffset, OffsetSerialization }
+import akka.projection.internal.OffsetSerialization
 import akka.projection.internal.OffsetSerialization.SingleOffset
 import akka.stream.alpakka.cassandra.scaladsl.CassandraSession
 

--- a/akka-projection-core/src/main/scala/akka/projection/MergeableOffset.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/MergeableOffset.scala
@@ -2,9 +2,6 @@
  * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package akka.projection.internal
+package akka.projection
 
-import akka.annotation.InternalApi
-
-@InternalApi
 final case class MergeableOffset[Offset](entries: Map[String, Offset])

--- a/akka-projection-core/src/main/scala/akka/projection/internal/OffsetSerialization.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/OffsetSerialization.scala
@@ -10,6 +10,7 @@ import scala.collection.immutable
 
 import akka.annotation.InternalApi
 import akka.persistence.query
+import akka.projection.MergeableOffset
 import akka.projection.ProjectionId
 
 /**

--- a/akka-projection-core/src/test/scala/akka/projection/internal/OffsetSerializationSpec.scala
+++ b/akka-projection-core/src/test/scala/akka/projection/internal/OffsetSerializationSpec.scala
@@ -7,6 +7,7 @@ package akka.projection.internal
 import java.util.UUID
 
 import akka.persistence.query
+import akka.projection.MergeableOffset
 import akka.projection.ProjectionId
 import org.scalatest.TestSuite
 import org.scalatest.matchers.should.Matchers

--- a/akka-projection-kafka/src/main/scala/akka/projection/kafka/KafkaSourceProvider.scala
+++ b/akka-projection-kafka/src/main/scala/akka/projection/kafka/KafkaSourceProvider.scala
@@ -6,7 +6,7 @@ package akka.projection.kafka
 
 import akka.actor.ClassicActorSystemProvider
 import akka.kafka.ConsumerSettings
-import akka.projection.internal.MergeableOffset
+import akka.projection.MergeableOffset
 import akka.projection.kafka.internal.KafkaSourceProviderImpl
 import akka.projection.scaladsl.SourceProvider
 import org.apache.kafka.clients.consumer.ConsumerRecord

--- a/akka-projection-kafka/src/main/scala/akka/projection/kafka/internal/KafkaSourceProviderImpl.scala
+++ b/akka-projection-kafka/src/main/scala/akka/projection/kafka/internal/KafkaSourceProviderImpl.scala
@@ -19,7 +19,7 @@ import akka.kafka.KafkaConsumerActor
 import akka.kafka.Subscriptions
 import akka.kafka.scaladsl.Consumer
 import akka.kafka.scaladsl.MetadataClient
-import akka.projection.internal.MergeableOffset
+import akka.projection.MergeableOffset
 import akka.projection.scaladsl.SourceProvider
 import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Source

--- a/akka-projection-kafka/src/test/scala/akka/projection/kafka/KafkaSourceProviderSpec.scala
+++ b/akka-projection-kafka/src/test/scala/akka/projection/kafka/KafkaSourceProviderSpec.scala
@@ -7,7 +7,7 @@ package akka.projection.kafka
 import scala.concurrent.Await
 import scala.concurrent.Future
 
-import akka.projection.internal.MergeableOffset
+import akka.projection.MergeableOffset
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSink

--- a/akka-projection-kafka/src/test/scala/akka/projection/kafka/integration/KafkaToSlickIntegrationSpec.scala
+++ b/akka-projection-kafka/src/test/scala/akka/projection/kafka/integration/KafkaToSlickIntegrationSpec.scala
@@ -16,8 +16,8 @@ import scala.concurrent.duration._
 import akka.Done
 import akka.kafka.scaladsl.Producer
 import akka.projection.HandlerRecoveryStrategy
+import akka.projection.MergeableOffset
 import akka.projection.ProjectionId
-import akka.projection.internal.MergeableOffset
 import akka.projection.kafka.KafkaSourceProvider
 import akka.projection.kafka.KafkaSpecBase
 import akka.projection.scaladsl.SourceProvider

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickOffsetStore.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickOffsetStore.scala
@@ -13,8 +13,8 @@ import scala.concurrent.Future
 import akka.Done
 import akka.annotation.InternalApi
 import akka.dispatch.ExecutionContexts
+import akka.projection.MergeableOffset
 import akka.projection.ProjectionId
-import akka.projection.internal.MergeableOffset
 import akka.projection.internal.OffsetSerialization
 import slick.jdbc.JdbcProfile
 

--- a/docs/src/main/paradox/eventsourced.md
+++ b/docs/src/main/paradox/eventsourced.md
@@ -3,7 +3,7 @@
 A typical source for Projections is events stored with @apidoc[EventSourcedBehavior] in [Akka Persistence](https://doc.akka.io/docs/akka/current/typed/persistence.html). Event can be [tagged](https://doc.akka.io/docs/akka/current/typed/persistence.html#tagging) and then
 consumed with the [eventsByTag query](https://doc.akka.io/docs/akka/current/persistence-query.html#eventsbytag-and-currenteventsbytag).
 
-Akka Projections has integration with `eventsByTag`, which is described in here. 
+Akka Projections has integration with `eventsByTag`, which is described here. 
 
 ## Dependencies
 

--- a/docs/src/main/paradox/kafka.md
+++ b/docs/src/main/paradox/kafka.md
@@ -1,5 +1,23 @@
 # Messages from Kafka
 
+A typical source for Projections is messages from Kafka. Akka Projections has integration with 
+[Alpakka Kafka](https://doc.akka.io/docs/alpakka-kafka/current/), which is described in here.
+
+The @apiddoc[KafkaSourceProvider] uses consumer group assignments from Kafka and can resume from offsets stored in
+a database.
+
+Akka Projections can store the offsets from Kafka in a @ref:[relational DB with Slick](slick.md).
+
+The `SlickProjection` envelope handler returns a `DBIO` that will be run by the projection. This means that the target database
+operations can be run in the same transaction as the storage of the offset, which means that @ref:[exactly-once](slick.md#exactly-once)
+processing semantics is supported. It also offers @ref:[at-least-once](slick.md#at-least-once) semantics.
+
+@@@ note
+
+Offset storage of Kafka offsets are not implemented for Cassandra yet, see [issue #97](https://github.com/akka/akka-projection/issues/97).
+ 
+@@@
+
 ## Dependencies
 
 To use the Kafka module of Akka Projections add the following dependency in your project:
@@ -12,10 +30,40 @@ To use the Kafka module of Akka Projections add the following dependency in your
 
 Akka Projections require Akka $akka.version$ or later, see @ref:[Akka version](overview.md#akka-version).
 
-FIXME project-info{ projectId="akka-projection-kafka" }
+@@project-info{ projectId="akka-projection-kafka" }
 
 ### Transitive dependencies
 
 The table below shows `akka-projection-kafka`'s direct dependencies and the second tab shows all libraries it depends on transitively.
 
-FIXME dependencies{ projectId="akka-projection-kafka" }
+@@dependencies{ projectId="akka-projection-kafka" }
+
+## KafkaSourceProvider
+
+A @apidoc[SourceProvider] defines the source of the envelopes that the `Projection` will process. A `SourceProvider`
+for messages from Kafka can be defined with the @apidoc[KafkaSourceProvider] like this:
+
+Scala
+:  @@snip [KafkaDocExample.scala](/examples/src/test/scala/docs/kafka/KafkaDocExample.scala) { #imports #sourceProvider }
+
+Java
+:  @@snip [KafkaDocExample.java](/examples/src/test/java/jdocs/kafka/KafkaDocExample.java) { #todo }
+
+Please consult the [Alpakka Kafka documentation](https://doc.akka.io/docs/alpakka-kafka/current/consumer.html) for
+specifics around the `ConsumerSettings`. The `KafkaSourceProvider` is using `Consumer.plainPartitionedManualOffsetSource`.
+
+The `Projection` can then be defined as:
+
+Scala
+:  @@snip [KafkaDocExample.scala](/examples/src/test/scala/docs/kafka/KafkaDocExample.scala) { #exactlyOnce }
+
+Java
+:  @@snip [KafkaDocExample.java](/examples/src/test/java/jdocs/kafka/KafkaDocExample.java) { #todo }
+
+and the `WordCountHandler`:
+
+Scala
+:  @@snip [KafkaDocExample.scala](/examples/src/test/scala/docs/kafka/KafkaDocExample.scala) { #handler }
+
+Java
+:  @@snip [KafkaDocExample.java](/examples/src/test/java/jdocs/kafka/KafkaDocExample.java) { #todo }

--- a/examples/src/test/java/jdocs/kafka/KafkaDocExample.java
+++ b/examples/src/test/java/jdocs/kafka/KafkaDocExample.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package jdocs.kafka;
+
+public interface KafkaDocExample {
+
+  //#todo
+  // TODO
+  //#todo
+}

--- a/examples/src/test/resources/logback-test.xml
+++ b/examples/src/test/resources/logback-test.xml
@@ -14,7 +14,10 @@
         <appender-ref ref="STDOUT"/>
     </logger>
 
-    <root level="DEBUG">
+    <logger name="org.apache.kafka" level="INFO" />
+
+    <root level="INFO">
         <appender-ref ref="CapturingAppender" />
+        <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/examples/src/test/scala/docs/kafka/KafkaDocExample.scala
+++ b/examples/src/test/scala/docs/kafka/KafkaDocExample.scala
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.kafka
+
+import akka.Done
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.Behaviors
+
+import akka.projection.Projection
+import akka.projection.ProjectionBehavior
+import akka.projection.ProjectionId
+import akka.projection.scaladsl.SourceProvider
+import akka.projection.slick.SlickHandler
+import akka.projection.slick.SlickProjection
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.slf4j.LoggerFactory
+import slick.basic.DatabaseConfig
+import slick.dbio.DBIO
+import slick.jdbc.H2Profile
+
+//#imports
+import akka.projection.kafka.KafkaSourceProvider
+import akka.projection.MergeableOffset
+import akka.kafka.ConsumerSettings
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.serialization.StringDeserializer
+
+//#imports
+
+object KafkaDocExample {
+
+  //#handler
+  type Word = String
+  type Count = Int
+
+  class WordCountHandler(projectionId: ProjectionId) extends SlickHandler[ConsumerRecord[String, String]] {
+    private val logger = LoggerFactory.getLogger(getClass)
+    private var state: Map[Word, Count] = Map.empty
+
+    override def process(envelope: ConsumerRecord[String, String]): DBIO[Done] = {
+      val word = envelope.value
+      val newCount = state.getOrElse(word, 0) + 1
+      logger.info(
+        "{} consumed from topic/partition {}/{}. Word count for {} is {}",
+        projectionId,
+        envelope.topic,
+        envelope.partition,
+        word,
+        newCount)
+      state = state.updated(word, newCount)
+      DBIO.successful(Done)
+    }
+  }
+  //#handler
+
+  val config: Config = ConfigFactory.parseString("""
+    akka.projection.slick = {
+
+      profile = "slick.jdbc.H2Profile$"
+
+      db = {
+       url = "jdbc:h2:mem:test1"
+       driver = org.h2.Driver
+       connectionPool = disabled
+       keepAliveConnection = true
+      }
+    }
+    """)
+
+  implicit lazy val system = ActorSystem[Guardian.Command](Guardian(), "Example", config)
+
+  object IllustrateSourceProvider {
+
+    //#sourceProvider
+    val bootstrapServers = "localhost:9092"
+    val groupId = "group-wordcount"
+    val topicName = "words"
+    val consumerSettings =
+      ConsumerSettings(system, new StringDeserializer, new StringDeserializer)
+        .withBootstrapServers(bootstrapServers)
+        .withGroupId(groupId)
+        .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+
+    val sourceProvider: SourceProvider[MergeableOffset[Long], ConsumerRecord[String, String]] =
+      KafkaSourceProvider(system, consumerSettings, Set(topicName))
+    //#sourceProvider
+  }
+
+  object IllustrateExactlyOnce {
+    import IllustrateSourceProvider._
+
+    //#exactlyOnce
+    val databaseConfig: DatabaseConfig[H2Profile] =
+      DatabaseConfig.forConfig("akka.projection.slick", system.settings.config)
+    val projectionId = ProjectionId("WordCount", "wordcount-1")
+    val projection =
+      SlickProjection.exactlyOnce(
+        projectionId,
+        sourceProvider,
+        databaseConfig,
+        handler = new WordCountHandler(projectionId))
+    //#exactlyOnce
+
+    projection.createOffsetTableIfNotExists()
+  }
+
+  def projection(n: Int): Projection[ConsumerRecord[String, String]] = {
+    import IllustrateSourceProvider.sourceProvider
+    import IllustrateExactlyOnce.databaseConfig
+
+    val projectionId = ProjectionId("WordCount", s"wordcount-$n")
+    SlickProjection.exactlyOnce(
+      projectionId,
+      sourceProvider,
+      databaseConfig,
+      handler = new WordCountHandler(projectionId))
+  }
+
+  object Guardian {
+    sealed trait Command
+    def apply(): Behavior[Command] = {
+      Behaviors.setup { context =>
+        context.spawn(ProjectionBehavior(projection(1)), "wordcount-1")
+        context.spawn(ProjectionBehavior(projection(2)), "wordcount-2")
+        context.spawn(ProjectionBehavior(projection(3)), "wordcount-3")
+
+        Behaviors.empty
+      }
+
+    }
+  }
+
+  /**
+   * {{{
+   * bin/kafka-topics.sh --create --bootstrap-server localhost:9092 --replication-factor 1 --partitions 3 --topic words
+   * bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic words
+   * bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic words --from-beginning
+   *
+   * sbt "examples/test:runMain docs.kafka.KafkaDocExample"
+   *
+   * bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic words
+   *
+   * }}}
+   */
+  def main(args: Array[String]): Unit = {
+    system
+  }
+
+}

--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -77,16 +77,15 @@ project-info {
       }
     ]
   }
-// FIXME
-//  akka-projection-kafka: ${project-info.shared-info} {
-//    title: "Akka Projection Kafka"
-//    jpms-name: "akka.projection.kafka"
-//    levels: [
-//      {
-//        readiness: CommunityDriven
-//        since: "2020-04-01"
-//        since-version: "0.0"
-//      }
-//    ]
-//  }
+  akka-projection-kafka: ${project-info.shared-info} {
+    title: "Akka Projection Kafka"
+    jpms-name: "akka.projection.kafka"
+    levels: [
+      {
+        readiness: CommunityDriven
+        since: "2020-04-01"
+        since-version: "0.0"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
On top of https://github.com/akka/akka-projection/pull/131
Also requires https://github.com/akka/akka-projection/pull/132 to be able to run the example.

* also moved MergableOffset to public place

I intend to add publishing to Kafka in a separate PR, and also mention committing offsets to Kafka. For the latter I guess we will just refer to Alpakka Kafka documentation since Projections is not adding any value.

References #79
