### PR TITLE
abort retries when projection is stopped, #187

### DIFF
--- a/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
+++ b/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
@@ -723,7 +723,7 @@ class CassandraProjectionSpec
           throw TestException(s"Fail $failOnceOnOffset")
         } else if (envelope.offset == alwaysFailOnOffset) {
           stopMessage = failedMessage
-          throw TestException(s"Fail $alwaysFailOnOffset")
+          throw TestException(s"Always Fail $alwaysFailOnOffset")
         } else {
           probe ! envelope.message
           Future.successful(Done)

--- a/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
+++ b/akka-projection-cassandra/src/test/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
@@ -692,7 +692,8 @@ class CassandraProjectionSpec
 
   "CassandraProjection lifecycle" must {
 
-    class LifecycleHandler(probe: ActorRef[String], failOnceOnOffset: Int) extends Handler[Envelope] {
+    class LifecycleHandler(probe: ActorRef[String], failOnceOnOffset: Int = -1, alwaysFailOnOffset: Int = -1)
+        extends Handler[Envelope] {
 
       private var failedOnce = false
       val startMessage = "start"
@@ -720,6 +721,9 @@ class CassandraProjectionSpec
           failedOnce = true
           stopMessage = failedMessage
           throw TestException(s"Fail $failOnceOnOffset")
+        } else if (envelope.offset == alwaysFailOnOffset) {
+          stopMessage = failedMessage
+          throw TestException(s"Fail $alwaysFailOnOffset")
         } else {
           probe ! envelope.message
           Future.successful(Done)
@@ -880,6 +884,34 @@ class CassandraProjectionSpec
       // completed with failure
       handlerProbe.expectMessage(handler.failedMessage)
       handlerProbe.expectNoMessage() // no duplicate stop
+    }
+
+    "be able to stop when retrying" in {
+      val entityId = UUID.randomUUID().toString
+      val projectionId = genRandomProjectionId()
+
+      val handlerProbe = createTestProbe[String]()
+      val handler = new LifecycleHandler(handlerProbe.ref, alwaysFailOnOffset = 4)
+
+      val projection =
+        CassandraProjection
+          .atLeastOnce[Long, Envelope](projectionId, sourceProvider(system, entityId), handler)
+          .withRecoveryStrategy(HandlerRecoveryStrategy.retryAndFail(100, 100.millis))
+          .withSaveOffset(1, Duration.Zero)
+
+      val ref = spawn(ProjectionBehavior(projection))
+
+      handlerProbe.expectMessage(handler.startMessage)
+      handlerProbe.expectMessage("abc")
+      handlerProbe.expectMessage("def")
+      handlerProbe.expectMessage("ghi")
+      // fail 4
+
+      // let it retry for a while
+      Thread.sleep(300)
+
+      ref ! ProjectionBehavior.Stop
+      createTestProbe().expectTerminated(ref)
     }
   }
 

--- a/akka-projection-core/src/main/scala/akka/projection/internal/HandlerRecoveryImpl.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/HandlerRecoveryImpl.scala
@@ -119,8 +119,9 @@ import akka.projection.StatusObserver
 
           case Skip =>
             logger.warning(
-              "Failed to process {}. " +
+              "[{}] Failed to process {}. " +
               "Envelope will be skipped as defined by recovery strategy. Exception: {}",
+              projectionId.id,
               offsetLogParameter,
               err)
             futDone

--- a/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
+++ b/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
@@ -1077,7 +1077,8 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
 
   "SlickProjection lifecycle" must {
 
-    class LifecycleHandler(probe: ActorRef[String], failOnceOnOffset: Int) extends SlickHandler[Envelope] {
+    class LifecycleHandler(probe: ActorRef[String], failOnceOnOffset: Int = -1, alwaysFailOnOffset: Int = -1)
+        extends SlickHandler[Envelope] {
 
       private var failedOnce = false
       val startMessage = "start"
@@ -1105,6 +1106,9 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
           failedOnce = true
           stopMessage = failedMessage
           slick.dbio.DBIO.failed(TestException(s"Fail $failOnceOnOffset"))
+        } else if (envelope.offset == alwaysFailOnOffset) {
+          stopMessage = failedMessage
+          throw TestException(s"Fail $alwaysFailOnOffset")
         } else {
           probe ! envelope.message
           slick.dbio.DBIO.successful(Done)
@@ -1281,6 +1285,34 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
       // completed with failure
       handlerProbe.expectMessage(handler.failedMessage)
       handlerProbe.expectNoMessage() // no duplicate stop
+    }
+
+    "be able to stop when retrying" in {
+      val entityId = UUID.randomUUID().toString
+      val projectionId = genRandomProjectionId()
+
+      val handlerProbe = createTestProbe[String]()
+      val handler = new LifecycleHandler(handlerProbe.ref, alwaysFailOnOffset = 4)
+
+      val projection =
+        SlickProjection
+          .atLeastOnce(projectionId, sourceProvider(system, entityId), dbConfig, handler)
+          .withRecoveryStrategy(HandlerRecoveryStrategy.retryAndFail(100, 100.millis))
+          .withSaveOffset(1, Duration.Zero)
+
+      val ref = spawn(ProjectionBehavior(projection))
+
+      handlerProbe.expectMessage(handler.startMessage)
+      handlerProbe.expectMessage("abc")
+      handlerProbe.expectMessage("def")
+      handlerProbe.expectMessage("ghi")
+      // fail 4
+
+      // let it retry for a while
+      Thread.sleep(300)
+
+      ref ! ProjectionBehavior.Stop
+      createTestProbe().expectTerminated(ref)
     }
   }
 

--- a/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
+++ b/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
@@ -1108,7 +1108,7 @@ class SlickProjectionSpec extends SlickSpec(SlickProjectionSpec.config) with Any
           slick.dbio.DBIO.failed(TestException(s"Fail $failOnceOnOffset"))
         } else if (envelope.offset == alwaysFailOnOffset) {
           stopMessage = failedMessage
-          throw TestException(s"Fail $alwaysFailOnOffset")
+          throw TestException(s"Always Fail $alwaysFailOnOffset")
         } else {
           probe ! envelope.message
           slick.dbio.DBIO.successful(Done)


### PR DESCRIPTION
* otherwise the stream would not be completed by the killSwitch until after all retries
* I considered if the abort mechanism in applyRecovery should abort immediately before
  waiting until the current handler.process (or delay) call had finished (using something like firstCompletedOf),
  but that would be dangerous to have an process call in flight and then a new projection instance is
  started with the same handler instance and thereby causing concurrent calls

References #187
