### PR TITLE
TestKit API improvements

### DIFF
--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
@@ -214,7 +214,7 @@ import akka.stream.scaladsl.Source
             .map(_ => Done)
       }
 
-      composedSource.via(RunningProjection.stopHandlerWhenFailed(() => handler.tryStop()))
+      RunningProjection.stopHandlerOnTermination(composedSource, () => handler.tryStop())
     }
 
     private[projection] def newRunningInstance(): RunningProjection = {
@@ -227,9 +227,6 @@ import akka.stream.scaladsl.Source
       extends RunningProjection {
 
     private val streamDone = source.run()
-    private val allStopped: Future[Done] =
-      RunningProjection.stopHandlerWhenStreamCompletedNormally(streamDone, () => handler.tryStop())(
-        systemProvider.classicSystem.dispatcher)
 
     /**
      * INTERNAL API
@@ -241,7 +238,7 @@ import akka.stream.scaladsl.Source
     @InternalApi
     override private[projection] def stop()(implicit ec: ExecutionContext): Future[Done] = {
       killSwitch.shutdown()
-      allStopped
+      streamDone
     }
   }
 

--- a/akka-projection-cassandra/src/test/java/akka/projection/cassandra/CassandraProjectionTest.java
+++ b/akka-projection-cassandra/src/test/java/akka/projection/cassandra/CassandraProjectionTest.java
@@ -158,8 +158,9 @@ public class CassandraProjectionTest extends JUnitSuite {
         concatHandler(str))
       .withSaveOffset(1, Duration.ZERO);
 
-    projectionTestKit.run(projection, () ->
-      assertEquals("abc|def|ghi|jkl|mno|pqr|", str.toString()));
+    projectionTestKit.run(projection, () -> {
+      assertEquals("abc|def|ghi|jkl|mno|pqr|", str.toString());
+    });
 
     assertStoredOffset(projectionId, 6L);
   }
@@ -179,8 +180,9 @@ public class CassandraProjectionTest extends JUnitSuite {
       .withSaveOffset(1, Duration.ZERO);
 
     try {
-      projectionTestKit.run(projection, () ->
-        assertEquals("abc|def|ghi|", str.toString()));
+      projectionTestKit.run(projection, () -> {
+        assertEquals("abc|def|ghi|", str.toString());
+      });
       Assert.fail("Expected exception");
     } catch (RuntimeException e) {
       assertEquals("fail on 4", e.getMessage());
@@ -196,8 +198,9 @@ public class CassandraProjectionTest extends JUnitSuite {
         concatHandler(str))
       .withSaveOffset(1, Duration.ZERO);
 
-    projectionTestKit.run(projection2, () ->
-      assertEquals("abc|def|ghi|jkl|mno|pqr|", str.toString()));
+    projectionTestKit.run(projection2, () -> {
+      assertEquals("abc|def|ghi|jkl|mno|pqr|", str.toString());
+    });
   }
 
   @Test
@@ -213,8 +216,9 @@ public class CassandraProjectionTest extends JUnitSuite {
         new TestSourceProvider(entityId),
         concatHandler(str));
 
-    projectionTestKit.run(projection, () ->
-      assertEquals("abc|def|ghi|jkl|mno|pqr|", str.toString()));
+    projectionTestKit.run(projection, () -> {
+      assertEquals("abc|def|ghi|jkl|mno|pqr|", str.toString());
+    });
 
     assertStoredOffset(projectionId, 6L);
   }
@@ -233,8 +237,9 @@ public class CassandraProjectionTest extends JUnitSuite {
         concatHandlerFail4(str));
 
     try {
-      projectionTestKit.run(projection, () ->
-        assertEquals("abc|def|ghi|", str.toString()));
+      projectionTestKit.run(projection, () -> {
+        assertEquals("abc|def|ghi|", str.toString());
+      });
       Assert.fail("Expected exception");
     } catch (RuntimeException e) {
       assertEquals("fail on 4", e.getMessage());
@@ -249,9 +254,10 @@ public class CassandraProjectionTest extends JUnitSuite {
         new TestSourceProvider(entityId),
         concatHandler(str));
 
-    projectionTestKit.run(projection2, () ->
+    projectionTestKit.run(projection2, () -> {
       // failed: jkl not included
-      assertEquals("abc|def|ghi|mno|pqr|", str.toString()));
+      assertEquals("abc|def|ghi|mno|pqr|", str.toString());
+    });
   }
 
 

--- a/akka-projection-core/src/main/scala/akka/projection/Projection.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/Projection.scala
@@ -6,13 +6,13 @@ package akka.projection
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.util.control.NoStackTrace
 
 import akka.Done
 import akka.NotUsed
 import akka.actor.ClassicActorSystemProvider
 import akka.annotation.ApiMayChange
 import akka.annotation.InternalApi
-import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.RestartSource
 import akka.stream.scaladsl.Source
 
@@ -66,18 +66,34 @@ private[projection] object RunningProjection {
         () => source()
       }
 
-  def stopHandlerWhenStreamCompletedNormally(whenStreamCompleted: Future[Done], stopHandler: () => Future[Done])(
-      implicit ec: ExecutionContext): Future[Done] = {
-    whenStreamCompleted.flatMap(_ => stopHandler())
-  }
+  /* internal exception to wrap exceptions coming from stopHandler */
+  private case class StopHandlerException(cause: Throwable) extends RuntimeException(cause) with NoStackTrace
 
-  def stopHandlerWhenFailed[T](stopHandler: () => Future[Done])(implicit ec: ExecutionContext): Flow[T, T, _] = {
-    Flow[T].recoverWithRetries(attempts = 1, {
-      case exc =>
-        Source
-          .futureSource(stopHandler().recover(_ => Done).map(_ => Source.failed(exc)))
-          .mapMaterializedValue(_ => NotUsed)
-    })
+  /**
+   * Adds a `watchTermination` on that passed Source that will call the `stopHandler` on completion.
+   *
+   * The stopHandler function is called on success or failure. In case of failure, the original failure is preserved.
+   */
+  def stopHandlerOnTermination(src: Source[Done, NotUsed], stopHandler: () => Future[Done])(
+      implicit ec: ExecutionContext): Source[Done, Future[Done]] = {
+    src.watchTermination() { (_, futDone) =>
+      futDone
+        .flatMap { _ =>
+          stopHandler().recoverWith {
+            // if stop fails we need to wrap it so
+            // on the next recoverWith we don't call it twice
+            case exc => Future.failed(StopHandlerException(exc))
+          }
+        }
+        .recoverWith {
+          case StopHandlerException(exc) => Future.failed(exc)
+          case streamFailure             =>
+            // ignore error in stop failure and preserve original stream failure
+            stopHandler().recoverWith(_ => Future.failed(streamFailure))
+        }
+        .map(_ => Done)
+    }
+
   }
 
 }

--- a/akka-projection-core/src/main/scala/akka/projection/Projection.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/Projection.scala
@@ -70,7 +70,7 @@ private[projection] object RunningProjection {
   private case class StopHandlerException(cause: Throwable) extends RuntimeException(cause) with NoStackTrace
 
   /**
-   * Adds a `watchTermination` on that passed Source that will call the `stopHandler` on completion.
+   * Adds a `watchTermination` on the passed Source that will call the `stopHandler` on completion.
    *
    * The stopHandler function is called on success or failure. In case of failure, the original failure is preserved.
    */

--- a/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
+++ b/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
@@ -301,9 +301,10 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       }
 
       withClue("check: projection failed with stream failure") {
-        val sinkProbe = projectionTestKit.runWithTestSink(slickProjectionFailing)
-        sinkProbe.request(1000)
-        eventuallyExpectError(sinkProbe).getMessage should startWith(concatHandlerFail4Msg)
+        projectionTestKit.runWithTestSink(slickProjectionFailing) { sinkProbe =>
+          sinkProbe.request(1000)
+          eventuallyExpectError(sinkProbe).getMessage should startWith(concatHandlerFail4Msg)
+        }
       }
       withClue("check: projection is consumed up to third") {
         val concatStr = dbConfig.db.run(repository.findById(entityId)).futureValue.value
@@ -340,9 +341,10 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       }
 
       withClue("check: projection failed with stream failure") {
-        val sinkProbe = projectionTestKit.runWithTestSink(slickProjectionFailing)
-        sinkProbe.request(1000)
-        eventuallyExpectError(sinkProbe).getMessage should startWith(concatHandlerFail4Msg)
+        projectionTestKit.runWithTestSink(slickProjectionFailing) { sinkProbe =>
+          sinkProbe.request(1000)
+          eventuallyExpectError(sinkProbe).getMessage should startWith(concatHandlerFail4Msg)
+        }
       }
       withClue("check: projection is consumed up to third") {
         val concatStr = dbConfig.db.run(repository.findById(entityId)).futureValue.value
@@ -396,9 +398,10 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       }
 
       withClue("check: projection failed with stream failure") {
-        val sinkProbe = projectionTestKit.runWithTestSink(slickProjectionFailing)
-        sinkProbe.request(1000)
-        eventuallyExpectError(sinkProbe).getMessage should startWith(concatHandlerFail4Msg)
+        projectionTestKit.runWithTestSink(slickProjectionFailing) { sinkProbe =>
+          sinkProbe.request(1000)
+          eventuallyExpectError(sinkProbe).getMessage should startWith(concatHandlerFail4Msg)
+        }
       }
       withClue("check: projection is consumed up to third") {
         val concatStr = dbConfig.db.run(repository.findById(entityId)).futureValue.value
@@ -455,9 +458,11 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
         offsetOpt shouldBe empty
       }
 
-      val sinkProbe = projectionTestKit.runWithTestSink(slickProjectionFailing)
-      sinkProbe.request(1000)
-      eventuallyExpectError(sinkProbe).getClass shouldBe classOf[JdbcSQLIntegrityConstraintViolationException]
+      projectionTestKit.runWithTestSink(slickProjectionFailing) { sinkProbe =>
+
+        sinkProbe.request(1000)
+        eventuallyExpectError(sinkProbe).getClass shouldBe classOf[JdbcSQLIntegrityConstraintViolationException]
+      }
 
       withClue("check: projection is consumed up to third") {
         val concatStr = dbConfig.db.run(repository.findById(entityId)).futureValue.value
@@ -611,9 +616,10 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       }
 
       withClue("check: projection failed with stream failure") {
-        val sinkProbe = projectionTestKit.runWithTestSink(slickProjectionFailing)
-        sinkProbe.request(1000)
-        eventuallyExpectError(sinkProbe).getMessage should startWith(concatHandlerFail4Msg)
+        projectionTestKit.runWithTestSink(slickProjectionFailing) { sinkProbe =>
+          sinkProbe.request(1000)
+          eventuallyExpectError(sinkProbe).getMessage should startWith(concatHandlerFail4Msg)
+        }
       }
       withClue("check: projection is consumed up to third") {
         val concatStr = dbConfig.db.run(repository.findById(entityId)).futureValue.value
@@ -670,9 +676,10 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       }
 
       withClue("check: projection failed with stream failure") {
-        val sinkProbe = projectionTestKit.runWithTestSink(slickProjectionFailing)
-        sinkProbe.request(1000)
-        eventuallyExpectError(sinkProbe).getMessage should startWith(concatHandlerFail4Msg)
+        projectionTestKit.runWithTestSink(slickProjectionFailing) { sinkProbe =>
+          sinkProbe.request(1000)
+          eventuallyExpectError(sinkProbe).getMessage should startWith(concatHandlerFail4Msg)
+        }
       }
       withClue("check: projection is consumed up to third") {
         val concatStr = dbConfig.db.run(repository.findById(entityId)).futureValue.value
@@ -736,29 +743,30 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
             eventHandler)
           .withSaveOffset(10, 1.minute)
 
-      val sinkProbe = projectionTestKit.runWithTestSink(slickProjection)
-      eventually {
-        sourceProbe.get should not be null
-      }
-      sinkProbe.request(1000)
+      projectionTestKit.runWithTestSink(slickProjection) { sinkProbe =>
 
-      (1 to 15).foreach { n =>
-        sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
-      }
-      eventually {
-        dbConfig.db.run(repository.findById(entityId)).futureValue.value.text should include("elem-15")
-      }
-      offsetStore.readOffset[Long](projectionId).futureValue.value shouldBe 10L
+        eventually {
+          sourceProbe.get should not be null
+        }
+        sinkProbe.request(1000)
 
-      (16 to 22).foreach { n =>
-        sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
-      }
-      eventually {
-        dbConfig.db.run(repository.findById(entityId)).futureValue.value.text should include("elem-22")
-      }
-      offsetStore.readOffset[Long](projectionId).futureValue.value shouldBe 20L
+        (1 to 15).foreach { n =>
+          sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
+        }
+        eventually {
+          dbConfig.db.run(repository.findById(entityId)).futureValue.value.text should include("elem-15")
+        }
+        offsetStore.readOffset[Long](projectionId).futureValue.value shouldBe 10L
 
-      sinkProbe.cancel()
+        (16 to 22).foreach { n =>
+          sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
+        }
+        eventually {
+          dbConfig.db.run(repository.findById(entityId)).futureValue.value.text should include("elem-22")
+        }
+        offsetStore.readOffset[Long](projectionId).futureValue.value shouldBe 20L
+      }
+
     }
 
     "save offset after idle duration" in {
@@ -784,29 +792,31 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
             databaseConfig = dbConfig,
             eventHandler)
           .withSaveOffset(10, 2.seconds)
-      val sinkProbe = projectionTestKit.runWithTestSink(slickProjection)
-      eventually {
-        sourceProbe.get should not be null
-      }
-      sinkProbe.request(1000)
 
-      (1 to 15).foreach { n =>
-        sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
-      }
-      eventually {
-        dbConfig.db.run(repository.findById(entityId)).futureValue.value.text should include("elem-15")
-      }
-      offsetStore.readOffset[Long](projectionId).futureValue.value shouldBe 10L
+      projectionTestKit.runWithTestSink(slickProjection) { sinkProbe =>
 
-      (16 to 17).foreach { n =>
-        sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
-      }
-      eventually {
-        offsetStore.readOffset[Long](projectionId).futureValue.value shouldBe 17L
-      }
-      dbConfig.db.run(repository.findById(entityId)).futureValue.value.text should include("elem-17")
+        eventually {
+          sourceProbe.get should not be null
+        }
+        sinkProbe.request(1000)
 
-      sinkProbe.cancel()
+        (1 to 15).foreach { n =>
+          sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
+        }
+        eventually {
+          dbConfig.db.run(repository.findById(entityId)).futureValue.value.text should include("elem-15")
+        }
+        offsetStore.readOffset[Long](projectionId).futureValue.value shouldBe 10L
+
+        (16 to 17).foreach { n =>
+          sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
+        }
+        eventually {
+          offsetStore.readOffset[Long](projectionId).futureValue.value shouldBe 17L
+        }
+        dbConfig.db.run(repository.findById(entityId)).futureValue.value.text should include("elem-17")
+      }
+
     }
 
   }

--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/javadsl/ProjectionTestKit.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/javadsl/ProjectionTestKit.scala
@@ -44,7 +44,7 @@ final class ProjectionTestKit private[akka] (testKit: ActorTestKit) {
    * If the assert function doesn't complete without error within 3 seconds the test will fail.
    *
    * @param projection - the Projection to run
-   * @param assertFunction - a function that exercise the test assertions
+   * @param assertFunction - a function that exercises the test assertions
    */
   def run(projection: Projection[_], assertFunction: Effect): Unit =
     runInternal(projection, assertFunction, settings.SingleExpectDefaultTimeout.asJava, 100.millis.asJava)
@@ -59,7 +59,7 @@ final class ProjectionTestKit private[akka] (testKit: ActorTestKit) {
    *
    * @param projection - the Projection to run
    * @param max - Duration delimiting the max duration of the test
-   * @param assertFunction - a function that exercise the test assertions
+   * @param assertFunction - a function that exercises the test assertions
    */
   def run(projection: Projection[_], max: Duration, assertFunction: Effect): Unit =
     runInternal(projection, assertFunction, max, 100.millis.asJava)
@@ -76,7 +76,7 @@ final class ProjectionTestKit private[akka] (testKit: ActorTestKit) {
    * @param projection - the Projection to run
    * @param max - Duration delimiting the max duration of the test
    * @param interval - Duration defining the internval in each the assert function will be called
-   * @param assertFunction - a function that exercise the test assertions
+   * @param assertFunction - a function that exercises the test assertions
    */
   def run(projection: Projection[_], max: Duration, interval: Duration, assertFunction: Effect): Unit =
     runInternal(projection, assertFunction, max, interval)
@@ -108,7 +108,7 @@ final class ProjectionTestKit private[akka] (testKit: ActorTestKit) {
    * control over the pace in which the elements flow through the Projection.
    *
    * The assertion function receives a `TestSubscriber.Probe` that you can use
-   * request elements.
+   * to request elements.
    *
    * The Projection starts as soon as the first element is requested by the `TestSubscriber.Probe`, new elements will be emitted
    * as requested. The Projection is stopped once the assert function completes.

--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/scaladsl/ProjectionTestKit.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/scaladsl/ProjectionTestKit.scala
@@ -11,7 +11,6 @@ import akka.Done
 import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.testkit.typed.scaladsl._
-import akka.actor.typed.scaladsl.adapter._
 import akka.annotation.ApiMayChange
 import akka.projection.Projection
 import akka.projection.ProjectionSettings
@@ -90,7 +89,6 @@ final class ProjectionTestKit private[akka] (testKit: ActorTestKit) {
       projection
         .withSettings(settingsForTest)
         .run()(testKit.system.classicSystem)
-
     try {
       probe.awaitAssert(assertFunction, max.dilated, interval)
     } finally {
@@ -99,19 +97,25 @@ final class ProjectionTestKit private[akka] (testKit: ActorTestKit) {
   }
 
   /**
-   * Run a Projection with an attached `TestSink` allowing
-   * control over the pace the elements flow through the Projection.
+   * Run a Projection with an attached `TestSubscriber.Probe` allowing
+   * control over the pace in which the elements flow through the Projection.
    *
-   * The Projection starts as soon as the first element is requested by the `TestSink`, new elements will be emitted
-   * as requested by the `TestSink`. The Projection won't stop by itself, therefore it's recommended to cancel the
-   * `TestSink` probe to gracefully stop the Projection.
+   * The assertion function receives a `TestSubscriber.Probe` that you can use
+   * request elements.
+   *
+   * The Projection starts as soon as the first element is requested by the `TestSubscriber.Probe`, new elements will be emitted
+   * as requested. The Projection is stopped once the assert function completes.
    *
    * @param projection - the Projection to run
+   * @param assertFunction - a function receiving a `TestSubscriber.Probe[Done]`
    */
-  def runWithTestSink[T](projection: Projection[_]): TestSubscriber.Probe[Done] = {
-    val sinkProbe = TestSink.probe[Done](testKit.system.toClassic)
-    // FIXME handler.stop is not called when running like this
-    projection.mappedSource().runWith(sinkProbe)
+  def runWithTestSink(projection: Projection[_])(assertFunction: TestSubscriber.Probe[Done] => Unit): Unit = {
+    val sinkProbe = projection.mappedSource().runWith(TestSink.probe[Done](testKit.system.classicSystem))
+    try {
+      assertFunction(sinkProbe)
+    } finally {
+      sinkProbe.cancel()
+    }
   }
 
 }

--- a/akka-projection-testkit/src/test/java/akka/projection/testkit/javadsl/ProjectionTestKitTest.java
+++ b/akka-projection-testkit/src/test/java/akka/projection/testkit/javadsl/ProjectionTestKitTest.java
@@ -29,7 +29,6 @@ import akka.stream.SharedKillSwitch;
 import akka.stream.javadsl.DelayStrategy;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
-import akka.stream.testkit.TestSubscriber;
 import org.scalatestplus.junit.JUnitSuite;
 
 import static org.junit.Assert.assertEquals;
@@ -52,7 +51,9 @@ public class ProjectionTestKitTest extends JUnitSuite {
         StringBuffer strBuffer = new StringBuffer("");
         TestProjection prj = new TestProjection(src, strBuffer, i -> i <= 6);
 
-        projectionTestKit.run(prj, () -> assertEquals(strBuffer.toString(), "1-2-3-4-5-6"));
+        projectionTestKit.run(prj, () -> {
+            assertEquals(strBuffer.toString(), "1-2-3-4-5-6");
+        });
     }
 
     @Test
@@ -103,7 +104,9 @@ public class ProjectionTestKitTest extends JUnitSuite {
         });
 
         try {
-            projectionTestKit.run(prj, () -> assertEquals(strBuffer.toString(), "1-2-3-4"));
+            projectionTestKit.run(prj, () -> {
+                assertEquals(strBuffer.toString(), "1-2-3-4");
+            });
             Assert.fail("should not reach that line");
         } catch (RuntimeException ex) {
             assertEquals(ex.getMessage(), streamFailureMsg);
@@ -123,7 +126,9 @@ public class ProjectionTestKitTest extends JUnitSuite {
         TestProjection prj = new TestProjection(failingSource, strBuffer, i ->  i <= 4);
 
         try {
-            projectionTestKit.run(prj, () -> assertEquals(strBuffer.toString(), "1-2-3-4"));
+            projectionTestKit.run(prj, () -> {
+                assertEquals(strBuffer.toString(), "1-2-3-4");
+            });
             Assert.fail("should not reach that line");
         } catch (RuntimeException ex) {
             assertEquals(ex.getMessage(), streamFailureMsg);
@@ -138,11 +143,12 @@ public class ProjectionTestKitTest extends JUnitSuite {
                 .boxed().collect(Collectors.toList());
 
         TestProjection prj = new TestProjection(Source.from(elements), strBuffer, i -> i <= 5);
-        TestSubscriber.Probe<Done> sinkProbe = projectionTestKit.runWithTestSink(prj);
 
-        sinkProbe.request(5);
-        sinkProbe.expectNextN(5);
-        sinkProbe.expectComplete();
+        projectionTestKit.runWithTestSink(prj, sinkProbe -> {
+            sinkProbe.request(5);
+            sinkProbe.expectNextN(5);
+            sinkProbe.expectComplete();
+        });
 
         assertEquals(strBuffer.toString(), "1-2-3-4-5");
 

--- a/akka-projection-testkit/src/test/scala/akka/projection/testkit/scaladsl/ProjectionTestKitSpec.scala
+++ b/akka-projection-testkit/src/test/scala/akka/projection/testkit/scaladsl/ProjectionTestKitSpec.scala
@@ -132,20 +132,6 @@ class ProjectionTestKitSpec extends ScalaTestWithActorTestKit with AnyWordSpecLi
       strBuffer.toString shouldBe "1-2-3-4-5"
     }
 
-    "run cray" in {
-
-      val probe =
-        Source
-          .repeat(1)
-          .runWith(TestSink.probe[Int](testKit.system.classicSystem))
-
-      probe.request(3)
-      probe.expectNextN(3)
-      probe.cancel()
-      probe.request(1)
-      probe.expectNoMessage()
-
-    }
   }
 
   case class TestProjection(src: Source[Int, NotUsed], strBuffer: StringBuffer, predicate: Int => Boolean)

--- a/docs/src/main/paradox/testing.md
+++ b/docs/src/main/paradox/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-Akka Projection provides a TestKit to ease testing. There are two supported styles of test: running with an assert function and driving it with an Akka Streams TestKit `TestSink`.
+Akka Projection provides a TestKit to ease testing. There are two supported styles of test: running with an assert function and driving it with an Akka Streams TestKit `TestSubscriber.Probe`.
 
 ## Dependencies
 
@@ -53,11 +53,11 @@ Scala
 Java
 :  @@snip [TestKitDocExample.java](/examples/src/test/java/jdocs/testkit/TestKitDocExample.java) { #testkit-duration #testkit-run-max-interval }  
 
-## Testing with a TestSink
+## Testing with a TestSubscriber.Probe
 
 The [Akka Stream TestKit](https://doc.akka.io/docs/akka/current/stream/stream-testkit.html#using-the-testkit) can be used to drive the pace of envelopes flowing through the Projection.
 
- The Projection starts as soon as the first element is requested by the `TestSink`, new elements will be emitted as requested by the `TestSink`. The Projection won't stop by itself, therefore it's recommended to cancel the `TestSink` probe to gracefully stop the Projection.
+The Projection starts as soon as the first element is requested by the `TestSubscriber.Probe`, new elements will be emitted as requested. The Projection is stopped once the assert function completes.
 
 Scala
 :  @@snip [TestKitDocExample.scala](/examples/src/test/scala/docs/testkit/TestKitDocExample.scala) { #testkit-sink-probe }

--- a/examples/src/test/java/jdocs/cassandra/CassandraProjectionDocExample.java
+++ b/examples/src/test/java/jdocs/cassandra/CassandraProjectionDocExample.java
@@ -67,6 +67,8 @@ public interface CassandraProjectionDocExample {
         return CompletableFuture.completedFuture(Done.getInstance());
       }
     }
+
+
   }
   //#handler
 

--- a/examples/src/test/java/jdocs/testkit/TestKitDocExample.java
+++ b/examples/src/test/java/jdocs/testkit/TestKitDocExample.java
@@ -24,6 +24,7 @@ import akka.projection.testkit.javadsl.ProjectionTestKit;
 
 //#testkit-duration
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 //#testkit-duration
 
@@ -82,37 +83,21 @@ public class TestKitDocExample {
   CartCheckoutRepository cartCheckoutRepository = new CartCheckoutRepository();
 
   void illustrateTestKitRun() {
-
     //#testkit-run
     projectionTestKit.run(projection, () -> {
-
-      TestProbe<CartView> testProbe = testKit.testKit().createTestProbe("cart-view-probe");
       cartCheckoutRepository
-              .findById("abc-def")
-              // use a probe to capture the async result
-              .thenAccept(view -> testProbe.ref().tell(view));
-
-      CartView cartView = testProbe.expectMessageClass(CartView.class);
-      assertEquals("abc-def", cartView.id);
-
+        .findById("abc-def")
+        .toCompletableFuture().get(1,TimeUnit.SECONDS);
     });
     //#testkit-run
-
   }
 
   void illustrateTestKitRunWithMaxAndInterval() {
     //#testkit-run-max-interval
     projectionTestKit.run(projection, Duration.ofSeconds(5), Duration.ofMillis(300), () -> {
-
-      TestProbe<CartView> testProbe = testKit.testKit().createTestProbe("cart-view-probe");
       cartCheckoutRepository
-              .findById("abc-def")
-              // use a probe to capture the async result
-              .thenAccept(view -> testProbe.ref().tell(view));
-
-      CartView cartView = testProbe.expectMessageClass(CartView.class);
-      assertEquals("abc-def", cartView.id);
-
+        .findById("abc-def")
+        .toCompletableFuture().get(1, TimeUnit.SECONDS);
     });
     //#testkit-run-max-interval
   }
@@ -121,19 +106,13 @@ public class TestKitDocExample {
   void illustrateTestKitRunWithTestSink() {
 
     //#testkit-sink-probe
-    TestSubscriber.Probe<Done> sinkProbe = projectionTestKit.runWithTestSink(projection);
-    sinkProbe.request(1);
-    sinkProbe.expectNext(Done.getInstance());
-    sinkProbe.cancel();
-
-    TestProbe<CartView> testProbe = testKit.testKit().createTestProbe("cart-view-probe");
-    cartCheckoutRepository
-      .findById("abc-def")
-       // use a probe to capture the async result
-       .thenAccept(view -> testProbe.ref().tell(view));
-
-    CartView cartView = testProbe.expectMessageClass(CartView.class);
-    assertEquals("abc-def", cartView.id);
+    projectionTestKit.runWithTestSink(projection, sinkProbe -> {
+      sinkProbe.request(1);
+      sinkProbe.expectNext(Done.getInstance());
+      cartCheckoutRepository
+        .findById("abc-def")
+        .toCompletableFuture().get(1, TimeUnit.SECONDS);
+    });
 
     //#testkit-sink-probe
   }

--- a/examples/src/test/scala/docs/testkit/TestKitDocExample.scala
+++ b/examples/src/test/scala/docs/testkit/TestKitDocExample.scala
@@ -27,12 +27,15 @@ abstract
 //#testkit
 class TestKitDocExample extends ScalaTestWithActorTestKit {
   val projectionTestKit = ProjectionTestKit(testKit)
+
   //#testkit
 
   case class CartView(id: String)
+
   class CartViewRepository {
     def findById(id: String): Future[CartView] = Future.successful(CartView(id))
   }
+
   val cartViewRepository = new CartViewRepository
 
   // it only needs to compile
@@ -42,30 +45,32 @@ class TestKitDocExample extends ScalaTestWithActorTestKit {
     databaseConfig = null,
     handler = null)
 
-  //#testkit-run
-  projectionTestKit.run(projection) {
-    // confirm that cart checkout was inserted in db
-    val cartView = cartViewRepository.findById("abc-def").futureValue
-    cartView.id shouldBe "abc-def"
+  {
+    //#testkit-run
+    projectionTestKit.run(projection) {
+      // confirm that cart checkout was inserted in db
+      cartViewRepository.findById("abc-def").futureValue
+    }
+    //#testkit-run
   }
-  //#testkit-run
 
-  //#testkit-run-max-interval
-  projectionTestKit.run(projection, max = 5.seconds, interval = 300.millis) {
-    // confirm that cart checkout was inserted in db
-    val cartView = cartViewRepository.findById("abc-def").futureValue
-    cartView.id shouldBe "abc-def"
+  {
+    //#testkit-run-max-interval
+    projectionTestKit.run(projection, max = 5.seconds, interval = 300.millis) {
+      // confirm that cart checkout was inserted in db
+      cartViewRepository.findById("abc-def").futureValue
+    }
+    //#testkit-run-max-interval
   }
-  //#testkit-run-max-interval
 
   //#testkit-sink-probe
-  val sinkProbe = projectionTestKit.runWithTestSink(projection)
-  sinkProbe.request(1)
-  sinkProbe.expectNext(Done)
-  sinkProbe.cancel()
+  projectionTestKit.runWithTestSink(projection) { sinkProbe =>
+    sinkProbe.request(1)
+    sinkProbe.expectNext(Done)
+  }
 
   // confirm that cart checkout was inserted in db
-  val cartView = cartViewRepository.findById("abc-def").futureValue
+  cartViewRepository.findById("abc-def").futureValue
 
   //#testkit-sink-probe
 //#testkit


### PR DESCRIPTION
References #134 

* ensure that TestKit will stop the projection when running with `runWithTestSink`
* all methods return the type returned by the user function *
* using Akka's Functions in Java to allow for throwing exceptions

\* that change make it easier to collect that from inside the lambda and use it further in other parts of the test. Scala users can return `Unit` if they want, and life continues. For Java users, it's a little bit more verbose. If they don't want to use the value from outside, they need to explicitly return something, like `Done.getInstance()`.