### PR TITLE
make Cassandra keyspace, table and config path configurable

### DIFF
--- a/akka-projection-cassandra/src/main/resources/reference.conf
+++ b/akka-projection-cassandra/src/main/resources/reference.conf
@@ -3,25 +3,35 @@
 
 //#config
 akka.projection.cassandra {
-  # The implementation of `akka.stream.alpakka.cassandra.CqlSessionProvider`
-  # used for creating the `CqlSession`.
-  # It may optionally have a constructor with an `ClassicActorSystemProvider` and `Config` parameters.
-  session-provider = "akka.stream.alpakka.cassandra.DefaultSessionProvider"
 
-  # Configure Akka Discovery by setting a service name
-  service-discovery {
-    name = ""
-    lookup-timeout = 1 s
+  session-config-path = "akka.projection.cassandra.session-config"
+
+  session-config {
+    # The implementation of `akka.stream.alpakka.cassandra.CqlSessionProvider`
+    # used for creating the `CqlSession`.
+    # It may optionally have a constructor with an `ClassicActorSystemProvider` and `Config` parameters.
+    session-provider = "akka.stream.alpakka.cassandra.DefaultSessionProvider"
+
+    # Configure Akka Discovery by setting a service name
+    service-discovery {
+      name = ""
+      lookup-timeout = 1 s
+    }
+
+    # The ExecutionContext to use for the session tasks and future composition.
+    session-dispatcher = "akka.actor.default-dispatcher"
+
+    # Full config path to the Datastax Java driver's configuration section.
+    # When connecting to more than one Cassandra cluster different session configuration can be
+    # defined with this property.
+    # See https://docs.datastax.com/en/developer/java-driver/latest/manual/core/configuration/#quick-overview
+    # and https://docs.datastax.com/en/developer/java-driver/latest/manual/core/configuration/reference/
+    datastax-java-driver-config = "datastax-java-driver"
   }
 
-  # The ExecutionContext to use for the session tasks and future composition.
-  session-dispatcher = "akka.actor.default-dispatcher"
-
-  # Full config path to the Datastax Java driver's configuration section.
-  # When connecting to more than one Cassandra cluster different session configuration can be
-  # defined with this property.
-  # See https://docs.datastax.com/en/developer/java-driver/latest/manual/core/configuration/#quick-overview
-  # and https://docs.datastax.com/en/developer/java-driver/latest/manual/core/configuration/reference/
-  datastax-java-driver-config = "datastax-java-driver"
+  offset-store {
+    keyspace = "akka_projection"
+    table = "offset_store"
+  }
 }
 //#config

--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraOffsetStore.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraOffsetStore.scala
@@ -29,7 +29,8 @@ import akka.stream.alpakka.cassandra.scaladsl.CassandraSessionRegistry
 
   private implicit val executionContext: ExecutionContext = system.executionContext
   private val cassandraSettings = CassandraSettings(system)
-  val session: CassandraSession = CassandraSessionRegistry(system).sessionFor(cassandraSettings.sessionConfigPath)
+  private val session: CassandraSession =
+    CassandraSessionRegistry(system).sessionFor(cassandraSettings.sessionConfigPath)
 
   val keyspace: String = cassandraSettings.keyspace
   val table: String = cassandraSettings.table

--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraOffsetStore.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraOffsetStore.scala
@@ -11,28 +11,32 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import akka.Done
+import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
 import akka.projection.MergeableOffset
 import akka.projection.ProjectionId
 import akka.projection.internal.OffsetSerialization
 import akka.projection.internal.OffsetSerialization.SingleOffset
 import akka.stream.alpakka.cassandra.scaladsl.CassandraSession
+import akka.stream.alpakka.cassandra.scaladsl.CassandraSessionRegistry
 
 /**
  * INTERNAL API
  */
-@InternalApi private[akka] class CassandraOffsetStore(session: CassandraSession, clock: Clock)(
-    implicit ec: ExecutionContext) {
+@InternalApi private[akka] class CassandraOffsetStore(system: ActorSystem[_], clock: Clock) {
   import OffsetSerialization.fromStorageRepresentation
   import OffsetSerialization.toStorageRepresentation
 
-  // FIXME make keyspace and table names configurable
-  val keyspace = "akka_projection"
-  val table = "offset_store"
-  val cassandraPartitions = 5
+  private implicit val executionContext: ExecutionContext = system.executionContext
+  private val cassandraSettings = CassandraSettings(system)
+  val session: CassandraSession = CassandraSessionRegistry(system).sessionFor(cassandraSettings.sessionConfigPath)
 
-  def this(session: CassandraSession)(implicit ec: ExecutionContext) =
-    this(session, Clock.systemUTC())
+  val keyspace: String = cassandraSettings.keyspace
+  val table: String = cassandraSettings.table
+  private val cassandraPartitions = 5
+
+  def this(system: ActorSystem[_]) =
+    this(system, Clock.systemUTC())
 
   def readOffset[Offset](projectionId: ProjectionId): Future[Option[Offset]] = {
     val partition = idToPartition(projectionId)

--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraSettings.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraSettings.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.cassandra.internal
+
+import akka.actor.typed.ActorSystem
+import akka.annotation.InternalApi
+import com.typesafe.config.Config
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[projection] case class CassandraSettings(config: Config) {
+  val keyspace: String = config.getString("offset-store.keyspace")
+  val table: String = config.getString("offset-store.table")
+  val sessionConfigPath: String = config.getString("session-config-path")
+}
+
+/**
+ * INTERNAL API
+ */
+@akka.annotation.InternalApi
+private[projection] object CassandraSettings {
+
+  def apply(system: ActorSystem[_]): CassandraSettings =
+    CassandraSettings(system.classicSystem.settings.config.getConfig("akka.projection.cassandra"))
+}

--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraSettings.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraSettings.scala
@@ -25,5 +25,5 @@ private[projection] case class CassandraSettings(config: Config) {
 private[projection] object CassandraSettings {
 
   def apply(system: ActorSystem[_]): CassandraSettings =
-    CassandraSettings(system.classicSystem.settings.config.getConfig("akka.projection.cassandra"))
+    CassandraSettings(system.settings.config.getConfig("akka.projection.cassandra"))
 }

--- a/akka-projection-cassandra/src/test/java/akka/projection/cassandra/CassandraProjectionTest.java
+++ b/akka-projection-cassandra/src/test/java/akka/projection/cassandra/CassandraProjectionTest.java
@@ -46,7 +46,7 @@ public class CassandraProjectionTest extends JUnitSuite {
   @BeforeClass
   public static void beforeAll() throws Exception {
     offsetStore = new CassandraOffsetStore(testKit.system());
-    session = new CassandraSession(offsetStore.session());
+    session =  CassandraSessionRegistry.get(testKit.system()).sessionFor("akka.projection.cassandra.session-config");
     Await.result(offsetStore.createKeyspaceAndTable(), scala.concurrent.duration.Duration.create(10, TimeUnit.SECONDS));
   }
 

--- a/akka-projection-cassandra/src/test/java/akka/projection/cassandra/CassandraProjectionTest.java
+++ b/akka-projection-cassandra/src/test/java/akka/projection/cassandra/CassandraProjectionTest.java
@@ -45,8 +45,8 @@ public class CassandraProjectionTest extends JUnitSuite {
 
   @BeforeClass
   public static void beforeAll() throws Exception {
-    session = CassandraSessionRegistry.get(testKit.system()).sessionFor("akka.projection.cassandra");
-    offsetStore = new CassandraOffsetStore(session.delegate(), testKit.system().executionContext());
+    offsetStore = new CassandraOffsetStore(testKit.system());
+    session = new CassandraSession(offsetStore.session());
     Await.result(offsetStore.createKeyspaceAndTable(), scala.concurrent.duration.Duration.create(10, TimeUnit.SECONDS));
   }
 

--- a/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraOffsetStoreSpec.scala
+++ b/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraOffsetStoreSpec.scala
@@ -21,7 +21,6 @@ import akka.persistence.query.TimeBasedUUID
 import akka.projection.ProjectionId
 import akka.projection.cassandra.internal.CassandraOffsetStore
 import akka.projection.testkit.internal.TestClock
-import akka.stream.alpakka.cassandra.scaladsl.CassandraSessionRegistry
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class CassandraOffsetStoreSpec
@@ -29,13 +28,11 @@ class CassandraOffsetStoreSpec
     with AnyWordSpecLike
     with LogCapturing {
 
-  private val session = CassandraSessionRegistry(system).sessionFor("akka.projection.cassandra")
-  private implicit val ec: ExecutionContext = system.executionContext
-
   // test clock for testing of the `last_updated` Instant
   private val clock = new TestClock
-
-  private val offsetStore = new CassandraOffsetStore(session, clock)
+  private val offsetStore = new CassandraOffsetStore(system, clock)
+  private val session = offsetStore.session
+  private implicit val ec: ExecutionContext = system.executionContext
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()

--- a/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraOffsetStoreSpec.scala
+++ b/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraOffsetStoreSpec.scala
@@ -21,6 +21,7 @@ import akka.persistence.query.TimeBasedUUID
 import akka.projection.ProjectionId
 import akka.projection.cassandra.internal.CassandraOffsetStore
 import akka.projection.testkit.internal.TestClock
+import akka.stream.alpakka.cassandra.scaladsl.CassandraSessionRegistry
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class CassandraOffsetStoreSpec
@@ -31,7 +32,7 @@ class CassandraOffsetStoreSpec
   // test clock for testing of the `last_updated` Instant
   private val clock = new TestClock
   private val offsetStore = new CassandraOffsetStore(system, clock)
-  private val session = offsetStore.session
+  private val session = CassandraSessionRegistry(system).sessionFor("akka.projection.cassandra.session-config")
   private implicit val ec: ExecutionContext = system.executionContext
 
   override protected def beforeAll(): Unit = {

--- a/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
+++ b/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
@@ -33,6 +33,7 @@ import akka.projection.scaladsl.Handler
 import akka.projection.scaladsl.SourceProvider
 import akka.projection.testkit.scaladsl.ProjectionTestKit
 import akka.stream.alpakka.cassandra.scaladsl.CassandraSession
+import akka.stream.alpakka.cassandra.scaladsl.CassandraSessionRegistry
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.TestPublisher
 import akka.stream.testkit.TestSubscriber
@@ -127,7 +128,7 @@ class CassandraProjectionSpec
 
   private implicit val ec: ExecutionContext = system.executionContext
   private val offsetStore = new CassandraOffsetStore(system)
-  private val session = offsetStore.session
+  private val session = CassandraSessionRegistry(system).sessionFor("akka.projection.cassandra.session-config")
   private val repository = new TestRepository(session)
   private val projectionTestKit = new ProjectionTestKit(testKit)
 

--- a/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
+++ b/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
@@ -33,7 +33,6 @@ import akka.projection.scaladsl.Handler
 import akka.projection.scaladsl.SourceProvider
 import akka.projection.testkit.scaladsl.ProjectionTestKit
 import akka.stream.alpakka.cassandra.scaladsl.CassandraSession
-import akka.stream.alpakka.cassandra.scaladsl.CassandraSessionRegistry
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.TestPublisher
 import akka.stream.testkit.TestSubscriber
@@ -126,9 +125,9 @@ class CassandraProjectionSpec
 
   import CassandraProjectionSpec._
 
-  private val session = CassandraSessionRegistry(system).sessionFor("akka.projection.cassandra")
   private implicit val ec: ExecutionContext = system.executionContext
-  private val offsetStore = new CassandraOffsetStore(session)
+  private val offsetStore = new CassandraOffsetStore(system)
+  private val session = offsetStore.session
   private val repository = new TestRepository(session)
   private val projectionTestKit = new ProjectionTestKit(testKit)
 

--- a/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/ContainerSessionProvider.scala
+++ b/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/ContainerSessionProvider.scala
@@ -49,6 +49,6 @@ object ContainerSessionProvider {
       ""
     else
       """
-      akka.projection.cassandra.session-provider = "akka.projection.cassandra.ContainerSessionProvider"
+      akka.projection.cassandra.session-config.session-provider = "akka.projection.cassandra.ContainerSessionProvider"
       """
 }

--- a/akka-projection-kafka/src/test/scala/akka/projection/kafka/integration/KafkaToSlickIntegrationSpec.scala
+++ b/akka-projection-kafka/src/test/scala/akka/projection/kafka/integration/KafkaToSlickIntegrationSpec.scala
@@ -26,6 +26,7 @@ import akka.projection.slick.SlickHandler
 import akka.projection.slick.SlickProjection
 import akka.projection.slick.SlickProjectionSpec
 import akka.projection.slick.internal.SlickOffsetStore
+import akka.projection.slick.internal.SlickSettings
 import akka.stream.scaladsl.Source
 import com.typesafe.config.ConfigFactory
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -117,8 +118,8 @@ class KafkaToSlickIntegrationSpec extends KafkaSpecBase(ConfigFactory.load().wit
   override implicit def patienceConfig: PatienceConfig =
     PatienceConfig(timeout = Span(30, Seconds), interval = Span(500, Milliseconds))
 
-  val dbConfig: DatabaseConfig[H2Profile] = DatabaseConfig.forConfig("akka.projection.slick", config)
-  val offsetStore = new SlickOffsetStore(dbConfig.db, dbConfig.profile)
+  val dbConfig: DatabaseConfig[H2Profile] = DatabaseConfig.forConfig(SlickSettings.configPath, config)
+  val offsetStore = new SlickOffsetStore(dbConfig.db, dbConfig.profile, SlickSettings(system.toTyped))
   val repository = new EventTypeCountRepository(dbConfig)
 
   override protected def beforeAll(): Unit = {

--- a/akka-projection-slick/src/main/resources/reference.conf
+++ b/akka-projection-slick/src/main/resources/reference.conf
@@ -14,4 +14,11 @@ akka.projection.slick = {
     # connectionPool = disabled
     # keepAliveConnection = true
   }
+
+  offset-store {
+    # set this to your database schema if applicable, empty by default
+    schema = ""
+    # the database talbe name for the offset store
+    table = "AKKA_PROJECTION_OFFSET_STORE"
+  }
 }

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickOffsetStore.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickOffsetStore.scala
@@ -24,6 +24,7 @@ import slick.jdbc.JdbcProfile
 @InternalApi private[akka] class SlickOffsetStore[P <: JdbcProfile](
     val db: P#Backend#Database,
     val profile: P,
+    slickSettings: SlickSettings,
     clock: Clock) {
   import OffsetSerialization.MultipleOffsets
   import OffsetSerialization.SingleOffset
@@ -31,8 +32,8 @@ import slick.jdbc.JdbcProfile
   import OffsetSerialization.toStorageRepresentation
   import profile.api._
 
-  def this(db: P#Backend#Database, profile: P) =
-    this(db, profile, Clock.systemUTC())
+  def this(db: P#Backend#Database, profile: P, slickSettings: SlickSettings) =
+    this(db, profile, slickSettings, Clock.systemUTC())
 
   def readOffset[Offset](projectionId: ProjectionId)(implicit ec: ExecutionContext): Future[Option[Offset]] = {
     val action = offsetTable.filter(_.projectionName === projectionId.name).result.map { maybeRow =>
@@ -65,7 +66,7 @@ import slick.jdbc.JdbcProfile
     }
   }
 
-  class OffsetStoreTable(tag: Tag) extends Table[OffsetRow](tag, "AKKA_PROJECTION_OFFSET_STORE") {
+  class OffsetStoreTable(tag: Tag) extends Table[OffsetRow](tag, slickSettings.schema, slickSettings.table) {
 
     def projectionName = column[String]("PROJECTION_NAME", O.Length(255, varying = false))
     def projectionKey = column[String]("PROJECTION_KEY", O.Length(255, varying = false))

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
@@ -111,9 +111,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
    */
   @InternalApi
   override private[projection] def run()(implicit system: ActorSystem[_]): RunningProjection =
-    new InternalProjectionState(
-      offsetStore = new SlickOffsetStore(databaseConfig.db, databaseConfig.profile, SlickSettings(system)),
-      settings = settingsOrDefaults).newRunningInstance()
+    new InternalProjectionState(settingsOrDefaults).newRunningInstance()
 
   /**
    * INTERNAL API
@@ -122,9 +120,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
    * This is mainly intended to be used by the TestKit allowing it to attach a TestSink to it.
    */
   override private[projection] def mappedSource()(implicit system: ActorSystem[_]): Source[Done, _] =
-    new InternalProjectionState(
-      offsetStore = new SlickOffsetStore(databaseConfig.db, databaseConfig.profile, SlickSettings(system)),
-      settings = settingsOrDefaults).mappedSource()
+    new InternalProjectionState(settingsOrDefaults).mappedSource()
 
   /*
    * Build the final ProjectionSettings to use, if currently set to None fallback to values in config file
@@ -137,8 +133,9 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
    * This internal class will hold the KillSwitch that is needed
    * when building the mappedSource and when running the projection (to stop)
    */
-  private class InternalProjectionState(offsetStore: SlickOffsetStore[P], settings: ProjectionSettings)(
-      implicit system: ActorSystem[_]) {
+  private class InternalProjectionState(settings: ProjectionSettings)(implicit system: ActorSystem[_]) {
+
+    private val offsetStore = createOffsetStore()
 
     private val killSwitch = KillSwitches.shared(projectionId.id)
 
@@ -257,8 +254,10 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
     }
   }
 
+  private def createOffsetStore()(implicit system: ActorSystem[_]) =
+    new SlickOffsetStore(databaseConfig.db, databaseConfig.profile, SlickSettings(system))
+
   override def createOffsetTableIfNotExists()(implicit system: ActorSystem[_]): Future[Done] = {
-    val offsetStore = new SlickOffsetStore(databaseConfig.db, databaseConfig.profile, SlickSettings(system))
-    offsetStore.createIfNotExists
+    createOffsetStore().createIfNotExists
   }
 }

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
@@ -112,7 +112,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
   @InternalApi
   override private[projection] def run()(implicit system: ActorSystem[_]): RunningProjection =
     new InternalProjectionState(
-      offsetStore = new SlickOffsetStore(databaseConfig.db, databaseConfig.profile),
+      offsetStore = new SlickOffsetStore(databaseConfig.db, databaseConfig.profile, SlickSettings(system)),
       settings = settingsOrDefaults).newRunningInstance()
 
   /**
@@ -123,7 +123,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
    */
   override private[projection] def mappedSource()(implicit system: ActorSystem[_]): Source[Done, _] =
     new InternalProjectionState(
-      offsetStore = new SlickOffsetStore(databaseConfig.db, databaseConfig.profile),
+      offsetStore = new SlickOffsetStore(databaseConfig.db, databaseConfig.profile, SlickSettings(system)),
       settings = settingsOrDefaults).mappedSource()
 
   /*
@@ -258,7 +258,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
   }
 
   override def createOffsetTableIfNotExists()(implicit system: ActorSystem[_]): Future[Done] = {
-    val offsetStore = new SlickOffsetStore(databaseConfig.db, databaseConfig.profile)
+    val offsetStore = new SlickOffsetStore(databaseConfig.db, databaseConfig.profile, SlickSettings(system))
     offsetStore.createIfNotExists
   }
 }

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickSettings.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickSettings.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.slick.internal
+
+import akka.actor.typed.ActorSystem
+import akka.annotation.InternalApi
+import com.typesafe.config.Config
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[projection] case class SlickSettings(config: Config) {
+
+  def schema: Option[String] =
+    Option(config.getString("offset-store.schema")).filterNot(_.trim.isEmpty)
+  def table: String = config.getString("offset-store.table")
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[projection] object SlickSettings {
+
+  val configPath = "akka.projection.slick"
+
+  def apply(system: ActorSystem[_]): SlickSettings =
+    SlickSettings(system.classicSystem.settings.config.getConfig(configPath))
+
+}

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickSettings.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickSettings.scala
@@ -14,9 +14,9 @@ import com.typesafe.config.Config
 @InternalApi
 private[projection] case class SlickSettings(config: Config) {
 
-  def schema: Option[String] =
+  val schema: Option[String] =
     Option(config.getString("offset-store.schema")).filterNot(_.trim.isEmpty)
-  def table: String = config.getString("offset-store.table")
+  val table: String = config.getString("offset-store.table")
 }
 
 /**

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickSettings.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickSettings.scala
@@ -28,6 +28,6 @@ private[projection] object SlickSettings {
   val configPath = "akka.projection.slick"
 
   def apply(system: ActorSystem[_]): SlickSettings =
-    SlickSettings(system.classicSystem.settings.config.getConfig(configPath))
+    SlickSettings(system.settings.config.getConfig(configPath))
 
 }

--- a/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
+++ b/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
@@ -46,13 +46,18 @@ object SlickProjectionSpec {
 
          profile = "slick.jdbc.H2Profile$"
 
-         # TODO: configure connection pool and slick async executor
-         db = {
-          url = "jdbc:h2:mem:test1"
-          driver = org.h2.Driver
-          connectionPool = disabled
-          keepAliveConnection = true
-         }
+          # TODO: configure connection pool and slick async executor
+          db = {
+            url = "jdbc:h2:mem:test1"
+            driver = org.h2.Driver
+            connectionPool = disabled
+            keepAliveConnection = true
+          }
+         
+          offset-store {
+            schema = ""
+            table = "AKKA_PROJECTION_OFFSET_STORE"
+          }
        }
       }
       """)

--- a/akka-projection-slick/src/test/scala/akka/projection/slick/SlickSpec.scala
+++ b/akka-projection-slick/src/test/scala/akka/projection/slick/SlickSpec.scala
@@ -10,6 +10,7 @@ import scala.concurrent.duration._
 import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.projection.slick.internal.SlickOffsetStore
+import akka.projection.slick.internal.SlickSettings
 import akka.projection.testkit.scaladsl.ProjectionTestKit
 import com.typesafe.config.Config
 import slick.basic.DatabaseConfig
@@ -17,9 +18,9 @@ import slick.jdbc.H2Profile
 
 abstract class SlickSpec(config: Config) extends ScalaTestWithActorTestKit(config) with LogCapturing {
 
-  val dbConfig: DatabaseConfig[H2Profile] = DatabaseConfig.forConfig("akka.projection.slick", config)
+  val dbConfig: DatabaseConfig[H2Profile] = DatabaseConfig.forConfig(SlickSettings.configPath, config)
 
-  val offsetStore = new SlickOffsetStore(dbConfig.db, dbConfig.profile)
+  val offsetStore = new SlickOffsetStore(dbConfig.db, dbConfig.profile, SlickSettings(system))
 
   val projectionTestKit = new ProjectionTestKit(testKit)
 

--- a/akka-projection-testkit/src/test/scala/akka/projection/testkit/scaladsl/ProjectionTestKitSpec.scala
+++ b/akka-projection-testkit/src/test/scala/akka/projection/testkit/scaladsl/ProjectionTestKitSpec.scala
@@ -21,7 +21,6 @@ import akka.stream.KillSwitches
 import akka.stream.SharedKillSwitch
 import akka.stream.scaladsl.DelayStrategy
 import akka.stream.scaladsl.Source
-import akka.stream.testkit.scaladsl.TestSink
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.wordspec.AnyWordSpecLike
 

--- a/examples/src/test/scala/akka/projection/cassandra/scaladsl/WordCountDocExampleSpec.scala
+++ b/examples/src/test/scala/akka/projection/cassandra/scaladsl/WordCountDocExampleSpec.scala
@@ -19,7 +19,6 @@ import akka.projection.ProjectionId
 import akka.projection.cassandra.ContainerSessionProvider
 import akka.projection.cassandra.internal.CassandraOffsetStore
 import akka.projection.testkit.scaladsl.ProjectionTestKit
-import akka.stream.alpakka.cassandra.scaladsl.CassandraSessionRegistry
 import docs.cassandra.WordCountDocExample._
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -28,9 +27,9 @@ class WordCountDocExampleSpec
     with AnyWordSpecLike
     with LogCapturing {
 
-  private val session = CassandraSessionRegistry(system).sessionFor("akka.projection.cassandra")
   private implicit val ec: ExecutionContext = system.executionContext
-  private val offsetStore = new CassandraOffsetStore(session)
+  private val offsetStore = new CassandraOffsetStore(system)
+  private val session = offsetStore.session
   private val repository = new CassandraWordCountRepository(session)
   private val projectionTestKit = new ProjectionTestKit(testKit)
 

--- a/examples/src/test/scala/akka/projection/cassandra/scaladsl/WordCountDocExampleSpec.scala
+++ b/examples/src/test/scala/akka/projection/cassandra/scaladsl/WordCountDocExampleSpec.scala
@@ -19,6 +19,7 @@ import akka.projection.ProjectionId
 import akka.projection.cassandra.ContainerSessionProvider
 import akka.projection.cassandra.internal.CassandraOffsetStore
 import akka.projection.testkit.scaladsl.ProjectionTestKit
+import akka.stream.alpakka.cassandra.scaladsl.CassandraSessionRegistry
 import docs.cassandra.WordCountDocExample._
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -29,7 +30,7 @@ class WordCountDocExampleSpec
 
   private implicit val ec: ExecutionContext = system.executionContext
   private val offsetStore = new CassandraOffsetStore(system)
-  private val session = offsetStore.session
+  private val session = CassandraSessionRegistry(system).sessionFor("akka.projection.cassandra.session-config")
   private val repository = new CassandraWordCountRepository(session)
   private val projectionTestKit = new ProjectionTestKit(testKit)
 


### PR DESCRIPTION
References #153 and #154

- [x] Cassandra 
- [x] Slick

On top of #180 