### PR TITLE
JdbcSettings loading improvements

### DIFF
--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcSettings.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcSettings.scala
@@ -10,6 +10,7 @@ import akka.actor.typed.ActorSystem
 import akka.actor.typed.DispatcherSelector
 import akka.annotation.InternalApi
 import com.typesafe.config.Config
+import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigValueType
 
 /**
@@ -58,24 +59,38 @@ private[projection] object JdbcSettings {
     val config = system.settings.config.getConfig(dispatcherConfigPath)
     val pathToPoolSize = "thread-pool-executor.fixed-pool-size"
 
+    def isEmptyString = {
+      config.getValue(pathToPoolSize).valueType() == ConfigValueType.STRING &&
+      config.getString(pathToPoolSize).trim.isEmpty
+    }
+
     // the reference config has a thread-pool-executor configured
     // with a invalid pool size. We need to check if users configured it correctly
     // it's also possible that user decide to not use a thread-pool-executor
     // in which case, we have nothing else to check
-    if (config.hasPath(pathToPoolSize)) {
-      if (config.getValue(pathToPoolSize).valueType() == ConfigValueType.STRING) {
+    if (config.getString("executor") == "thread-pool-executor") {
+
+      // empty string can't be parsed to Int, users probably forgot to configure the pool-size
+      if (isEmptyString)
         throw new IllegalArgumentException(
-          s"Config value for '$dispatcherConfigPath.$pathToPoolSize' isn't configured. Current value is [${config
+          s"Config value for '$dispatcherConfigPath.$pathToPoolSize' is not configured.  Current value is [${config
             .getValue(pathToPoolSize)}]. " +
-          "The thread pool size must be as large as the JDBC connection pool.")
+          "The thread pool size must be integer and be as large as the JDBC connection pool.")
+
+      try {
+        // not only explicit Int, but also Int defined as String are valid, eg: 10 and "10"
+        config.getInt(pathToPoolSize)
+      } catch {
+        case _: ConfigException.WrongType =>
+          throw new IllegalArgumentException(
+            s"Value [${config.getValue(pathToPoolSize).render()}] is not a valid value for settings '$dispatcherConfigPath.$pathToPoolSize'" +
+            "The thread pool size must be integer and be as large as the JDBC connection pool.")
       }
     }
   }
 
   def apply(system: ActorSystem[_]): JdbcSettings = {
-
     checkDispatcherConfig(system)
-
     val blockingDbDispatcher = system.dispatchers.lookup(DispatcherSelector.fromConfig(dispatcherConfigPath))
     JdbcSettings(system.settings.config.getConfig(configPath), blockingDbDispatcher)
   }

--- a/akka-projection-jdbc/src/test/scala/akka/projection/jdbc/internal/JdbcSettingsSpec.scala
+++ b/akka-projection-jdbc/src/test/scala/akka/projection/jdbc/internal/JdbcSettingsSpec.scala
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.jdbc.internal
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.TestSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class JdbcSettingsSpec extends TestSuite with Matchers with AnyWordSpecLike with LogCapturing {
+
+  "Loading JdbcSettings" must {
+
+    "accept convert a valid string to integer when reading the pool size" in {
+
+      val config: Config =
+        ConfigFactory.parseString("""
+          akka {
+            loglevel = "DEBUG"
+            projection.jdbc = {
+              dialect = "h2-dialect"
+              blocking-jdbc-dispatcher.thread-pool-executor.fixed-pool-size = "5"
+            }
+          }
+          """)
+
+      createSystem(config) { sys =>
+        JdbcSettings(sys)
+      }
+    }
+
+    "accept convert a valid string (with spaces) to integer when reading the pool size" in {
+
+      val config: Config =
+        ConfigFactory.parseString("""
+          akka {
+            loglevel = "DEBUG"
+            projection.jdbc = {
+              dialect = "h2-dialect"
+              blocking-jdbc-dispatcher.thread-pool-executor.fixed-pool-size = " 5  "
+            }
+          }
+          """)
+
+      createSystem(config) { sys =>
+        JdbcSettings(sys)
+      }
+    }
+
+    "accept a correctly filled pool size" in {
+
+      val config: Config =
+        ConfigFactory.parseString("""
+          akka {
+            loglevel = "DEBUG"
+            projection.jdbc = {
+              dialect = "h2-dialect"
+              blocking-jdbc-dispatcher.thread-pool-executor.fixed-pool-size = 5
+            }
+          }
+          """)
+
+      createSystem(config) { sys =>
+        JdbcSettings(sys)
+      }
+    }
+
+    "throw an exception if pool size is configured with invalid value (unparsable string)" in {
+
+      val config: Config =
+        ConfigFactory.parseString("""
+          akka {
+            loglevel = "DEBUG"
+            projection.jdbc = {
+              dialect = "h2-dialect"
+              blocking-jdbc-dispatcher.thread-pool-executor.fixed-pool-size = "this-is-not-valid"
+            }
+          }
+          """)
+
+      createSystem(config) { sys =>
+        val msg =
+          intercept[IllegalArgumentException] {
+            JdbcSettings(sys)
+          }.getMessage
+
+        msg should startWith(
+          """Value ["this-is-not-valid"] is not a valid value for settings 'akka.projection.jdbc.blocking-jdbc-dispatcher.thread-pool-executor.fixed-pool-size'""")
+      }
+    }
+
+    "throw exception when dialect not defined" in {
+
+      val config: Config =
+        ConfigFactory.parseString("""
+          akka {
+            loglevel = "DEBUG"
+            projection.jdbc = {
+              blocking-jdbc-dispatcher.thread-pool-executor.fixed-pool-size = 5
+            }
+          }
+          """)
+
+      createSystem(config) { sys =>
+        val msg =
+          intercept[IllegalArgumentException] {
+            JdbcSettings(sys)
+          }.getMessage
+
+        msg shouldBe "Dialect type not set. Settings 'akka.projection.jdbc.dialect' currently set to []"
+      }
+    }
+
+    "throw exception when dialect is unknown" in {
+
+      val config: Config =
+        ConfigFactory.parseString("""
+          akka {
+            loglevel = "DEBUG"
+            projection.jdbc = {
+              dialect = "h3-dialect"
+              blocking-jdbc-dispatcher.thread-pool-executor.fixed-pool-size = 5
+            }
+          }
+          """)
+
+      createSystem(config) { sys =>
+        val msg =
+          intercept[IllegalArgumentException] {
+            JdbcSettings(sys)
+          }.getMessage
+
+        msg shouldBe "Unknown dialect type: [h3-dialect]. Check settings 'akka.projection.jdbc.dialect'"
+      }
+    }
+
+    "throw exception when pool size not defined" in {
+
+      val config: Config =
+        ConfigFactory.parseString("""
+          akka {
+            loglevel = "DEBUG"
+            projection.jdbc = {
+              dialect = "h2-dialect"
+            }
+          }
+          """)
+
+      createSystem(config) { sys =>
+        intercept[IllegalArgumentException] {
+          JdbcSettings(sys)
+        }
+      }
+    }
+
+    "dont' fail if user decide to step out of a thread-pool-executor" in {
+      val config: Config =
+        ConfigFactory.parseString("""
+          akka {
+            loglevel = "DEBUG"
+            projection.jdbc = {
+              dialect = "h2-dialect"
+              
+              # user tweaks the dispatcher to be something else
+              # we can't check the pool size if it's not a thread-pool-executor
+              blocking-jdbc-dispatcher {
+                executor = "fork-join-executor"
+                fork-join-executor {
+                  parallelism-min = 2
+                  parallelism-factor = 2.0
+                  parallelism-max = 10
+                }
+                throughput = 1
+              }
+            }
+          }
+          """)
+
+      createSystem(config) { sys =>
+        JdbcSettings(sys)
+      }
+
+    }
+  }
+
+  private def createSystem(config: Config)(func: ActorSystem[Any] => Unit) = {
+    val sys = ActorSystem(Behaviors.empty[Any], "test-sys", config)
+    func(sys)
+    sys.terminate()
+    Await.ready(sys.whenTerminated, 3.seconds)
+  }
+}


### PR DESCRIPTION
References #311 

* allows the pool size to be defined with a valid string, eg: "10". 
* more clear error messages and extended tests
* allows users to step out of thread-pool-executor