### PR TITLE
Upgrade to Akka 2.6.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,9 @@ jobs:
 
     - stage: test
       env:
-        - AKKA_SNAPSHOT="-Dbuild.akka.version=2.6.5+95-24f2b2e6"
         - CMD="test"
       name: "Run tests with Scala 2.13 and AdoptOpenJDK 8"
     - env:
-        - AKKA_SNAPSHOT="-Dbuild.akka.version=2.6.5+95-24f2b2e6"
         - JDK="adopt@~1.11-0"
         - _JAVA_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
         - CMD="test"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   val AlpakkaKafkaVersionInDocs = "2.0"
 
   object Versions {
-    val akka = sys.props.getOrElse("build.akka.version", "2.6.5")
+    val akka = sys.props.getOrElse("build.akka.version", "2.6.6")
     val alpakka = "2.0.0"
     val alpakkaKafka = "2.0.3"
     val slick = "3.3.2"


### PR DESCRIPTION
Upgrades to Akka 2.6.6

This remove the need to use snapshots in the test (workaround for the logging issue).

Not removing the snapshot repository (eg: project/AkkaSnapshotRepository.scala) because this will be useful for running CRON jobs. 