### PR TITLE
Prefer JDK API over Akka-custom functional interfaces

### DIFF
--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/javadsl/JdbcProjection.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/javadsl/JdbcProjection.scala
@@ -11,7 +11,6 @@ import scala.compat.java8.FutureConverters._
 
 import akka.Done
 import akka.actor.typed.ActorSystem
-import akka.japi.function.Creator
 import akka.projection.ProjectionContext
 import akka.projection.ProjectionId
 import akka.projection.internal.AtLeastOnce
@@ -47,11 +46,11 @@ object JdbcProjection {
   def exactlyOnce[Offset, Envelope, S <: JdbcSession](
       projectionId: ProjectionId,
       sourceProvider: SourceProvider[Offset, Envelope],
-      sessionCreator: Creator[S],
+      sessionCreator: Supplier[S],
       handler: Supplier[JdbcHandler[Envelope, S]],
       system: ActorSystem[_]): ExactlyOnceProjection[Offset, Envelope] = {
 
-    val sessionFactory = () => sessionCreator.create()
+    val sessionFactory = () => sessionCreator.get()
     val javaSourceProvider = new SourceProviderAdapter(sourceProvider)
     val offsetStore = JdbcProjectionImpl.createOffsetStore(sessionFactory)(system)
 
@@ -90,11 +89,11 @@ object JdbcProjection {
   def atLeastOnce[Offset, Envelope, S <: JdbcSession](
       projectionId: ProjectionId,
       sourceProvider: SourceProvider[Offset, Envelope],
-      sessionCreator: Creator[S],
+      sessionCreator: Supplier[S],
       handler: Supplier[JdbcHandler[Envelope, S]],
       system: ActorSystem[_]): AtLeastOnceProjection[Offset, Envelope] = {
 
-    val sessionFactory = () => sessionCreator.create()
+    val sessionFactory = () => sessionCreator.get()
     val offsetStore = JdbcProjectionImpl.createOffsetStore(sessionFactory)(system)
 
     val adaptedHandler =
@@ -133,11 +132,11 @@ object JdbcProjection {
   def atLeastOnceAsync[Offset, Envelope, S <: JdbcSession](
       projectionId: ProjectionId,
       sourceProvider: SourceProvider[Offset, Envelope],
-      sessionCreator: Creator[S],
+      sessionCreator: Supplier[S],
       handler: Supplier[Handler[Envelope]],
       system: ActorSystem[_]): AtLeastOnceProjection[Offset, Envelope] = {
 
-    val sessionFactory = () => sessionCreator.create()
+    val sessionFactory = () => sessionCreator.get()
     val offsetStore = JdbcProjectionImpl.createOffsetStore(sessionFactory)(system)
 
     new JdbcProjectionImpl(
@@ -165,11 +164,11 @@ object JdbcProjection {
   def groupedWithin[Offset, Envelope, S <: JdbcSession](
       projectionId: ProjectionId,
       sourceProvider: SourceProvider[Offset, Envelope],
-      sessionCreator: Creator[S],
+      sessionCreator: Supplier[S],
       handler: Supplier[JdbcHandler[java.util.List[Envelope], S]],
       system: ActorSystem[_]): GroupedProjection[Offset, Envelope] = {
 
-    val sessionFactory = () => sessionCreator.create()
+    val sessionFactory = () => sessionCreator.get()
     val javaSourceProvider = new SourceProviderAdapter(sourceProvider)
     val offsetStore = JdbcProjectionImpl.createOffsetStore(sessionFactory)(system)
 
@@ -211,11 +210,11 @@ object JdbcProjection {
   def groupedWithinAsync[Offset, Envelope, S <: JdbcSession](
       projectionId: ProjectionId,
       sourceProvider: SourceProvider[Offset, Envelope],
-      sessionCreator: Creator[S],
+      sessionCreator: Supplier[S],
       handler: Supplier[Handler[java.util.List[Envelope]]],
       system: ActorSystem[_]): GroupedProjection[Offset, Envelope] = {
 
-    val sessionFactory = () => sessionCreator.create()
+    val sessionFactory = () => sessionCreator.get()
     val javaSourceProvider = new SourceProviderAdapter(sourceProvider)
     val offsetStore = JdbcProjectionImpl.createOffsetStore(sessionFactory)(system)
 
@@ -255,11 +254,11 @@ object JdbcProjection {
   def atLeastOnceFlow[Offset, Envelope, S <: JdbcSession](
       projectionId: ProjectionId,
       sourceProvider: SourceProvider[Offset, Envelope],
-      sessionCreator: Creator[S],
+      sessionCreator: Supplier[S],
       handler: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, _],
       system: ActorSystem[_]): AtLeastOnceFlowProjection[Offset, Envelope] = {
 
-    val sessionFactory = () => sessionCreator.create()
+    val sessionFactory = () => sessionCreator.get()
     val javaSourceProvider = new SourceProviderAdapter(sourceProvider)
     val offsetStore = JdbcProjectionImpl.createOffsetStore(sessionFactory)(system)
 

--- a/akka-projection-jdbc/src/test/java/akka/projection/jdbc/JdbcProjectionTest.java
+++ b/akka-projection-jdbc/src/test/java/akka/projection/jdbc/JdbcProjectionTest.java
@@ -9,7 +9,6 @@ import akka.NotUsed;
 import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
-import akka.japi.function.Creator;
 import akka.japi.function.Function;
 import akka.projection.Projection;
 import akka.projection.ProjectionContext;
@@ -96,10 +95,10 @@ public class JdbcProjectionTest extends JUnitSuite {
     }
   }
 
-  private static class JdbcSessionCreator implements Creator<PureJdbcSession> {
+  private static class JdbcSessionCreator implements Supplier<PureJdbcSession> {
 
     @Override
-    public PureJdbcSession create() {
+    public PureJdbcSession get() {
       return new PureJdbcSession();
     }
   }
@@ -108,7 +107,7 @@ public class JdbcProjectionTest extends JUnitSuite {
 
   private static final JdbcSettings jdbcSettings = JdbcSettings.apply(testKit.system());
   private static final JdbcOffsetStore<PureJdbcSession> offsetStore =
-      new JdbcOffsetStore<>(testKit.system(), jdbcSettings, jdbcSessionCreator::create);
+      new JdbcOffsetStore<>(testKit.system(), jdbcSettings, jdbcSessionCreator::get);
 
   private static final scala.concurrent.duration.Duration awaitTimeout =
       scala.concurrent.duration.Duration.create(3, TimeUnit.SECONDS);

--- a/examples/src/test/java/jdocs/jdbc/JdbcHibernateTest.java
+++ b/examples/src/test/java/jdocs/jdbc/JdbcHibernateTest.java
@@ -7,7 +7,6 @@ package jdocs.jdbc;
 import akka.NotUsed;
 import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
-import akka.japi.function.Creator;
 import akka.projection.Projection;
 import akka.projection.ProjectionId;
 import akka.projection.javadsl.SourceProvider;


### PR DESCRIPTION
References #317

`ProjectionTestKit` still has a couple usages of Akka-custom functional interfaces:

 - `akka.japi.function.Effect`, which has no JDK APi equivalent
 - `akka.japi.function.Procedure` instead of `java.util.function.Consumer`. I haven't replaced this one because it is more convenient for users (`Procedure` allows users to throw exception). 
