### PR TITLE
uses a factory for  MetadataClientAdapter

### DIFF
--- a/akka-projection-kafka/src/main/scala/akka/projection/kafka/javadsl/KafkaSourceProvider.scala
+++ b/akka-projection-kafka/src/main/scala/akka/projection/kafka/javadsl/KafkaSourceProvider.scala
@@ -28,7 +28,7 @@ object KafkaSourceProvider {
       system,
       settings,
       topics.asScala.toSet,
-      new MetadataClientAdapterImpl(system, settings),
+      () => new MetadataClientAdapterImpl(system, settings),
       KafkaSourceProviderSettings(system))
   }
 }

--- a/akka-projection-kafka/src/main/scala/akka/projection/kafka/scaladsl/KafkaSourceProvider.scala
+++ b/akka-projection-kafka/src/main/scala/akka/projection/kafka/scaladsl/KafkaSourceProvider.scala
@@ -27,6 +27,6 @@ object KafkaSourceProvider {
       system,
       settings,
       topics,
-      new MetadataClientAdapterImpl(system, settings),
+      () => new MetadataClientAdapterImpl(system, settings),
       KafkaSourceProviderSettings(system))
 }

--- a/akka-projection-kafka/src/test/scala/akka/projection/kafka/integration/KafkaToSlickIntegrationSpec.scala
+++ b/akka-projection-kafka/src/test/scala/akka/projection/kafka/integration/KafkaToSlickIntegrationSpec.scala
@@ -214,10 +214,10 @@ class KafkaToSlickIntegrationSpec extends KafkaSpecBase(ConfigFactory.load().wit
 
       produceEvents(topicName)
 
-      def slickProjection() = {
+      val kafkaSourceProvider: SourceProvider[MergeableOffset[JLong], ConsumerRecord[String, String]] =
+        KafkaSourceProvider(system.toTyped, consumerDefaults().withGroupId(groupId), Set(topicName))
 
-        val kafkaSourceProvider: SourceProvider[MergeableOffset[JLong], ConsumerRecord[String, String]] =
-          KafkaSourceProvider(system.toTyped, consumerDefaults().withGroupId(groupId), Set(topicName))
+      def slickProjection() = {
 
         SlickProjection.exactlyOnce(
           projectionId,

--- a/akka-projection-kafka/src/test/scala/akka/projection/kafka/internal/KafkaSourceProviderImplSpec.scala
+++ b/akka-projection-kafka/src/test/scala/akka/projection/kafka/internal/KafkaSourceProviderImplSpec.scala
@@ -45,6 +45,7 @@ class KafkaSourceProviderImplSpec extends ScalaTestWithActorTestKit with LogCapt
   implicit val ec = system.classicSystem.dispatcher
 
   "The KafkaSourceProviderImpl" must {
+
     "successfully verify offsets from assigned partitions" in {
       val topic = "topic"
       val partitions = 2
@@ -64,10 +65,16 @@ class KafkaSourceProviderImplSpec extends ScalaTestWithActorTestKit with LogCapt
         .mapMaterializedValue(_ => Consumer.NoopControl)
 
       val provider =
-        new KafkaSourceProviderImpl(system, settings, Set(topic), metadataClient, KafkaSourceProviderSettings(system)) {
+        new KafkaSourceProviderImpl(
+          system,
+          settings,
+          Set(topic),
+          () => metadataClient,
+          KafkaSourceProviderSettings(system)) {
           override protected[internal] def _source(
               readOffsets: () => Future[Option[MergeableOffset[JLong]]],
-              numPartitions: Int): Source[ConsumerRecord[String, String], Consumer.Control] =
+              numPartitions: Int,
+              metadataClient: MetadataClientAdapter): Source[ConsumerRecord[String, String], Consumer.Control] =
             consumerSource
         }
 


### PR DESCRIPTION

Draft because on top of #315.
Ready for review otherwise

References #316 
