### PR TITLE
MS SQL and Oracle support

### DIFF
--- a/akka-projection-jdbc/src/main/resources/reference.conf
+++ b/akka-projection-jdbc/src/main/resources/reference.conf
@@ -1,7 +1,7 @@
 
 
 akka.projection.jdbc = {
-  dialect = ""
+  dialect = "default-dialect"
 
   blocking-jdbc-dispatcher {
     type = Dispatcher

--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/Dialect.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/Dialect.scala
@@ -14,9 +14,10 @@ private[jdbc] trait Dialect {
   def createTableStatement: String
   def alterTableStatement: String
 
-  def insertOrUpdateStatement: String
   def readOffsetQuery: String
   def clearOffsetStatement: String
+  def insertStatement(): String
+  def updateStatement(): String
 
 }
 
@@ -27,15 +28,24 @@ private[jdbc] trait Dialect {
 @InternalApi
 private[jdbc] object DialectDefaults {
   def readOffsetQuery(table: String) =
-    s"SELECT * FROM $table WHERE PROJECTION_NAME = ?"
+    s"""SELECT * FROM "$table" WHERE "PROJECTION_NAME" = ?"""
 
   def clearOffsetStatement(table: String) =
-    s"DELETE FROM $table WHERE PROJECTION_NAME = ? AND PROJECTION_KEY = ?"
+    s"""DELETE FROM "$table" WHERE "PROJECTION_NAME" = ? AND "PROJECTION_KEY" = ?"""
 
-  def insertOrUpdateStatement(table: String) =
-    s"""MERGE INTO "$table" ("PROJECTION_NAME","PROJECTION_KEY","OFFSET","MANIFEST","MERGEABLE","LAST_UPDATED")  VALUES (?,?,?,?,?,?)"""
+  def insertStatement(table: String): String =
+    s"""INSERT INTO "$table" ("PROJECTION_NAME","PROJECTION_KEY","OFFSET","MANIFEST","MERGEABLE","LAST_UPDATED")  VALUES (?,?,?,?,?,?)"""
 
-  // NOTE: keep this aligned with insertOrUpdateStatement columns
+  def updateStatement(table: String): String =
+    s"""UPDATE "$table" 
+       | SET 
+       |  "OFFSET" = ?,
+       |  "MANIFEST" = ?,
+       |  "MERGEABLE" = ?,
+       |  "LAST_UPDATED" = ?
+       | WHERE "PROJECTION_NAME" = ? AND "PROJECTION_KEY" = ?
+       |""".stripMargin
+
   object InsertIndices {
     val PROJECTION_NAME = 1
     val PROJECTION_KEY = 2
@@ -43,6 +53,17 @@ private[jdbc] object DialectDefaults {
     val MANIFEST = 4
     val MERGEABLE = 5
     val LAST_UPDATED = 6
+  }
+
+  object UpdateIndices {
+    // SET
+    val OFFSET = 1
+    val MANIFEST = 2
+    val MERGEABLE = 3
+    val LAST_UPDATED = 4
+    // WHERE
+    val PROJECTION_NAME = 5
+    val PROJECTION_KEY = 6
   }
 
 }
@@ -59,9 +80,9 @@ private[jdbc] case class H2Dialect(schema: Option[String], tableName: String) ex
 
   override val createTableStatement = s"""
      CREATE TABLE IF NOT EXISTS "$table" (
-      "PROJECTION_NAME" CHAR(255) NOT NULL,
-      "PROJECTION_KEY" CHAR(255) NOT NULL,
-      "OFFSET" CHAR(255) NOT NULL,
+      "PROJECTION_NAME" VARCHAR(255) NOT NULL,
+      "PROJECTION_KEY" VARCHAR(255) NOT NULL,
+      "OFFSET" VARCHAR(255) NOT NULL,
       "MANIFEST" VARCHAR(4) NOT NULL,
       "MERGEABLE" BOOLEAN NOT NULL,
       "LAST_UPDATED" TIMESTAMP(9) WITH TIME ZONE NOT NULL
@@ -76,7 +97,9 @@ private[jdbc] case class H2Dialect(schema: Option[String], tableName: String) ex
 
   override val readOffsetQuery: String = DialectDefaults.readOffsetQuery(table)
 
-  override val insertOrUpdateStatement = DialectDefaults.insertOrUpdateStatement(table)
-
   override val clearOffsetStatement: String = DialectDefaults.clearOffsetStatement(table)
+
+  override def insertStatement(): String = DialectDefaults.insertStatement(table)
+
+  override def updateStatement(): String = DialectDefaults.updateStatement(table)
 }

--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/Dialect.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/Dialect.scala
@@ -162,3 +162,88 @@ private[jdbc] case class MySQLDialect(schema: Option[String], tableName: String)
   override def updateStatement(): String =
     removeQuotes(DialectDefaults.updateStatement(table))
 }
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[jdbc] case class MSSQLServerDialect(schema: Option[String], tableName: String) extends Dialect {
+
+  def this(tableName: String) = this(None, tableName)
+
+  private val table = schema.map(s => s"$s.$tableName").getOrElse(tableName)
+  override val createTableStatements =
+    immutable.Seq(s"""
+      IF  NOT EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID(N'$table') AND type in (N'U'))
+      begin
+      create table "$table" (
+        "PROJECTION_NAME" VARCHAR(255) NOT NULL,
+        "PROJECTION_KEY" VARCHAR(255) NOT NULL,
+        "OFFSET" VARCHAR(255) NOT NULL,
+        "MANIFEST" VARCHAR(4) NOT NULL,
+        "MERGEABLE" BIT NOT NULL,
+        "LAST_UPDATED" DATETIME2 NOT NULL
+        )
+      
+      alter table "$table" add constraint "PK_PROJECTION_ID" primary key("PROJECTION_NAME","PROJECTION_KEY")
+      
+      create index "PROJECTION_NAME_INDEX" on "$table" ("PROJECTION_NAME")
+      end""")
+
+  override val readOffsetQuery: String = DialectDefaults.readOffsetQuery(table)
+
+  override val clearOffsetStatement: String = DialectDefaults.clearOffsetStatement(table)
+
+  override def insertStatement(): String = DialectDefaults.insertStatement(table)
+
+  override def updateStatement(): String = DialectDefaults.updateStatement(table)
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[jdbc] case class OracleServerDialect(schema: Option[String], tableName: String) extends Dialect {
+
+  def this(tableName: String) = this(None, tableName)
+
+  private val table = schema.map(s => s"$s.$tableName").getOrElse(tableName)
+  override val createTableStatements =
+    immutable.Seq(s"""
+     BEGIN
+
+      execute immediate '
+        create table "$table" (
+          "PROJECTION_NAME" VARCHAR2(255) NOT NULL,
+          "PROJECTION_KEY" VARCHAR2(255) NOT NULL,
+          "OFFSET" VARCHAR2(255) NOT NULL,
+          "MANIFEST" VARCHAR2(4) NOT NULL,
+          "MERGEABLE" CHAR(1) NOT NULL check ("MERGEABLE" in (0, 1)),
+          "LAST_UPDATED" TIMESTAMP(9) WITH TIME ZONE NOT NULL)';
+          
+      execute immediate 'alter table "$table" add constraint "PK_PROJECTION_ID" primary key("PROJECTION_NAME","PROJECTION_KEY") ';
+      execute immediate 'create index "PROJECTION_NAME_INDEX" on "$table" ("PROJECTION_NAME") ';
+      
+      EXCEPTION
+          WHEN OTHERS THEN
+            IF SQLCODE = -955 THEN
+              NULL; -- suppresses ORA-00955 exception
+            ELSE
+               RAISE;
+            END IF;
+      END; 
+     """)
+
+  override val readOffsetQuery: String = DialectDefaults.readOffsetQuery(table)
+
+  override val clearOffsetStatement: String = DialectDefaults.clearOffsetStatement(table)
+
+  override def insertStatement(): String = DialectDefaults.insertStatement(table)
+
+  override def updateStatement(): String = DialectDefaults.updateStatement(table)
+}
+
+/*
+
+
+ */

--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcOffsetStore.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcOffsetStore.scala
@@ -42,8 +42,9 @@ private[akka] class JdbcOffsetStore[S <: JdbcSession](
   def createIfNotExists(): Future[Done] = {
     withConnection(jdbcSessionFactory) { conn =>
       tryWithResource(conn.createStatement()) { stmt =>
-        stmt.execute(settings.dialect.createTableStatement)
-        stmt.execute(settings.dialect.alterTableStatement)
+        settings.dialect.createTableStatements.foreach { stmtStr =>
+          stmt.execute(stmtStr)
+        }
         Done
       }
     }

--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcSessionUtil.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcSessionUtil.scala
@@ -48,6 +48,10 @@ object JdbcSessionUtil {
     }
   }
 
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
   private[akka] def withConnection[S <: JdbcSession, Result](jdbcSessionFactory: () => S)(func: Connection => Result)(
       implicit ec: ExecutionContext): Future[Result] = {
     withSession(jdbcSessionFactory) { sess =>

--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcSettings.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcSettings.scala
@@ -31,6 +31,7 @@ private[projection] case class JdbcSettings(config: Config, executionContext: Ex
 
     dialectToLoad match {
       case "mysql-dialect"   => MySQLDialect(schema, table)
+      case "mssql-dialect"   => MSSQLServerDialect(schema, table)
       case "default-dialect" => DefaultDialect(schema, table)
       case _                 => DefaultDialect(schema, table)
     }

--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcSettings.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcSettings.scala
@@ -30,10 +30,9 @@ private[projection] case class JdbcSettings(config: Config, executionContext: Ex
         s"Dialect type not set. Settings 'akka.projection.jdbc.dialect' currently set to [$dialectToLoad]")
 
     dialectToLoad match {
-      case "h2-dialect" => H2Dialect(schema, table)
-      case unknown =>
-        throw new IllegalArgumentException(
-          s"Unknown dialect type: [$unknown]. Check settings 'akka.projection.jdbc.dialect'")
+      case "mysql-dialect"   => MySQLDialect(schema, table)
+      case "default-dialect" => DefaultDialect(schema, table)
+      case _                 => DefaultDialect(schema, table)
     }
   }
 

--- a/akka-projection-jdbc/src/test/resources/container-license-acceptance.txt
+++ b/akka-projection-jdbc/src/test/resources/container-license-acceptance.txt
@@ -1,0 +1,1 @@
+mcr.microsoft.com/mssql/server:2017-CU12

--- a/akka-projection-jdbc/src/test/scala/akka/projection/jdbc/JdbcOffsetStoreSpec.scala
+++ b/akka-projection-jdbc/src/test/scala/akka/projection/jdbc/JdbcOffsetStoreSpec.scala
@@ -10,6 +10,9 @@ import java.time.Instant
 import java.util.UUID
 
 import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 import akka.actor.testkit.typed.scaladsl.LogCapturing
@@ -25,6 +28,8 @@ import akka.projection.jdbc.internal.JdbcSessionUtil.tryWithResource
 import akka.projection.jdbc.internal.JdbcSessionUtil.withConnection
 import akka.projection.jdbc.internal.JdbcSettings
 import akka.projection.testkit.internal.TestClock
+import com.dimafeng.testcontainers.JdbcDatabaseContainer
+import com.dimafeng.testcontainers.PostgreSQLContainer
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import org.scalatest.OptionValues
@@ -37,11 +42,25 @@ object JdbcOffsetStoreSpec {
 
   trait JdbcSpecConfig {
     val name: String
-    val config: Config
-    val jdbcSessionFactory: () => JdbcSession
+    val config: Config = ConfigFactory.parseString("""
+    akka.projection.jdbc = {
+      fetch-size = 10
+      offset-store {
+        schema = ""
+        table = "AKKA_PROJECTION_OFFSET_STORE"
+      }
+      
+      # TODO: configure a connection pool for the tests
+      blocking-jdbc-dispatcher.thread-pool-executor.fixed-pool-size = 5
+    }
+    """)
+    def jdbcSessionFactory(): JdbcSession
+
+    def initContainer(implicit ec: ExecutionContext): Future[Unit]
   }
 
-  private[akka] class PureJdbcSession(connFunc: () => Connection) extends JdbcSession {
+  private[projection] class PureJdbcSession(connFunc: () => Connection) extends JdbcSession {
+
     lazy val conn = connFunc()
     override def withConnection[Result](func: function.Function[Connection, Result]): Result =
       func(conn)
@@ -56,10 +75,11 @@ object JdbcOffsetStoreSpec {
   object H2SpecConfig extends JdbcSpecConfig {
 
     val name = "H2 Database"
-    val config: Config = ConfigFactory.parseString("""
+    override val config: Config =
+      ConfigFactory.parseString("""
     akka.projection.jdbc = {
+      # FIXME: remove this override when dialect is gone
       dialect = "h2-dialect"
-      fetch-size = 10
       offset-store {
         schema = ""
         table = "AKKA_PROJECTION_OFFSET_STORE"
@@ -70,13 +90,60 @@ object JdbcOffsetStoreSpec {
     }
     """)
 
-    val jdbcSessionFactory = () =>
+    def jdbcSessionFactory(): PureJdbcSession =
       new PureJdbcSession(() => {
         Class.forName("org.h2.Driver")
         val c = DriverManager.getConnection("jdbc:h2:mem:offset-store-test;DB_CLOSE_DELAY=-1")
         c.setAutoCommit(false)
         c
       })
+
+    override def initContainer(implicit ec: ExecutionContext): Future[Unit] = Future.successful(())
+  }
+
+  trait ContainerJdbcSpecConfig extends JdbcSpecConfig {
+
+    override val config: Config =
+      ConfigFactory.parseString("""
+    akka.projection.jdbc = {
+      # FIXME: remove this override when dialect is gone
+      dialect = "h2-dialect" 
+      
+      offset-store {
+        schema = ""
+        table = "AKKA_PROJECTION_OFFSET_STORE"
+      }
+      
+      # TODO: configure a connection pool for the tests
+      blocking-jdbc-dispatcher.thread-pool-executor.fixed-pool-size = 5
+    }
+    """)
+
+    def jdbcSessionFactory(): PureJdbcSession =
+      new PureJdbcSession(() => {
+        // this is safe as tests only start after the container is init
+        val container = _container.get
+        Class.forName(container.driverClassName)
+        val c =
+          DriverManager.getConnection(container.jdbcUrl, container.username, container.password)
+        c.setAutoCommit(false)
+        c
+      })
+
+    protected var _container: Option[JdbcDatabaseContainer] = None
+
+  }
+
+  object PostgresSpecConfig extends ContainerJdbcSpecConfig {
+
+    val name = "Postgres Database"
+
+    override def initContainer(implicit ec: ExecutionContext): Future[Unit] =
+      Future.successful {
+        val container = new PostgreSQLContainer
+        _container = Some(container)
+        container.start()
+      }
   }
 }
 
@@ -89,7 +156,7 @@ abstract class JdbcOffsetStoreSpec(specConfig: JdbcSpecConfig)
   override implicit val patienceConfig: PatienceConfig =
     PatienceConfig(timeout = Span(3, Seconds), interval = Span(100, Millis))
 
-  implicit val executionContext = testKit.system.executionContext
+  implicit val executionContext: ExecutionContextExecutor = testKit.system.executionContext
 
   // test clock for testing of the `last_updated` Instant
   private val clock = new TestClock
@@ -99,16 +166,18 @@ abstract class JdbcOffsetStoreSpec(specConfig: JdbcSpecConfig)
   private val dialectLabel = specConfig.name
 
   override protected def beforeAll(): Unit = {
+    // start test container if needed
+    // Note, the H2 test don't run in container and are therefore will run must faster
+    Await.result(specConfig.initContainer, 30.seconds)
+
     // create offset table
     Await.result(offsetStore.createIfNotExists(), 3.seconds)
   }
 
-  override protected def afterAll(): Unit = {}
-
   private def selectLastUpdated(projectionId: ProjectionId): Instant = {
     withConnection(specConfig.jdbcSessionFactory) { conn =>
 
-      val statement = s"SELECT * FROM ${settings.table} WHERE projection_name = ? AND projection_key = ?"
+      val statement = s"""SELECT * FROM "${settings.table}" WHERE "PROJECTION_NAME" = ? AND "PROJECTION_KEY" = ?"""
 
       // init statement in try-with-resource
       tryWithResource(conn.prepareStatement(statement)) { stmt =>
@@ -118,7 +187,7 @@ abstract class JdbcOffsetStoreSpec(specConfig: JdbcSpecConfig)
         // init ResultSet in try-with-resource
         tryWithResource(stmt.executeQuery()) { resultSet =>
 
-          if (resultSet.first()) {
+          if (resultSet.next()) {
             val t = resultSet.getTimestamp(6)
             Instant.ofEpochMilli(t.getTime)
           } else throw new RuntimeException(s"no records found for $projectionId")
@@ -257,7 +326,7 @@ abstract class JdbcOffsetStoreSpec(specConfig: JdbcSpecConfig)
 
       val projectionId = ProjectionId("projection-with-mergeable-offsets", "00")
 
-      val origOffset = MergeableOffset(Map(StringKey("abc") -> 1L, StringKey("def") -> 2L, StringKey("ghi") -> 3L))
+      val origOffset = MergeableOffset(Map(StringKey("abc") -> 1L, StringKey("def") -> 1L, StringKey("ghi") -> 1L))
       withClue("check - save offset") {
         offsetStore.saveOffset(projectionId, origOffset).futureValue
       }
@@ -265,6 +334,31 @@ abstract class JdbcOffsetStoreSpec(specConfig: JdbcSpecConfig)
       withClue("check - read offset") {
         val offset = offsetStore.readOffset[MergeableOffset[StringKey, Long]](projectionId)
         offset.futureValue.value shouldBe origOffset
+      }
+    }
+
+    "add new offsets to MergeableOffset" in {
+      val projectionId = ProjectionId("projection-with-mergeable-offsets-mixed", "00")
+
+      val origOffset = MergeableOffset(Map(StringKey("abc") -> 1L, StringKey("def") -> 1L))
+      withClue("check - save offset") {
+        offsetStore.saveOffset(projectionId, origOffset).futureValue
+      }
+
+      withClue("check - read offset") {
+        val offset = offsetStore.readOffset[MergeableOffset[StringKey, Long]](projectionId)
+        offset.futureValue.value shouldBe origOffset
+      }
+
+      // mix updates and inserts
+      val updatedOffset = MergeableOffset(Map(StringKey("abc") -> 2L, StringKey("def") -> 2L, StringKey("ghi") -> 1L))
+      withClue("check - save offset") {
+        offsetStore.saveOffset(projectionId, updatedOffset).futureValue
+      }
+
+      withClue("check - read offset") {
+        val offset = offsetStore.readOffset[MergeableOffset[StringKey, Long]](projectionId)
+        offset.futureValue.value shouldBe updatedOffset
       }
     }
 
@@ -307,3 +401,4 @@ abstract class JdbcOffsetStoreSpec(specConfig: JdbcSpecConfig)
 }
 
 class H2JdbcOffsetStoreSpec extends JdbcOffsetStoreSpec(JdbcOffsetStoreSpec.H2SpecConfig)
+class PostgresJdbcOffsetStoreSpec extends JdbcOffsetStoreSpec(JdbcOffsetStoreSpec.PostgresSpecConfig)

--- a/akka-projection-jdbc/src/test/scala/akka/projection/jdbc/JdbcOffsetStoreSpec.scala
+++ b/akka-projection-jdbc/src/test/scala/akka/projection/jdbc/JdbcOffsetStoreSpec.scala
@@ -44,7 +44,6 @@ object JdbcOffsetStoreSpec {
     val name: String
     val config: Config = ConfigFactory.parseString("""
     akka.projection.jdbc = {
-      fetch-size = 10
       offset-store {
         schema = ""
         table = "AKKA_PROJECTION_OFFSET_STORE"

--- a/akka-projection-jdbc/src/test/scala/akka/projection/jdbc/JdbcProjectionSpec.scala
+++ b/akka-projection-jdbc/src/test/scala/akka/projection/jdbc/JdbcProjectionSpec.scala
@@ -59,6 +59,7 @@ import org.slf4j.LoggerFactory
 object JdbcProjectionSpec {
   val config: Config = ConfigFactory.parseString("""
     akka.projection.jdbc = {
+      # FIXME: remove this override when dialect is gone
       dialect = "h2-dialect"
       offset-store {
         schema = ""

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickOffsetStore.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickOffsetStore.scala
@@ -80,6 +80,7 @@ import slick.jdbc.JdbcProfile
     def lastUpdated = column[Instant]("LAST_UPDATED")
 
     def pk = primaryKey("PK_PROJECTION_ID", (projectionName, projectionKey))
+    def idx = index("PROJECTION_NAME_INDEX", projectionName)
 
     def * = (projectionName, projectionKey, offset, manifest, mergeable, lastUpdated).mapTo[OffsetRow]
   }

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickOffsetStore.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickOffsetStore.scala
@@ -72,12 +72,13 @@ import slick.jdbc.JdbcProfile
 
   class OffsetStoreTable(tag: Tag) extends Table[OffsetRow](tag, slickSettings.schema, slickSettings.table) {
 
-    def projectionName = column[String]("PROJECTION_NAME", O.Length(255, varying = false))
-    def projectionKey = column[String]("PROJECTION_KEY", O.Length(255, varying = false))
-    def offset = column[String]("OFFSET", O.Length(255, varying = false))
+    def projectionName = column[String]("PROJECTION_NAME", O.Length(255))
+    def projectionKey = column[String]("PROJECTION_KEY", O.Length(255))
+    def offset = column[String]("OFFSET", O.Length(255))
     def manifest = column[String]("MANIFEST", O.Length(4))
     def mergeable = column[Boolean]("MERGEABLE")
     def lastUpdated = column[Instant]("LAST_UPDATED")
+
     def pk = primaryKey("PK_PROJECTION_ID", (projectionName, projectionKey))
 
     def * = (projectionName, projectionKey, offset, manifest, mergeable, lastUpdated).mapTo[OffsetRow]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,6 +55,8 @@ object Dependencies {
 
     val h2Driver = Compile.h2Driver % sbt.Test
     val postgresDriver = "org.postgresql" % "postgresql" % "42.2.12" % sbt.Test
+    val mysqlDriver = "mysql" % "mysql-connector-java" % "8.0.20" % sbt.Test
+
     val logback = "ch.qos.logback" % "logback-classic" % "1.2.3" % sbt.Test
 
     val testContainersScalatest =
@@ -63,6 +65,8 @@ object Dependencies {
       "com.dimafeng" %% "testcontainers-scala-cassandra" % Versions.testContainersScala % sbt.Test
     val postgresContainer =
       "com.dimafeng" %% "testcontainers-scala-postgresql" % Versions.testContainersScala % sbt.Test
+    val mysqlContainer =
+      "com.dimafeng" %% "testcontainers-scala-mysql" % Versions.testContainersScala % sbt.Test
 
     val alpakkaKafkaTestkit = "com.typesafe.akka" %% "akka-stream-kafka-testkit" % Versions.alpakkaKafka % sbt.Test
   }
@@ -101,9 +105,11 @@ object Dependencies {
     deps ++= Seq(
         Compile.akkaPersistenceQuery,
         Test.akkaTypedTestkit,
-        Test.postgresContainer,
-        Test.postgresDriver,
         Test.h2Driver,
+        Test.postgresDriver,
+        Test.postgresContainer,
+        Test.mysqlDriver,
+        Test.mysqlContainer,
         Test.logback)
 
   val slick =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,6 +56,7 @@ object Dependencies {
     val h2Driver = Compile.h2Driver % sbt.Test
     val postgresDriver = "org.postgresql" % "postgresql" % "42.2.12" % sbt.Test
     val mysqlDriver = "mysql" % "mysql-connector-java" % "8.0.20" % sbt.Test
+    val msSQLServerDriver = "com.microsoft.sqlserver" % "mssql-jdbc" % "7.4.1.jre8" % sbt.Test
 
     val logback = "ch.qos.logback" % "logback-classic" % "1.2.3" % sbt.Test
 
@@ -67,6 +68,11 @@ object Dependencies {
       "com.dimafeng" %% "testcontainers-scala-postgresql" % Versions.testContainersScala % sbt.Test
     val mysqlContainer =
       "com.dimafeng" %% "testcontainers-scala-mysql" % Versions.testContainersScala % sbt.Test
+    val msSQLServerContainer =
+    "com.dimafeng" %% "testcontainers-scala-mssqlserver" % Versions.testContainersScala % sbt.Test
+
+    val oracleDbContainer =
+      "com.dimafeng" %% "testcontainers-scala-oracle-xe" % Versions.testContainersScala % sbt.Test
 
     val alpakkaKafkaTestkit = "com.typesafe.akka" %% "akka-stream-kafka-testkit" % Versions.alpakkaKafka % sbt.Test
   }
@@ -110,6 +116,9 @@ object Dependencies {
         Test.postgresContainer,
         Test.mysqlDriver,
         Test.mysqlContainer,
+        Test.msSQLServerDriver,
+        Test.msSQLServerContainer,
+        Test.oracleDbContainer,
         Test.logback)
 
   val slick =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -54,10 +54,15 @@ object Dependencies {
     val junit = "junit" % "junit" % Versions.junit % sbt.Test
 
     val h2Driver = Compile.h2Driver % sbt.Test
+    val postgresDriver = "org.postgresql" % "postgresql" % "42.2.12" % sbt.Test
     val logback = "ch.qos.logback" % "logback-classic" % "1.2.3" % sbt.Test
-    val testContainers = "com.dimafeng" %% "testcontainers-scala-scalatest" % Versions.testContainersScala % sbt.Test
+
+    val testContainersScalatest =
+      "com.dimafeng" %% "testcontainers-scala-scalatest" % Versions.testContainersScala % sbt.Test
     val cassandraContainer =
       "com.dimafeng" %% "testcontainers-scala-cassandra" % Versions.testContainersScala % sbt.Test
+    val postgresContainer =
+      "com.dimafeng" %% "testcontainers-scala-postgresql" % Versions.testContainersScala % sbt.Test
 
     val alpakkaKafkaTestkit = "com.typesafe.akka" %% "akka-stream-kafka-testkit" % Versions.alpakkaKafka % sbt.Test
   }
@@ -93,7 +98,13 @@ object Dependencies {
     deps ++= Seq(Compile.akkaPersistenceQuery)
 
   val jdbc =
-    deps ++= Seq(Compile.akkaPersistenceQuery, Test.akkaTypedTestkit, Test.h2Driver, Test.logback)
+    deps ++= Seq(
+        Compile.akkaPersistenceQuery,
+        Test.akkaTypedTestkit,
+        Test.postgresContainer,
+        Test.postgresDriver,
+        Test.h2Driver,
+        Test.logback)
 
   val slick =
     deps ++= Seq(Compile.slick, Compile.akkaPersistenceQuery, Test.akkaTypedTestkit, Test.h2Driver, Test.logback)
@@ -104,7 +115,7 @@ object Dependencies {
         Compile.akkaPersistenceQuery,
         Test.akkaTypedTestkit,
         Test.logback,
-        Test.testContainers,
+        Test.testContainersScalatest,
         Test.cassandraContainer,
         Test.scalatestJUnit)
 
@@ -116,7 +127,7 @@ object Dependencies {
         Test.akkaStreamTestkit,
         Test.alpakkaKafkaTestkit,
         Test.logback,
-        Test.testContainers,
+        Test.testContainersScalatest,
         Test.scalatestJUnit)
 
   val examples =
@@ -129,6 +140,6 @@ object Dependencies {
         Test.h2Driver,
         Test.akkaTypedTestkit,
         Test.logback,
-        Test.testContainers,
+        Test.testContainersScalatest,
         Test.cassandraContainer)
 }


### PR DESCRIPTION

Draft because on top of #263.
Ready for review otherwise.

The main reason I'm sending this apart is that it may have some legal/license implications. 

1. Oracle driver is not available in Maven Central. We need to download it and add to the `lib` folder. We won't distribute it, so I think it's fine but this need to be confirmed.
1. Microsoft docker image requires a license agreement. It works by adding a file under `src/test/resource`. Again, we won't be distributing it, but needs to be confirmed if that's ok. People checking out the projection will be building it without 'signing' it themselves. 



References #23
