### PR TITLE
Scala 2.13.3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import sbt._
 
 object Dependencies {
 
-  val Scala213 = "2.13.2"
+  val Scala213 = "2.13.3"
   val Scala212 = "2.12.11"
   val ScalaVersions = Seq(Scala212, Scala213)
 


### PR DESCRIPTION
2.13.2 had some issues (that was the reason we didn't use that in akka/akka)