### PR TITLE
support Future based Handler in SlickProjection, #68

### DIFF
--- a/akka-projection-slick/src/main/scala/akka/projection/slick/SlickProjection.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/SlickProjection.scala
@@ -7,6 +7,7 @@ package akka.projection.slick
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag
 
 import akka.Done
@@ -168,6 +169,39 @@ object SlickProjection {
   }
 
   /**
+   * Create a [[akka.projection.Projection]] with at-least-once processing semantics.
+   *
+   * Compared to [[SlickProjection.atLeastOnce]] the [[Handler]] is not storing the projected result in the
+   * database, but is integrating with something else.
+   *
+   * It stores the offset in a relational database table using Slick after the `handler` has processed the envelope.
+   * This means that if the projection is restarted from previously stored offset then some elements may be processed
+   * more than once.
+   *
+   * The offset is stored after a time window, or limited by a number of envelopes, whatever happens first.
+   * This window can be defined with [[AtLeastOnceProjection.withSaveOffset]] of the returned
+   * `AtLeastOnceProjection`. The default settings for the window is defined in configuration
+   * section `akka.projection.at-least-once`.
+   */
+  def atLeastOnceAsync[Offset, Envelope, P <: JdbcProfile: ClassTag](
+      projectionId: ProjectionId,
+      sourceProvider: SourceProvider[Offset, Envelope],
+      databaseConfig: DatabaseConfig[P],
+      handler: () => Handler[Envelope])(implicit system: ActorSystem[_]): AtLeastOnceProjection[Offset, Envelope] = {
+
+    new SlickProjectionImpl(
+      projectionId,
+      sourceProvider,
+      databaseConfig,
+      settingsOpt = None,
+      restartBackoffOpt = None,
+      AtLeastOnce(),
+      SingleHandlerStrategy(handler),
+      NoopStatusObserver,
+      createOffsetStore(databaseConfig))
+  }
+
+  /**
    * Create a [[akka.projection.Projection]] that groups envelopes and calls the `handler` with a group of `Envelopes`.
    * The envelopes are grouped within a time window, or limited by a number of envelopes,
    * whatever happens first. This window can be defined with [[GroupedProjection.withGroup]] of
@@ -239,6 +273,42 @@ object SlickProjection {
       restartBackoffOpt = None,
       ExactlyOnce(),
       GroupedHandlerStrategy(adaptedSlickHandler),
+      NoopStatusObserver,
+      offsetStore)
+  }
+
+  /**
+   * Create a [[akka.projection.Projection]] that groups envelopes and calls the `handler` with a group of `Envelopes`.
+   * The envelopes are grouped within a time window, or limited by a number of envelopes,
+   * whatever happens first. This window can be defined with [[GroupedProjection.withGroup]] of
+   * the returned `GroupedProjection`. The default settings for the window is defined in configuration
+   * section `akka.projection.grouped`.
+   *
+   * Compared to [[SlickProjection.groupedWithin]] the [[Handler]] is not storing the projected result in the
+   * database, but is integrating with something else.
+   *
+   * It stores the offset in  a relational database table using Slick immediately after the `handler` has
+   * processed the envelopes, but that is still with at-least-once processing semantics. This means that
+   * if the projection is restarted from previously stored offset the previous group of envelopes may be
+   * processed more than once.
+   */
+  def groupedWithinAsync[Offset, Envelope, P <: JdbcProfile: ClassTag](
+      projectionId: ProjectionId,
+      sourceProvider: SourceProvider[Offset, Envelope],
+      databaseConfig: DatabaseConfig[P],
+      handler: () => Handler[immutable.Seq[Envelope]])(
+      implicit system: ActorSystem[_]): GroupedProjection[Offset, Envelope] = {
+
+    val offsetStore = createOffsetStore(databaseConfig)
+
+    new SlickProjectionImpl(
+      projectionId,
+      sourceProvider,
+      databaseConfig,
+      settingsOpt = None,
+      restartBackoffOpt = None,
+      AtLeastOnce(afterEnvelopes = Some(1), orAfterDuration = Some(Duration.Zero)),
+      GroupedHandlerStrategy(handler),
       NoopStatusObserver,
       offsetStore)
   }

--- a/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
+++ b/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
@@ -32,6 +32,7 @@ import akka.projection.ProjectionBehavior
 import akka.projection.ProjectionContext
 import akka.projection.ProjectionId
 import akka.projection.TestStatusObserver
+import akka.projection.scaladsl.Handler
 import akka.projection.scaladsl.ProjectionManagement
 import akka.projection.scaladsl.SourceProvider
 import akka.projection.scaladsl.VerifiableSourceProvider
@@ -738,6 +739,40 @@ class SlickProjectionSpec
         handlerProbe.expectMessage(handlerCalled)
       }
     }
+
+    "handle grouped async projection and store offset" in {
+      val entityId = UUID.randomUUID().toString
+      val projectionId = genRandomProjectionId()
+
+      val result = new StringBuffer()
+
+      def handler(): Handler[immutable.Seq[Envelope]] = new Handler[immutable.Seq[Envelope]] {
+        override def process(envelopes: immutable.Seq[Envelope]): Future[Done] = {
+          Future {
+            envelopes.foreach(env => result.append(env.message).append("|"))
+          }.map(_ => Done)
+        }
+      }
+
+      val projection =
+        SlickProjection
+          .groupedWithinAsync(
+            projectionId,
+            sourceProvider = sourceProvider(system, entityId),
+            databaseConfig = dbConfig,
+            handler = () => handler())
+          .withGroup(2, 3.seconds)
+
+      projectionTestKit.run(projection) {
+        withClue("check - all values were concatenated") {
+          result.toString shouldBe "abc|def|ghi|jkl|mno|pqr|"
+        }
+      }
+      withClue("check - all offsets were seen") {
+        val offset = offsetStore.readOffset[Long](projectionId).futureValue.value
+        offset shouldBe 6L
+      }
+    }
   }
 
   "A Slick at-least-once projection" must {
@@ -1122,6 +1157,38 @@ class SlickProjectionSpec
           val concatStr = dbConfig.db.run(repository.findById(entityId)).futureValue.value
           concatStr.text shouldBe "abc|def|jkl|mno|pqr" // `ghi` was skipped
         }
+      }
+    }
+
+    "handle async projection and store offset" in {
+      val entityId = UUID.randomUUID().toString
+      val projectionId = genRandomProjectionId()
+
+      val result = new StringBuffer()
+
+      def handler(): Handler[Envelope] = new Handler[Envelope] {
+        override def process(envelope: Envelope): Future[Done] = {
+          Future {
+            result.append(envelope.message).append("|")
+          }.map(_ => Done)
+        }
+      }
+
+      val projection =
+        SlickProjection.atLeastOnceAsync(
+          projectionId,
+          sourceProvider = sourceProvider(system, entityId),
+          databaseConfig = dbConfig,
+          handler = () => handler())
+
+      projectionTestKit.run(projection) {
+        withClue("check - all values were concatenated") {
+          result.toString shouldBe "abc|def|ghi|jkl|mno|pqr|"
+        }
+      }
+      withClue("check - all offsets were seen") {
+        val offset = offsetStore.readOffset[Long](projectionId).futureValue.value
+        offset shouldBe 6L
       }
     }
 

--- a/docs/src/main/paradox/actor.md
+++ b/docs/src/main/paradox/actor.md
@@ -2,6 +2,9 @@
 
 A good alternative for advanced state management is to implement the handler as an [actor](https://doc.akka.io/docs/akka/current/typed/actors.html).
 
+The following example is using the `CassandraProjection` but the handler and actor would be the same if used
+with `JdbcProjection` or `SlickProjection`. 
+
 An actor `Behavior` for the word count example that was introduced in the section about @ref:[Stateful handler](cassandra.md#stateful-handler):
 
 Scala

--- a/docs/src/main/paradox/flow.md
+++ b/docs/src/main/paradox/flow.md
@@ -3,6 +3,9 @@
 An Akka Streams `FlowWithContext` can be used instead of a handler for processing the envelopes with at-least-once
 semantics.
 
+The following example is using the `CassandraProjection` but the flow would be the same if used
+with `JdbcProjection` or `SlickProjection`.
+
 Scala
 :  @@snip [CassandraProjectionDocExample.scala](/examples/src/test/scala/docs/cassandra/CassandraProjectionDocExample.scala) { #atLeastOnceFlow }
 

--- a/examples/src/test/scala/docs/slick/SlickProjectionDocExample.scala
+++ b/examples/src/test/scala/docs/slick/SlickProjectionDocExample.scala
@@ -13,10 +13,8 @@ import scala.concurrent.ExecutionContext
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.Behaviors
 import akka.persistence.jdbc.query.scaladsl.JdbcReadJournal
-import akka.projection.ProjectionContext
 import akka.projection.eventsourced.EventEnvelope
 import akka.projection.eventsourced.scaladsl.EventSourcedProvider
-import akka.stream.scaladsl.FlowWithContext
 import docs.eventsourced.ShoppingCart
 
 //#projection-imports
@@ -163,33 +161,6 @@ class SlickProjectionDocExample {
           handler = () => new GroupedShoppingCartHandler(repository))
         .withGroup(groupAfterEnvelopes = 20, groupAfterDuration = 500.millis)
     //#grouped
-  }
-
-  object IllustrateAtLeastOnceFlow {
-    //#atLeastOnceFlow
-    val logger = LoggerFactory.getLogger(getClass)
-
-    val flow = FlowWithContext[EventEnvelope[ShoppingCart.Event], ProjectionContext]
-      .map(envelope => envelope.event)
-      .map {
-        case ShoppingCart.CheckedOut(cartId, time) =>
-          logger.info2("Shopping cart {} was checked out at {}", cartId, time)
-          Done
-
-        case otherEvent =>
-          logger.debug2("Shopping cart {} changed by {}", otherEvent.cartId, otherEvent)
-          Done
-      }
-
-    val projection =
-      SlickProjection
-        .atLeastOnceFlow(
-          projectionId = ProjectionId("shopping-carts", "carts-1"),
-          sourceProvider,
-          dbConfig,
-          handler = flow)
-        .withSaveOffset(afterEnvelopes = 100, afterDuration = 500.millis)
-    //#atLeastOnceFlow
   }
 
 }


### PR DESCRIPTION
* also use the jdbc atLeastOnceAsync in the Kafka doc sample

References #68
