### PR TITLE
Extend SlickOffsetStore tests to all supported DBs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ target
 # we don't want to push this file,
 # each contributor must create its own to signal acceptance
 akka-projection-jdbc/src/test/resources/container-license-acceptance.txt
+akka-projection-slick/src/test/resources/container-license-acceptance.txt
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
   - java -version
   # copy mssql license agreement for tests
   - cp container-license-acceptance.txt akka-projection-jdbc/src/test/resources/container-license-acceptance.txt
+  - cp container-license-acceptance.txt akka-projection-slick/src/test/resources/container-license-acceptance.txt
   - sbt -jvm-opts .jvmopts-travis "$AKKA_SNAPSHOT" "$ALPAKKA_KAFKA_SNAPSHOT" "$CMD"
 
 jobs:

--- a/akka-projection-slick/src/test/scala/akka/projection/slick/SlickOffsetStoreSpec.scala
+++ b/akka-projection-slick/src/test/scala/akka/projection/slick/SlickOffsetStoreSpec.scala
@@ -18,9 +18,16 @@ import akka.persistence.query.TimeBasedUUID
 import akka.projection.MergeableOffset
 import akka.projection.ProjectionId
 import akka.projection.StringKey
+import akka.projection.slick.SlickOffsetStoreSpec.SlickSpecConfig
 import akka.projection.slick.internal.SlickOffsetStore
 import akka.projection.slick.internal.SlickSettings
 import akka.projection.testkit.internal.TestClock
+import com.dimafeng.testcontainers.JdbcDatabaseContainer
+import com.dimafeng.testcontainers.MSSQLServerContainer
+import com.dimafeng.testcontainers.MySQLContainer
+import com.dimafeng.testcontainers.OracleContainer
+import com.dimafeng.testcontainers.PostgreSQLContainer
+import com.dimafeng.testcontainers.SingleContainer
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import org.scalatest.OptionValues
@@ -29,31 +36,141 @@ import org.scalatest.time.Seconds
 import org.scalatest.time.Span
 import org.scalatest.wordspec.AnyWordSpecLike
 import slick.basic.DatabaseConfig
-import slick.jdbc.H2Profile
+import slick.jdbc.JdbcProfile
 
 object SlickOffsetStoreSpec {
-  def config: Config = ConfigFactory.parseString("""
+
+  trait SlickSpecConfig {
+    val name: String
+    val baseConfig = ConfigFactory.parseString("""
     akka.projection.slick = {
-
-      profile = "slick.jdbc.H2Profile$"
-
-      # TODO: configure connection pool and slick async executor
-      db = {
-       url = "jdbc:h2:mem:offset-store-test-slick;DB_CLOSE_DELAY=-1"
-       driver = org.h2.Driver
-       connectionPool = disabled
-       keepAliveConnection = true
-      }
-      
       offset-store {
         schema = ""
         table = "AKKA_PROJECTION_OFFSET_STORE"
       }
     }
     """)
+    def config: Config
+    def stopContainer(): Unit
+
+  }
+
+  object H2SpecConfig extends SlickSpecConfig {
+
+    val name = "H2 Database"
+    override def config: Config =
+      baseConfig.withFallback(ConfigFactory.parseString("""
+        akka.projection.slick = {
+           profile = "slick.jdbc.H2Profile$"
+           db = {
+             url = "jdbc:h2:mem:offset-store-test-slick;DB_CLOSE_DELAY=-1"
+             driver = org.h2.Driver
+             connectionPool = disabled
+             keepAliveConnection = true
+           }
+        }
+        """))
+
+    override def stopContainer(): Unit = ()
+  }
+
+  abstract class ContainerJdbcSpecConfig extends SlickSpecConfig {
+
+    def container: JdbcDatabaseContainer
+
+    override def config = {
+      baseConfig.withFallback(ConfigFactory.parseString(s"""
+        akka.projection.slick = {
+           db = {
+             url = "${container.jdbcUrl}"
+             driver = ${container.driverClassName}
+             user = ${container.username}
+             password = ${container.password}
+             connectionPool = disabled
+             keepAliveConnection = true
+           }
+        }
+        """))
+
+    }
+    override def stopContainer(): Unit =
+      container.asInstanceOf[SingleContainer[_]].stop()
+  }
+
+  class PostgresSpecConfig extends ContainerJdbcSpecConfig {
+
+    val name = "Postgres Database"
+    val container = new PostgreSQLContainer
+    container.start()
+
+    override def config: Config =
+      super.config.withFallback(ConfigFactory.parseString("""
+        akka.projection.slick = {
+           profile = "slick.jdbc.PostgresProfile$"
+        }
+        """))
+  }
+
+  class MySQLSpecConfig extends ContainerJdbcSpecConfig {
+
+    val name = "MySQL Database"
+    val container = new MySQLContainer
+    container.start()
+
+    override def config: Config =
+      super.config.withFallback(ConfigFactory.parseString("""
+        akka.projection.slick = {
+           profile = "slick.jdbc.MySQLProfile$"
+        }
+        """))
+  }
+  class MSSQLServerSpecConfig extends ContainerJdbcSpecConfig {
+
+    val name = "MS SQL Server Database"
+    val container = new MSSQLServerContainer
+    container.start()
+
+    override def config: Config =
+      super.config.withFallback(ConfigFactory.parseString("""
+        akka.projection.slick = {
+           profile = "slick.jdbc.SQLServerProfile$"
+        }
+        """))
+  }
+  class OracleSpecConfig extends ContainerJdbcSpecConfig {
+
+    val name = "Oracle Database"
+    val container =
+      // little hack to workaround that not all JDBC containers impl the same
+      // interface (Oracle doesn't impl JdbcDatabaseContainer)
+      new OracleContainer(dockerImageName = "oracleinanutshell/oracle-xe-11g") with JdbcDatabaseContainer {
+        override def jdbcUrl: String = super.jdbcUrl
+
+        override def username: String = super.username
+
+        override def password: String = super.password
+
+        override def driverClassName: String = super.driverClassName
+      }
+
+    container.start()
+
+    override def config: Config =
+      super.config.withFallback(ConfigFactory.parseString("""
+        akka.projection.slick = {
+           profile = "slick.jdbc.OracleProfile$"
+        }
+        """))
+  }
 }
-class SlickOffsetStoreSpec
-    extends ScalaTestWithActorTestKit(SlickOffsetStoreSpec.config)
+class H2SlickOffsetStoreSpec extends SlickOffsetStoreSpec(SlickOffsetStoreSpec.H2SpecConfig)
+class PostgresSlickOffsetStoreSpec extends SlickOffsetStoreSpec(new SlickOffsetStoreSpec.PostgresSpecConfig)
+class MySQLSlickOffsetStoreSpec extends SlickOffsetStoreSpec(new SlickOffsetStoreSpec.MySQLSpecConfig)
+class MSSQLServerSlickOffsetStoreSpec extends SlickOffsetStoreSpec(new SlickOffsetStoreSpec.MSSQLServerSpecConfig)
+class OracleSlickOffsetStoreSpec extends SlickOffsetStoreSpec(new SlickOffsetStoreSpec.OracleSpecConfig)
+
+abstract class SlickOffsetStoreSpec(specConfig: SlickSpecConfig)
+    extends ScalaTestWithActorTestKit(specConfig.config)
     with LogCapturing
     with AnyWordSpecLike
     with OptionValues {
@@ -61,10 +178,11 @@ class SlickOffsetStoreSpec
   override implicit val patienceConfig: PatienceConfig =
     PatienceConfig(timeout = Span(3, Seconds), interval = Span(100, Millis))
 
-  private val slickConfig = SlickOffsetStoreSpec.config.getConfig(SlickSettings.configPath)
+  private val slickConfig = specConfig.config.getConfig(SlickSettings.configPath)
+  private val dialectLabel = specConfig.name
 
-  val dbConfig: DatabaseConfig[H2Profile] =
-    DatabaseConfig.forConfig(SlickSettings.configPath, SlickOffsetStoreSpec.config)
+  val dbConfig: DatabaseConfig[JdbcProfile] =
+    DatabaseConfig.forConfig(SlickSettings.configPath, specConfig.config)
 
   // test clock for testing of the `last_updated` Instant
   private val clock = new TestClock
@@ -79,6 +197,7 @@ class SlickOffsetStoreSpec
 
   override protected def afterAll(): Unit = {
     dbConfig.db.close()
+    specConfig.stopContainer()
   }
 
   private def selectLastUpdated(projectionId: ProjectionId): Instant = {
@@ -92,7 +211,7 @@ class SlickOffsetStoreSpec
 
   private def genRandomProjectionId() = ProjectionId(UUID.randomUUID().toString, "00")
 
-  "The SlickOffsetStore" must {
+  s"The SlickOffsetStore [$dialectLabel]" must {
 
     implicit val ec: ExecutionContext = dbConfig.db.executor.executionContext
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -124,7 +124,20 @@ object Dependencies {
         Test.logback)
 
   val slick =
-    deps ++= Seq(Compile.slick, Compile.akkaPersistenceQuery, Test.akkaTypedTestkit, Test.h2Driver, Test.logback)
+    deps ++= Seq(
+        Compile.slick,
+        Compile.akkaPersistenceQuery,
+        Test.akkaTypedTestkit,
+        Test.h2Driver,
+        Test.postgresDriver,
+        Test.postgresContainer,
+        Test.mysqlDriver,
+        Test.mysqlContainer,
+        Test.msSQLServerDriver,
+        Test.msSQLServerContainer,
+        Test.oracleDriver,
+        Test.oracleDbContainer,
+        Test.logback)
 
   val cassandra =
     deps ++= Seq(


### PR DESCRIPTION
Adds tests for Postgres, MySQL, MS SQL Server and Oracle for the SlickOffsetStore. 

Very surprisingly, this worked on first run. I was expecting it to fail for MS Server because of differences in how the timestamp column is handled. 

I was also expecting this to fail because of #305. 

