### PR TITLE
Run JDK11 tests with Akka snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,11 @@ jobs:
 
     - stage: test
       env:
-        - AKKA_SNAPSHOT="-Dbuild.akka.version=2.6.5+52-5dc56a6d"
+        - AKKA_SNAPSHOT="-Dbuild.akka.version=2.6.5+95-24f2b2e6"
         - CMD="test"
       name: "Run tests with Scala 2.13 and AdoptOpenJDK 8"
     - env:
+        - AKKA_SNAPSHOT="-Dbuild.akka.version=2.6.5+95-24f2b2e6"
         - JDK="adopt@~1.11-0"
         - _JAVA_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
         - CMD="test"


### PR DESCRIPTION
Apparently we enabled it only for JDK8. 

Took the opportunity to bump the snapshot version as well. 