### PR TITLE
adjust default recovery-strategy retries

### DIFF
--- a/akka-projection-core/src/main/resources/reference.conf
+++ b/akka-projection-core/src/main/resources/reference.conf
@@ -23,10 +23,10 @@ akka.projection {
 
     # The Number of times to retry handler function
     # Only applicable to `retry-and-fail` and `retry-and-skip` recovery strategies
-    retries = 1
+    retries = 5
 
     # Delay between retry attempts
     # Only applicable to `retry-and-fail` and `retry-and-skip` recovery strategies
-    retry-delay = 0 s
+    retry-delay = 1 s
   }
 }


### PR DESCRIPTION
* so that it's possible to only configure the strategy to some
  retry strategy and still have a meaningful behavior

Follow up on https://github.com/akka/akka-projection/pull/176
