### PR TITLE
Convert offset strategies to implementations and provide atLeastOnce settings with fluent API

### DIFF
--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/scaladsl/CassandraProjection.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/scaladsl/CassandraProjection.scala
@@ -10,10 +10,12 @@ import scala.concurrent.duration.FiniteDuration
 import akka.Done
 import akka.actor.ClassicActorSystemProvider
 import akka.annotation.ApiMayChange
+import akka.projection.AtLeastOnceSettings
 import akka.projection.Projection
 import akka.projection.ProjectionId
 import akka.projection.ProjectionSettings
-import akka.projection.cassandra.internal.CassandraProjectionImpl
+import akka.projection.cassandra.internal.AtLeastOnceCassandraProjectionImpl
+import akka.projection.cassandra.internal.AtMostOnceCassandraProjectionImpl
 import akka.projection.scaladsl.Handler
 import akka.projection.scaladsl.SourceProvider
 
@@ -37,14 +39,12 @@ object CassandraProjection {
   def atLeastOnce[Offset, Envelope](
       projectionId: ProjectionId,
       sourceProvider: SourceProvider[Offset, Envelope],
-      saveOffsetAfterEnvelopes: Int,
-      saveOffsetAfterDuration: FiniteDuration,
-      handler: Handler[Envelope]): CassandraProjection[Envelope] =
-    new CassandraProjectionImpl(
+      handler: Handler[Envelope]): AtLeastOnceCassandraProjection[Envelope] =
+    new AtLeastOnceCassandraProjectionImpl(
       projectionId,
       sourceProvider,
-      CassandraProjectionImpl.AtLeastOnce(saveOffsetAfterEnvelopes, saveOffsetAfterDuration),
-      settingsOpt = None,
+      projectionSettings = None,
+      atLeastOnceSettings = None,
       handler)
 
   /**
@@ -55,18 +55,11 @@ object CassandraProjection {
   def atMostOnce[Offset, Envelope](
       projectionId: ProjectionId,
       sourceProvider: SourceProvider[Offset, Envelope],
-      handler: Handler[Envelope]): CassandraProjection[Envelope] =
-    new CassandraProjectionImpl(
-      projectionId,
-      sourceProvider,
-      CassandraProjectionImpl.AtMostOnce,
-      settingsOpt = None,
-      handler)
+      handler: Handler[Envelope]): AtMostOnceCassandraProjection[Envelope] =
+    new AtMostOnceCassandraProjectionImpl(projectionId, sourceProvider, projectionSettings = None, handler)
 }
 
 trait CassandraProjection[Envelope] extends Projection[Envelope] {
-
-  override def withSettings(settings: ProjectionSettings): CassandraProjection[Envelope]
 
   /**
    * For testing purposes the offset table can be created programmatically.
@@ -74,4 +67,16 @@ trait CassandraProjection[Envelope] extends Projection[Envelope] {
    * before the system is started.
    */
   def createOffsetTableIfNotExists()(implicit systemProvider: ClassicActorSystemProvider): Future[Done]
+}
+
+trait AtLeastOnceCassandraProjection[Envelope] extends CassandraProjection[Envelope] {
+  override def withSettings(settings: ProjectionSettings): AtLeastOnceCassandraProjection[Envelope]
+
+  def withAtLeastOnceSettings(settings: AtLeastOnceSettings): AtLeastOnceCassandraProjection[Envelope]
+  def withSaveOffsetAfterEnvelopes(afterEnvelopes: Int): AtLeastOnceCassandraProjection[Envelope]
+  def withSaveOffsetAfterDuration(afterDuration: FiniteDuration): AtLeastOnceCassandraProjection[Envelope]
+}
+
+trait AtMostOnceCassandraProjection[Envelope] extends CassandraProjection[Envelope] {
+  override def withSettings(settings: ProjectionSettings): AtMostOnceCassandraProjection[Envelope]
 }

--- a/akka-projection-cassandra/src/test/java/akka/projection/cassandra/CassandraProjectionTest.java
+++ b/akka-projection-cassandra/src/test/java/akka/projection/cassandra/CassandraProjectionTest.java
@@ -18,7 +18,6 @@ import akka.Done;
 import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.projection.Projection;
-import akka.projection.ProjectionSettings;
 import akka.projection.ProjectionId;
 import akka.projection.cassandra.internal.CassandraOffsetStore;
 import akka.projection.cassandra.javadsl.CassandraProjection;
@@ -156,9 +155,9 @@ public class CassandraProjectionTest extends JUnitSuite {
       .atLeastOnce(
         projectionId,
         new TestSourceProvider(entityId),
-        1,
-        Duration.ZERO,
-        concatHandler(str));
+        concatHandler(str))
+            .withSaveOffsetAfterEnvelopes(1)
+            .withSaveOffsetAfterDuration(Duration.ZERO);
 
     projectionTestKit.run(projection, () ->
       assertEquals("abc|def|ghi|jkl|mno|pqr|", str.toString()));
@@ -177,9 +176,9 @@ public class CassandraProjectionTest extends JUnitSuite {
       .atLeastOnce(
         projectionId,
         new TestSourceProvider(entityId),
-        1,
-        Duration.ZERO,
-        concatHandlerFail4(str));
+        concatHandlerFail4(str))
+            .withSaveOffsetAfterEnvelopes(1)
+            .withSaveOffsetAfterDuration(Duration.ZERO);
 
     try {
       projectionTestKit.run(projection, () ->
@@ -196,9 +195,9 @@ public class CassandraProjectionTest extends JUnitSuite {
       .atLeastOnce(
         projectionId,
         new TestSourceProvider(entityId),
-        1,
-        Duration.ZERO,
-        concatHandler(str));
+        concatHandler(str))
+            .withSaveOffsetAfterEnvelopes(1)
+            .withSaveOffsetAfterDuration(Duration.ZERO);
 
     projectionTestKit.run(projection2, () ->
       assertEquals("abc|def|ghi|jkl|mno|pqr|", str.toString()));

--- a/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
+++ b/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
@@ -209,12 +209,9 @@ class CassandraProjectionSpec
 
       val projection =
         CassandraProjection
-          .atLeastOnce[Long, Envelope](
-            projectionId,
-            sourceProvider(system, entityId),
-            saveOffsetAfterEnvelopes = 1,
-            saveOffsetAfterDuration = Duration.Zero,
-            concatHandler())
+          .atLeastOnce[Long, Envelope](projectionId, sourceProvider(system, entityId), concatHandler())
+          .withSaveOffsetAfterEnvelopes(1)
+          .withSaveOffsetAfterDuration(Duration.Zero)
 
       projectionTestKit.run(projection) {
         withClue("check - all values were concatenated") {
@@ -234,12 +231,9 @@ class CassandraProjectionSpec
 
       val failingProjection =
         CassandraProjection
-          .atLeastOnce[Long, Envelope](
-            projectionId,
-            sourceProvider(system, entityId),
-            saveOffsetAfterEnvelopes = 1,
-            saveOffsetAfterDuration = Duration.Zero,
-            concatHandlerFail4())
+          .atLeastOnce[Long, Envelope](projectionId, sourceProvider(system, entityId), concatHandlerFail4())
+          .withSaveOffsetAfterEnvelopes(1)
+          .withSaveOffsetAfterDuration(Duration.Zero)
 
       withClue("check - offset is empty") {
         val offsetOpt = offsetStore.readOffset[Long](projectionId).futureValue
@@ -263,12 +257,9 @@ class CassandraProjectionSpec
       // re-run projection without failing function
       val projection =
         CassandraProjection
-          .atLeastOnce[Long, Envelope](
-            projectionId,
-            sourceProvider(system, entityId),
-            saveOffsetAfterEnvelopes = 1,
-            saveOffsetAfterDuration = Duration.Zero,
-            concatHandler())
+          .atLeastOnce[Long, Envelope](projectionId, sourceProvider(system, entityId), concatHandler())
+          .withSaveOffsetAfterEnvelopes(1)
+          .withSaveOffsetAfterDuration(Duration.Zero)
 
       projectionTestKit.run(projection) {
         withClue("checking: all values were concatenated") {
@@ -289,12 +280,9 @@ class CassandraProjectionSpec
 
       val failingProjection =
         CassandraProjection
-          .atLeastOnce[Long, Envelope](
-            projectionId,
-            sourceProvider(system, entityId),
-            saveOffsetAfterEnvelopes = 2,
-            saveOffsetAfterDuration = 1.minute,
-            concatHandlerFail4())
+          .atLeastOnce[Long, Envelope](projectionId, sourceProvider(system, entityId), concatHandlerFail4())
+          .withSaveOffsetAfterEnvelopes(2)
+          .withSaveOffsetAfterDuration(1.minute)
 
       withClue("check - offset is empty") {
         val offsetOpt = offsetStore.readOffset[Long](projectionId).futureValue
@@ -318,12 +306,9 @@ class CassandraProjectionSpec
       // re-run projection without failing function
       val projection =
         CassandraProjection
-          .atLeastOnce[Long, Envelope](
-            projectionId,
-            sourceProvider(system, entityId),
-            saveOffsetAfterEnvelopes = 2,
-            saveOffsetAfterDuration = 1.minute,
-            concatHandler())
+          .atLeastOnce[Long, Envelope](projectionId, sourceProvider(system, entityId), concatHandler())
+          .withSaveOffsetAfterEnvelopes(2)
+          .withSaveOffsetAfterDuration(1.minute)
 
       projectionTestKit.run(projection) {
         withClue("checking: all values were concatenated") {
@@ -351,12 +336,10 @@ class CassandraProjectionSpec
       }
 
       val projection =
-        CassandraProjection.atLeastOnce[Long, Envelope](
-          projectionId,
-          TestSourceProvider(system, source),
-          saveOffsetAfterEnvelopes = 10,
-          saveOffsetAfterDuration = 1.minute,
-          concatHandler())
+        CassandraProjection
+          .atLeastOnce[Long, Envelope](projectionId, TestSourceProvider(system, source), concatHandler())
+          .withSaveOffsetAfterEnvelopes(10)
+          .withSaveOffsetAfterDuration(1.minute)
 
       val sinkProbe = projectionTestKit.runWithTestSink(projection)
       eventually {
@@ -395,12 +378,10 @@ class CassandraProjectionSpec
       }
 
       val projection =
-        CassandraProjection.atLeastOnce[Long, Envelope](
-          projectionId,
-          TestSourceProvider(system, source),
-          saveOffsetAfterEnvelopes = 10,
-          saveOffsetAfterDuration = 2.seconds,
-          concatHandler())
+        CassandraProjection
+          .atLeastOnce[Long, Envelope](projectionId, TestSourceProvider(system, source), concatHandler())
+          .withSaveOffsetAfterEnvelopes(10)
+          .withSaveOffsetAfterDuration(2.seconds)
 
       val sinkProbe = projectionTestKit.runWithTestSink(projection)
       eventually {
@@ -436,9 +417,9 @@ class CassandraProjectionSpec
           .atLeastOnce[Long, Envelope](
             projectionId,
             sourceProvider(system, entityId),
-            saveOffsetAfterEnvelopes = 2,
-            saveOffsetAfterDuration = 1.minute,
             concatHandlerFail4(HandlerRecoveryStrategy.skip))
+          .withSaveOffsetAfterEnvelopes(2)
+          .withSaveOffsetAfterDuration(1.minute)
 
       projectionTestKit.run(projection) {
         withClue("checking: all expected values were concatenated") {
@@ -462,12 +443,9 @@ class CassandraProjectionSpec
 
       val projection =
         CassandraProjection
-          .atLeastOnce[Long, Envelope](
-            projectionId,
-            sourceProvider(system, entityId),
-            saveOffsetAfterEnvelopes = 2,
-            saveOffsetAfterDuration = 1.minute,
-            handler)
+          .atLeastOnce[Long, Envelope](projectionId, sourceProvider(system, entityId), handler)
+          .withSaveOffsetAfterEnvelopes(2)
+          .withSaveOffsetAfterDuration(1.minute)
 
       projectionTestKit.run(projection) {
         withClue("checking: all expected values were concatenated") {
@@ -496,12 +474,9 @@ class CassandraProjectionSpec
 
       val projection =
         CassandraProjection
-          .atLeastOnce[Long, Envelope](
-            projectionId,
-            sourceProvider(system, entityId),
-            saveOffsetAfterEnvelopes = 2,
-            saveOffsetAfterDuration = 1.minute,
-            handler)
+          .atLeastOnce[Long, Envelope](projectionId, sourceProvider(system, entityId), handler)
+          .withSaveOffsetAfterEnvelopes(2)
+          .withSaveOffsetAfterDuration(1.minute)
 
       intercept[TestException] {
         projectionTestKit.run(projection) {
@@ -655,12 +630,9 @@ class CassandraProjectionSpec
 
       val projection =
         CassandraProjection
-          .atLeastOnce[Long, Envelope](
-            projectionId,
-            sourceProvider(system, entityId),
-            saveOffsetAfterEnvelopes = 1,
-            saveOffsetAfterDuration = Duration.Zero,
-            handler)
+          .atLeastOnce[Long, Envelope](projectionId, sourceProvider(system, entityId), handler)
+          .withSaveOffsetAfterEnvelopes(1)
+          .withSaveOffsetAfterDuration(Duration.Zero)
 
       // not using ProjectionTestKit because want to test restarts
       spawn(ProjectionBehavior(projection))
@@ -686,13 +658,10 @@ class CassandraProjectionSpec
 
       val projection =
         CassandraProjection
-          .atLeastOnce[Long, Envelope](
-            projectionId,
-            sourceProvider(system, entityId),
-            saveOffsetAfterEnvelopes = 1,
-            saveOffsetAfterDuration = Duration.Zero,
-            handler)
+          .atLeastOnce[Long, Envelope](projectionId, sourceProvider(system, entityId), handler)
           .withSettings(ProjectionSettings(system).withBackoff(1.second, 2.seconds, 0.0))
+          .withSaveOffsetAfterEnvelopes(1)
+          .withSaveOffsetAfterDuration(Duration.Zero)
 
       // not using ProjectionTestKit because want to test restarts
       spawn(ProjectionBehavior(projection))
@@ -721,15 +690,12 @@ class CassandraProjectionSpec
 
       val projection =
         CassandraProjection
-          .atLeastOnce[Long, Envelope](
-            projectionId,
-            sourceProvider(system, entityId),
-            saveOffsetAfterEnvelopes = 1,
-            saveOffsetAfterDuration = Duration.Zero,
-            handler)
+          .atLeastOnce[Long, Envelope](projectionId, sourceProvider(system, entityId), handler)
           .withSettings(
             ProjectionSettings(system).withBackoff(1.second, 2.seconds, 0.0, maxRestarts = 0)
           ) // no restarts
+          .withSaveOffsetAfterEnvelopes(1)
+          .withSaveOffsetAfterDuration(Duration.Zero)
 
       // not using ProjectionTestKit because want to test restarts
       spawn(ProjectionBehavior(projection))

--- a/akka-projection-core/src/main/resources/reference.conf
+++ b/akka-projection-core/src/main/resources/reference.conf
@@ -1,9 +1,16 @@
-akka.projection.restart-backoff {
-  min-backoff = 3s
-  max-backoff = 30s
-  random-factor = 0.2
+akka.projection {
+  restart-backoff {
+    min-backoff = 3s
+    max-backoff = 30s
+    random-factor = 0.2
 
-  # -1 will not cap the amount of restarts
-  # 0 will disable restarts
-  max-restarts = -1
+    # -1 will not cap the amount of restarts
+    # 0 will disable restarts
+    max-restarts = -1
+  }
+
+  at-least-once {
+    save-offset-after-envelopes = 1
+    save-offset-after-duration = 0 s
+  }
 }

--- a/akka-projection-core/src/main/scala/akka/projection/AtLeastOnceSettings.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/AtLeastOnceSettings.scala
@@ -1,0 +1,82 @@
+package akka.projection
+
+import java.time
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.MILLISECONDS
+import scala.concurrent.duration._
+
+import akka.actor.ClassicActorSystemProvider
+import akka.util.JavaDurationConverters._
+import com.typesafe.config.Config
+
+trait AtLeastOnceSettings {
+  def saveOffsetAfterEnvelopes: Int
+  def saveOffsetAfterDuration: FiniteDuration
+
+  /**
+   * Java API
+   */
+  def getSaveOffsetAfterDuration(): java.time.Duration
+
+  def withSaveOffsetAfterEnvelopes(afterElements: Int): AtLeastOnceSettings
+
+  /**
+   * Scala API
+   */
+  def withSaveOffsetAfterDuration(afterDuration: FiniteDuration): AtLeastOnceSettings
+
+  /**
+   * Java API
+   */
+  def withSaveOffsetAfterDuration(afterDuration: java.time.Duration): AtLeastOnceSettings
+}
+
+object AtLeastOnceSettings {
+
+  /**
+   * Java API
+   */
+  def create(system: ClassicActorSystemProvider): AtLeastOnceSettings = apply(system)
+
+  def apply(system: ClassicActorSystemProvider): AtLeastOnceSettings = {
+    fromConfig(system.classicSystem.settings.config.getConfig("akka.projection.at-least-once"))
+  }
+
+  def fromConfig(config: Config) =
+    new AtLeastOnceSettingsImpl(
+      config.getInt("save-offset-after-envelopes"),
+      config.getDuration("save-offset-after-duration", MILLISECONDS).millis)
+
+}
+
+private[akka] class AtLeastOnceSettingsImpl(
+    val saveOffsetAfterEnvelopes: Int,
+    val saveOffsetAfterDuration: FiniteDuration)
+    extends AtLeastOnceSettings {
+
+  /**
+   * Java API
+   */
+  override def getSaveOffsetAfterDuration(): time.Duration = saveOffsetAfterDuration.asJava
+
+  override def withSaveOffsetAfterEnvelopes(afterEnvelopes: Int): AtLeastOnceSettings =
+    copy(saveOffsetAfterEnvelopes = afterEnvelopes)
+
+  /**
+   * Scala API
+   */
+  override def withSaveOffsetAfterDuration(afterDuration: FiniteDuration): AtLeastOnceSettings =
+    copy(saveOffsetAfterDuration = afterDuration)
+
+  /**
+   * Java API
+   */
+  override def withSaveOffsetAfterDuration(afterDuration: java.time.Duration): AtLeastOnceSettings =
+    copy(saveOffsetAfterDuration = afterDuration.asScala)
+
+  private[akka] def copy(
+      saveOffsetAfterEnvelopes: Int = saveOffsetAfterEnvelopes,
+      saveOffsetAfterDuration: FiniteDuration = saveOffsetAfterDuration): AtLeastOnceSettings =
+    new AtLeastOnceSettingsImpl(saveOffsetAfterEnvelopes, saveOffsetAfterDuration)
+}

--- a/examples/src/test/java/jdocs/cassandra/CassandraProjectionDocExample.java
+++ b/examples/src/test/java/jdocs/cassandra/CassandraProjectionDocExample.java
@@ -86,9 +86,9 @@ public interface CassandraProjectionDocExample {
       CassandraProjection.atLeastOnce(
         ProjectionId.of("shopping-carts", "carts-1"),
         sourceProvider,
-        saveOffsetAfterEnvelopes,
-        saveOffsetAfterDuration,
-        new ShoppingCartHandler());
+        new ShoppingCartHandler())
+            .withSaveOffsetAfterEnvelopes(saveOffsetAfterEnvelopes)
+            .withSaveOffsetAfterDuration(saveOffsetAfterDuration);
     //#atLeastOnce
 
   }
@@ -130,9 +130,9 @@ public interface CassandraProjectionDocExample {
       return CassandraProjection.atLeastOnce(
         ProjectionId.of("shopping-carts", tag),
         sourceProvider(tag),
-        saveOffsetAfterEnvelopes,
-        saveOffsetAfterDuration,
-        new ShoppingCartHandler());
+        new ShoppingCartHandler())
+              .withSaveOffsetAfterEnvelopes(saveOffsetAfterEnvelopes)
+              .withSaveOffsetAfterDuration(saveOffsetAfterDuration);
     }
     //#running-projection
 
@@ -168,8 +168,6 @@ public interface CassandraProjectionDocExample {
             CassandraProjection.atLeastOnce(
                     ProjectionId.of("shopping-carts", "carts-1"),
                     sourceProvider,
-                    saveOffsetAfterEnvelopes,
-                    saveOffsetAfterDuration,
                     new ShoppingCartHandler()
             ).withSettings(
                     ProjectionSettings.create(system)
@@ -178,7 +176,9 @@ public interface CassandraProjectionDocExample {
                                     Duration.ofSeconds(60), /*maxBackoff*/
                                     0.5 /*randomFactor*/
                             )
-            );
+            )
+            .withSaveOffsetAfterEnvelopes(saveOffsetAfterEnvelopes)
+            .withSaveOffsetAfterDuration(saveOffsetAfterDuration);
     //#projection-settings
 
   }

--- a/examples/src/test/scala/akka/projection/cassandra/scaladsl/WordCountDocExampleSpec.scala
+++ b/examples/src/test/scala/akka/projection/cassandra/scaladsl/WordCountDocExampleSpec.scala
@@ -93,12 +93,9 @@ class WordCountDocExampleSpec
       //#projection
       val projection =
         CassandraProjection
-          .atLeastOnce[Long, WordEnvelope](
-            projectionId,
-            new WordSource,
-            saveOffsetAfterEnvelopes = 1,
-            saveOffsetAfterDuration = Duration.Zero,
-            new WordCountHandler(projectionId, repository))
+          .atLeastOnce[Long, WordEnvelope](projectionId, new WordSource, new WordCountHandler(projectionId, repository))
+          .withSaveOffsetAfterEnvelopes(1)
+          .withSaveOffsetAfterDuration(Duration.Zero)
       //#projection
 
       runAndAssert(projection)
@@ -113,12 +110,9 @@ class WordCountDocExampleSpec
 
       val projection =
         CassandraProjection
-          .atLeastOnce[Long, WordEnvelope](
-            projectionId,
-            new WordSource,
-            saveOffsetAfterEnvelopes = 1,
-            saveOffsetAfterDuration = Duration.Zero,
-            handler)
+          .atLeastOnce[Long, WordEnvelope](projectionId, new WordSource, handler)
+          .withSaveOffsetAfterEnvelopes(1)
+          .withSaveOffsetAfterDuration(Duration.Zero)
 
       runAndAssert(projection)
     }

--- a/examples/src/test/scala/docs/cassandra/CassandraProjectionDocExample.scala
+++ b/examples/src/test/scala/docs/cassandra/CassandraProjectionDocExample.scala
@@ -71,12 +71,13 @@ object CassandraProjectionDocExample {
   object IllustrateAtLeastOnce {
     //#atLeastOnce
     val projection =
-      CassandraProjection.atLeastOnce(
-        projectionId = ProjectionId("shopping-carts", "carts-1"),
-        sourceProvider,
-        saveOffsetAfterEnvelopes = 100,
-        saveOffsetAfterDuration = 500.millis,
-        handler = new ShoppingCartHandler)
+      CassandraProjection
+        .atLeastOnce(
+          projectionId = ProjectionId("shopping-carts", "carts-1"),
+          sourceProvider,
+          handler = new ShoppingCartHandler)
+        .withSaveOffsetAfterEnvelopes(100)
+        .withSaveOffsetAfterDuration(500.millis)
     //#atLeastOnce
   }
 
@@ -103,12 +104,13 @@ object CassandraProjectionDocExample {
 
     //#running-projection
     def projection(tag: String) =
-      CassandraProjection.atLeastOnce(
-        projectionId = ProjectionId("shopping-carts", tag),
-        sourceProvider(tag),
-        saveOffsetAfterEnvelopes = 100,
-        saveOffsetAfterDuration = 500.millis,
-        handler = new ShoppingCartHandler)
+      CassandraProjection
+        .atLeastOnce(
+          projectionId = ProjectionId("shopping-carts", tag),
+          sourceProvider(tag),
+          handler = new ShoppingCartHandler)
+        .withSaveOffsetAfterEnvelopes(100)
+        .withSaveOffsetAfterDuration(500.millis)
     //#running-projection
 
     //#running-with-daemon-process
@@ -129,11 +131,11 @@ object CassandraProjectionDocExample {
         .atLeastOnce(
           projectionId = ProjectionId("shopping-carts", "carts-1"),
           sourceProvider,
-          saveOffsetAfterEnvelopes = 100,
-          saveOffsetAfterDuration = 500.millis,
           handler = new ShoppingCartHandler)
         .withSettings(ProjectionSettings(system)
           .withBackoff(minBackoff = 10.seconds, maxBackoff = 60.seconds, randomFactor = 0.5))
+        .withSaveOffsetAfterEnvelopes(100)
+        .withSaveOffsetAfterDuration(500.millis)
     //#projection-settings
 
   }


### PR DESCRIPTION
This PR went down a rabbit hole. Initially I was just working on #59 to extract atLeastOnce parameters to configuration, but that required many internal changes.

I'm creating a draft PR first for guidance on the implementation, before polishing it.

* Create `AtLeastOnceSettings` that can be provided programmatically or through typesafe config
* Create `AtLeastOnce*` Cassandra Projection implementations that encapsulate their own "composed source logic" (instead of putting it all in one `CassandraProjectionImpl`.
* Add fluent API for config for `AtLeastOnceCassandraProjection` to replace atLeastOnce params.
