### PR TITLE
Remove usage of scala 2.13 conversions

### DIFF
--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
@@ -7,10 +7,10 @@ package akka.projection.cassandra.internal
 import java.util.concurrent.CompletionStage
 
 import scala.collection.immutable
+import scala.compat.java8.DurationConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
-import scala.jdk.DurationConverters._
 
 import akka.Done
 import akka.NotUsed

--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/HandlerAdapter.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/HandlerAdapter.scala
@@ -5,7 +5,6 @@
 package akka.projection.cassandra.internal
 
 import scala.collection.immutable
-import scala.jdk.CollectionConverters._
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.Future
 
@@ -13,6 +12,7 @@ import akka.Done
 import akka.annotation.InternalApi
 import akka.projection.javadsl
 import akka.projection.scaladsl
+import akka.util.ccompat.JavaConverters._
 
 /**
  * INTERNAL API: Adapter from javadsl.Handler to scaladsl.Handler

--- a/akka-projection-core/src/main/scala/akka/projection/internal/SourceProviderAdapter.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/SourceProviderAdapter.scala
@@ -8,9 +8,9 @@ import java.util.Optional
 import java.util.concurrent.CompletionStage
 import java.util.function.Supplier
 
+import scala.compat.java8.FutureConverters._
+import scala.compat.java8.OptionConverters._
 import scala.concurrent.Future
-import scala.jdk.FutureConverters._
-import scala.jdk.OptionConverters._
 
 import akka.annotation.InternalApi
 import akka.projection.javadsl
@@ -29,9 +29,9 @@ import akka.stream.scaladsl.Source
     // it _should_ not be used for the blocking operation of getting offsets themselves
     val ec = akka.dispatch.ExecutionContexts.parasitic
     val offsetAdapter = new Supplier[CompletionStage[Optional[Offset]]] {
-      override def get(): CompletionStage[Optional[Offset]] = offset().map(_.toJava)(ec).asJava
+      override def get(): CompletionStage[Optional[Offset]] = offset().map(_.asJava)(ec).toJava
     }
-    delegate.source(offsetAdapter).asScala.map(_.asScala)(ec)
+    delegate.source(offsetAdapter).toScala.map(_.asScala)(ec)
   }
 
   def extractOffset(envelope: Envelope): Offset =

--- a/akka-projection-eventsourced/src/main/scala/akka/projection/eventsourced/javadsl/EventSourcedProvider.scala
+++ b/akka-projection-eventsourced/src/main/scala/akka/projection/eventsourced/javadsl/EventSourcedProvider.scala
@@ -8,9 +8,9 @@ import java.util.Optional
 import java.util.concurrent.CompletionStage
 import java.util.function.Supplier
 
+import scala.compat.java8.FutureConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import scala.jdk.FutureConverters._
 
 import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
@@ -48,12 +48,12 @@ object EventSourcedProvider {
 
     override def source(
         offsetAsync: Supplier[CompletionStage[Optional[Offset]]]): CompletionStage[Source[EventEnvelope[Event], _]] = {
-      val source: Future[Source[EventEnvelope[Event], _]] = offsetAsync.get().asScala.map { offsetOpt =>
+      val source: Future[Source[EventEnvelope[Event], _]] = offsetAsync.get().toScala.map { offsetOpt =>
         eventsByTagQuery
           .eventsByTag(tag, offsetOpt.orElse(NoOffset))
           .map(env => EventEnvelope(env))
       }
-      source.asJava
+      source.toJava
     }
 
     override def extractOffset(envelope: EventEnvelope[Event]): Offset = envelope.offset


### PR DESCRIPTION
We don't cross build yet, but something we will probably want to do. 

I notice that we are using some 2.13 JDK conversions. This PR removes it and fallback to compat-java8 and akka's internal port for collections.