### PR TITLE
rename StatusObserver.restarted to failed, #194

### DIFF
--- a/akka-projection-core/src/main/scala/akka/projection/Projection.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/Projection.scala
@@ -92,7 +92,7 @@ private[projection] object RunningProjection {
             statusObserver.stopped(projectionId)
           case Failure(exc) =>
             Try(statusObserver.stopped(projectionId))
-            statusObserver.restarted(projectionId, exc)
+            statusObserver.failed(projectionId, exc)
         }
     }
   }

--- a/akka-projection-core/src/main/scala/akka/projection/StatusObserver.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/StatusObserver.scala
@@ -17,9 +17,12 @@ abstract class StatusObserver[-Envelope] {
   def started(projectionId: ProjectionId): Unit
 
   /**
-   * Called when a projection is restarted due to failure.
+   * Called when a projection failed.
+   *
+   * The projection will be restarted unless the projection restart backoff settings
+   * are configured with `max-restarts` limit.
    */
-  def restarted(projectionId: ProjectionId, cause: Throwable): Unit
+  def failed(projectionId: ProjectionId, cause: Throwable): Unit
 
   /**
    * Called when a projection is stopped.

--- a/akka-projection-core/src/main/scala/akka/projection/internal/NoopStatusObserver.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/NoopStatusObserver.scala
@@ -19,7 +19,7 @@ import akka.projection.StatusObserver
 
   def started(projectionId: ProjectionId): Unit = ()
 
-  def restarted(projectionId: ProjectionId, cause: Throwable): Unit = ()
+  def failed(projectionId: ProjectionId, cause: Throwable): Unit = ()
 
   def stopped(projectionId: ProjectionId): Unit = ()
 

--- a/akka-projection-core/src/test/scala/akka/projection/TestStatusObserver.scala
+++ b/akka-projection-core/src/test/scala/akka/projection/TestStatusObserver.scala
@@ -38,7 +38,7 @@ class TestStatusObserver[Envelope](
       probe ! Started
   }
 
-  override def restarted(projectionId: ProjectionId, cause: Throwable): Unit = {
+  override def failed(projectionId: ProjectionId, cause: Throwable): Unit = {
     if (lifecycle)
       probe ! Restarted
   }

--- a/docs/src/main/paradox/management.md
+++ b/docs/src/main/paradox/management.md
@@ -35,7 +35,7 @@ Java
 The status of a `Projection` can be tracked by implementing a @apidoc[StatusObserver] and enable it with 
 `withStatusObserver` before running the `Projection`.
 
-The `StatusObserver` is called when errors occur and envelopes are retried or the projection is restarted.
+The `StatusObserver` is called when errors occur and envelopes are retried or the projection failed (restarted).
 It also has callbacks for processing progress and projection lifecyle.
 
 The intention is that the implementation of the `StatusObserver` would maintain a view that can be accessed


### PR DESCRIPTION

References #194
