### PR TITLE
Fine grained envelope ops in status observer

### DIFF
--- a/akka-projection-cassandra/src/it/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
+++ b/akka-projection-cassandra/src/it/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
@@ -939,7 +939,7 @@ class CassandraProjectionSpec
       }
 
       val statusProbe = createTestProbe[TestStatusObserver.Status]()
-      val progressProbe = createTestProbe[TestStatusObserver.Progress[Envelope]]()
+      val progressProbe = createTestProbe[TestStatusObserver.OffsetProgress[Envelope]]()
       val statusObserver = new TestStatusObserver[Envelope](statusProbe.ref, lifecycle = true, Some(progressProbe.ref))
 
       val projection =
@@ -958,11 +958,11 @@ class CassandraProjectionSpec
 
       handlerProbe.expectMessage(handler.startMessage)
       handlerProbe.expectMessage("abc")
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 1, "abc")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 1, "abc")))
       handlerProbe.expectMessage("def")
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 2, "def")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 2, "def")))
       handlerProbe.expectMessage("ghi")
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 3, "ghi")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 3, "ghi")))
       // fail 4
       handlerProbe.expectMessage(handler.failedMessage)
       val someTestException = TestException("err")
@@ -975,11 +975,11 @@ class CassandraProjectionSpec
       handlerProbe.expectMessage(handler.startMessage)
       statusProbe.expectMessage(TestStatusObserver.Started)
       handlerProbe.expectMessage("jkl")
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 4, "jkl")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 4, "jkl")))
       handlerProbe.expectMessage("mno")
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 5, "mno")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 5, "mno")))
       handlerProbe.expectMessage("pqr")
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 6, "pqr")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 6, "pqr")))
       // now completed without failure
       handlerProbe.expectMessage(handler.completedMessage)
       handlerProbe.expectNoMessage() // no duplicate stop

--- a/akka-projection-core/src/main/scala/akka/projection/StatusObserver.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/StatusObserver.scala
@@ -30,7 +30,17 @@ abstract class StatusObserver[-Envelope] {
    */
   def stopped(projectionId: ProjectionId): Unit
 
+  /**
+   * Called as soon as an envelop is ready to be processed. The envelope processing may
+   * not start immediately if grouping or batching are enabled.
+   */
   def beforeProcess(projectionId: ProjectionId, envelope: Envelope): Unit
+
+  /**
+   * Invoked as soon as the projected information is readable by a separate thread (e.g
+   * committed to database). It will not be invoked if the envelope is skipped or
+   * handling fails.
+   */
   def afterProcess(projectionId: ProjectionId, envelope: Envelope): Unit
 
   /**

--- a/akka-projection-core/src/main/scala/akka/projection/StatusObserver.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/StatusObserver.scala
@@ -30,6 +30,9 @@ abstract class StatusObserver[-Envelope] {
    */
   def stopped(projectionId: ProjectionId): Unit
 
+  def beforeProcess(projectionId: ProjectionId, envelope: Envelope): Unit
+  def afterProcess(projectionId: ProjectionId, envelope: Envelope): Unit
+
   /**
    * Called when the corresponding offset has been stored.
    * It might not be called for each envelope.

--- a/akka-projection-core/src/main/scala/akka/projection/internal/NoopStatusObserver.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/NoopStatusObserver.scala
@@ -23,6 +23,10 @@ import akka.projection.StatusObserver
 
   def stopped(projectionId: ProjectionId): Unit = ()
 
+  override def beforeProcess(projectionId: ProjectionId, envelope: Any): Unit = ()
+
+  override def afterProcess(projectionId: ProjectionId, envelope: Any): Unit = ()
+
   def offsetProgress(projectionId: ProjectionId, env: Any): Unit = ()
 
   override def error(

--- a/akka-projection-core/src/test/scala/akka/projection/StatusObserverSpec.scala
+++ b/akka-projection-core/src/test/scala/akka/projection/StatusObserverSpec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.projection
 
 import scala.concurrent.duration._

--- a/akka-projection-core/src/test/scala/akka/projection/TestStatusObserver.scala
+++ b/akka-projection-core/src/test/scala/akka/projection/TestStatusObserver.scala
@@ -13,11 +13,11 @@ object TestStatusObserver {
   case object Failed extends Status
   case object Stopped extends Status
 
-  final case class OffsetProgress[Envelope](env: Envelope) extends Status
+  final case class OffsetProgress[Envelope](envelope: Envelope) extends Status
 
   trait EnvelopeProgress[Envelope] extends Status
-  final case class Before[Envelope](env: Envelope) extends EnvelopeProgress[Envelope]
-  final case class After[Envelope](env: Envelope) extends EnvelopeProgress[Envelope]
+  final case class Before[Envelope](envelope: Envelope) extends EnvelopeProgress[Envelope]
+  final case class After[Envelope](envelope: Envelope) extends EnvelopeProgress[Envelope]
 
   final case class Err[Envelope](env: Envelope, cause: Throwable) extends Status {
     // don't include cause message in equals
@@ -34,7 +34,8 @@ class TestStatusObserver[Envelope](
     probe: ActorRef[TestStatusObserver.Status],
     lifecycle: Boolean = false,
     offsetProgressProbe: Option[ActorRef[TestStatusObserver.OffsetProgress[Envelope]]] = None,
-    envelopeProgressProbe: Option[ActorRef[TestStatusObserver.EnvelopeProgress[Envelope]]] = None)
+    beforeEnvelopeProbe: Option[ActorRef[TestStatusObserver.Before[Envelope]]] = None,
+    afterEnvelopeProbe: Option[ActorRef[TestStatusObserver.After[Envelope]]] = None)
     extends StatusObserver[Envelope] {
   import TestStatusObserver._
 
@@ -53,15 +54,24 @@ class TestStatusObserver[Envelope](
       probe ! Stopped
   }
 
-  override def offsetProgress(projectionId: ProjectionId, env: Envelope): Unit = {
-    offsetProgressProbe.foreach(_ ! OffsetProgress(env))
+  override def beforeProcess(projectionId: ProjectionId, envelope: Envelope): Unit = {
+    beforeEnvelopeProbe.foreach(_ ! Before(envelope))
+  }
+
+  override def afterProcess(projectionId: ProjectionId, envelope: Envelope): Unit = {
+    afterEnvelopeProbe.foreach(_ ! After(envelope))
+  }
+
+  override def offsetProgress(projectionId: ProjectionId, envelope: Envelope): Unit = {
+    offsetProgressProbe.foreach(_ ! OffsetProgress(envelope))
   }
 
   override def error(
       projectionId: ProjectionId,
-      env: Envelope,
+      envelope: Envelope,
       cause: Throwable,
       recoveryStrategy: HandlerRecoveryStrategy): Unit = {
-    probe ! Err(env, cause)
+    probe ! Err(envelope, cause)
   }
+
 }

--- a/akka-projection-core/src/test/scala/akka/projection/internal/metrics/ServiceTimeMetricSpec.scala
+++ b/akka-projection-core/src/test/scala/akka/projection/internal/metrics/ServiceTimeMetricSpec.scala
@@ -177,7 +177,12 @@ class ServiceTimeAndProcessingCountMetricAtLeastOnceSpec extends ServiceTimeAndP
         val tt =
           new TelemetryTester(AtLeastOnce(afterEnvelopes = Some(2)), FlowHandlerStrategy[Envelope](flow))
         runInternal(tt.projectionState) {
-          instruments.afterProcessInvocations.get should be(10)
+          // When there's a failure handling `envelope(n)` there is a race condition between
+          // the stream cancellation and the invocation to `afterProcess(envelope(n-1))` (the
+          // previous envelope). As a consequence, the `afterProcessInvocations` count is
+          // nondeterministic and we can only assert it'll be some value between 8 and 10 (both
+          // included)
+          instruments.afterProcessInvocations.get should be >= (8)
         }
       }
     }

--- a/akka-projection-core/src/test/scala/akka/projection/internal/metrics/tools/InternalProjectionStateMetricsSpec.scala
+++ b/akka-projection-core/src/test/scala/akka/projection/internal/metrics/tools/InternalProjectionStateMetricsSpec.scala
@@ -24,6 +24,7 @@ import akka.event.LoggingAdapter
 import akka.projection.ProjectionId
 import akka.projection.RunningProjection
 import akka.projection.StatusObserver
+import akka.projection.TestStatusObserver
 import akka.projection.internal.ExactlyOnce
 import akka.projection.internal.FlowHandlerStrategy
 import akka.projection.internal.GroupedHandlerStrategy
@@ -133,12 +134,16 @@ object InternalProjectionStateMetricsSpec {
     override def extractCreationTime(envelope: Envelope): Long = envelope.creationTimestamp
   }
 
-  class TelemetryTester(offsetStrategy: OffsetStrategy, handlerStrategy: HandlerStrategy, numberOfEnvelopes: Int = 6)(
+  class TelemetryTester(
+      offsetStrategy: OffsetStrategy,
+      handlerStrategy: HandlerStrategy,
+      numberOfEnvelopes: Int = 6,
+      statusObserver: StatusObserver[Envelope] = NoopStatusObserver)(
       implicit system: ActorSystem[_],
       projectionId: ProjectionId) {
 
     private implicit val exCtx = system.executionContext
-    private val entityId = UUID.randomUUID().toString
+    val entityId = UUID.randomUUID().toString
 
     private val projectionSettings = ProjectionSettings(system)
 
@@ -178,7 +183,7 @@ object InternalProjectionStateMetricsSpec {
         sourceProvider(system, entityId, numberOfEnvelopes),
         offsetStrategy,
         adaptedHandlerStrategy,
-        NoopStatusObserver,
+        statusObserver,
         projectionSettings,
         offsetStore)
 

--- a/akka-projection-core/src/test/scala/akka/projection/internal/metrics/tools/InternalProjectionStateMetricsSpec.scala
+++ b/akka-projection-core/src/test/scala/akka/projection/internal/metrics/tools/InternalProjectionStateMetricsSpec.scala
@@ -24,7 +24,6 @@ import akka.event.LoggingAdapter
 import akka.projection.ProjectionId
 import akka.projection.RunningProjection
 import akka.projection.StatusObserver
-import akka.projection.TestStatusObserver
 import akka.projection.internal.ExactlyOnce
 import akka.projection.internal.FlowHandlerStrategy
 import akka.projection.internal.GroupedHandlerStrategy
@@ -113,7 +112,7 @@ object InternalProjectionStateMetricsSpec {
   }
 
   def sourceProvider(system: ActorSystem[_], id: String, numberOfEnvelopes: Int): SourceProvider[Long, Envelope] = {
-    val chars = "abcdefghijklkmnopqrstuvwxyz"
+    val chars = "abcdefghijklmnopqrstuvwxyz"
     val envelopes = (1 to numberOfEnvelopes).map { offset =>
       Envelope(id, offset.toLong, chars.charAt((offset - 1) % chars.length).toString)
     }

--- a/akka-projection-jdbc/src/it/scala/akka/projection/jdbc/JdbcProjectionSpec.scala
+++ b/akka-projection-jdbc/src/it/scala/akka/projection/jdbc/JdbcProjectionSpec.scala
@@ -1163,7 +1163,7 @@ class JdbcProjectionSpec
       }
 
       val statusProbe = createTestProbe[TestStatusObserver.Status]()
-      val progressProbe = createTestProbe[TestStatusObserver.Progress[Envelope]]()
+      val progressProbe = createTestProbe[TestStatusObserver.OffsetProgress[Envelope]]()
       val statusObserver = new TestStatusObserver[Envelope](statusProbe.ref, lifecycle = true, Some(progressProbe.ref))
 
       val projection =
@@ -1185,11 +1185,11 @@ class JdbcProjectionSpec
 
       handlerProbe.expectMessage(handler.startMessage)
       handlerProbe.expectMessage("e1")
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 1, "e1")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 1, "e1")))
       handlerProbe.expectMessage("e2")
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 2, "e2")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 2, "e2")))
       handlerProbe.expectMessage("e3")
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 3, "e3")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 3, "e3")))
       // fail 4
       handlerProbe.expectMessage(handler.failedMessage)
       val someTestException = TestException("err")
@@ -1202,11 +1202,11 @@ class JdbcProjectionSpec
       handlerProbe.expectMessage(handler.startMessage)
       statusProbe.expectMessage(TestStatusObserver.Started)
       handlerProbe.expectMessage("e4")
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 4, "e4")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 4, "e4")))
       handlerProbe.expectMessage("e5")
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 5, "e5")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 5, "e5")))
       handlerProbe.expectMessage("e6")
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 6, "e6")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 6, "e6")))
       // now completed without failure
       handlerProbe.expectMessage(handler.completedMessage)
       handlerProbe.expectNoMessage() // no duplicate stop

--- a/akka-projection-jdbc/src/it/scala/akka/projection/jdbc/JdbcProjectionSpec.scala
+++ b/akka-projection-jdbc/src/it/scala/akka/projection/jdbc/JdbcProjectionSpec.scala
@@ -367,8 +367,9 @@ class JdbcProjectionSpec
       val bogusEventHandler = new ConcatHandler(_ == 4)
 
       val statusProbe = createTestProbe[TestStatusObserver.Status]()
-      val progressProbe = createTestProbe[TestStatusObserver.Progress[Envelope]]()
-      val statusObserver = new TestStatusObserver[Envelope](statusProbe.ref, progressProbe = Some(progressProbe.ref))
+      val progressProbe = createTestProbe[TestStatusObserver.OffsetProgress[Envelope]]()
+      val statusObserver =
+        new TestStatusObserver[Envelope](statusProbe.ref, offsetProgressProbe = Some(progressProbe.ref))
 
       val projectionFailing =
         JdbcProjection

--- a/akka-projection-jdbc/src/it/scala/akka/projection/jdbc/JdbcProjectionSpec.scala
+++ b/akka-projection-jdbc/src/it/scala/akka/projection/jdbc/JdbcProjectionSpec.scala
@@ -394,11 +394,11 @@ class JdbcProjectionSpec
       statusProbe.expectMessage(TestStatusObserver.Err(Envelope(entityId, 4, "e4"), someTestException))
       statusProbe.expectMessage(TestStatusObserver.Err(Envelope(entityId, 4, "e4"), someTestException))
       statusProbe.expectNoMessage()
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 1, "e1")))
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 2, "e2")))
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 3, "e3")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 1, "e1")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 2, "e2")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 3, "e3")))
       // Offset 4 is not stored so it is not reported.
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 5, "e5")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 5, "e5")))
 
       offsetShouldBe(6L)
     }

--- a/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
+++ b/akka-projection-slick/src/test/scala/akka/projection/slick/SlickProjectionSpec.scala
@@ -1380,7 +1380,7 @@ class SlickProjectionSpec
       }
 
       val statusProbe = createTestProbe[TestStatusObserver.Status]()
-      val progressProbe = createTestProbe[TestStatusObserver.Progress[Envelope]]()
+      val progressProbe = createTestProbe[TestStatusObserver.OffsetProgress[Envelope]]()
       val statusObserver = new TestStatusObserver[Envelope](statusProbe.ref, lifecycle = true, Some(progressProbe.ref))
 
       val projection =
@@ -1403,11 +1403,11 @@ class SlickProjectionSpec
 
       handlerProbe.expectMessage(handler.startMessage)
       handlerProbe.expectMessage("abc")
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 1, "abc")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 1, "abc")))
       handlerProbe.expectMessage("def")
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 2, "def")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 2, "def")))
       handlerProbe.expectMessage("ghi")
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 3, "ghi")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 3, "ghi")))
       // fail 4
       handlerProbe.expectMessage(handler.failedMessage)
       val someTestException = TestException("err")
@@ -1420,11 +1420,11 @@ class SlickProjectionSpec
       handlerProbe.expectMessage(handler.startMessage)
       statusProbe.expectMessage(TestStatusObserver.Started)
       handlerProbe.expectMessage("jkl")
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 4, "jkl")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 4, "jkl")))
       handlerProbe.expectMessage("mno")
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 5, "mno")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 5, "mno")))
       handlerProbe.expectMessage("pqr")
-      progressProbe.expectMessage(TestStatusObserver.Progress(Envelope(entityId, 6, "pqr")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 6, "pqr")))
       // now completed without failure
       handlerProbe.expectMessage(handler.completedMessage)
       handlerProbe.expectNoMessage() // no duplicate stop


### PR DESCRIPTION
References #277 


Note to reviewers: The big chunk in this PR is the test `StatusObserverSpec`. The rest is rather small and straightforward.
