### PR TITLE
Document transaction semantics for Slick.atLeastOnce

### DIFF
--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/scaladsl/JdbcProjection.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/scaladsl/JdbcProjection.scala
@@ -72,7 +72,7 @@ object JdbcProjection {
    * This means that if the projection is restarted from previously stored offset then some elements may be processed
    * more than once.
    *
-   * The [[JdbcHandler.process()]] in [[handler]] will be wrapped in a transaction, it is highly recommended to use
+   * The [[JdbcHandler.process()]] in [[handler]] will be wrapped in a transaction. It is highly recommended to use
    * a [[sessionFactory]] that provides [[java.sql.Connection]]'s with [[setAutoCommit(false)]]. The transaction
    * will be committed after invoking [[JdbcHandler.process()]].
    *

--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/scaladsl/JdbcProjection.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/scaladsl/JdbcProjection.scala
@@ -35,7 +35,6 @@ object JdbcProjection {
    *
    * It stores the offset in a relational database table using JDBC in the same transaction
    * as the user defined `handler`.
-   *
    */
   def exactlyOnce[Offset, Envelope, S <: JdbcSession](
       projectionId: ProjectionId,
@@ -72,6 +71,10 @@ object JdbcProjection {
    * It stores the offset in a relational database table using JDBC after the `handler` has processed the envelope.
    * This means that if the projection is restarted from previously stored offset then some elements may be processed
    * more than once.
+   *
+   * The [[JdbcHandler.process()]] in [[handler]] will be wrapped in a transaction, it is highly recommended to use
+   * a [[sessionFactory]] that provides [[java.sql.Connection]]'s with [[setAutoCommit(false)]]. The transaction
+   * will be committed after invoking [[JdbcHandler.process()]].
    *
    * The offset is stored after a time window, or limited by a number of envelopes, whatever happens first.
    * This window can be defined with [[AtLeastOnceProjection.withSaveOffset]] of the returned

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/SlickProjection.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/SlickProjection.scala
@@ -53,7 +53,6 @@ object SlickProjection {
    *
    * It stores the offset in a relational database table using Slick in the same transaction
    * as the DBIO returned from the `handler`.
-   *
    */
   def exactlyOnce[Offset, Envelope, P <: JdbcProfile: ClassTag](
       projectionId: ProjectionId,
@@ -123,6 +122,9 @@ object SlickProjection {
 
   /**
    * Create a [[akka.projection.Projection]] with at-least-once processing semantics.
+   *
+   * The DBIO returned by the [[SlickHandler.process()]] of the provided [[handler]] will be
+   * wrapped in a transaction.
    *
    * It stores the offset in a relational database table using Slick after the `handler` has processed the envelope.
    * This means that if the projection is restarted from previously stored offset then some elements may be processed


### PR DESCRIPTION
References #77 

I've done a review of the API doc of all other methods in `SlickProjection` and didn't find anything else missing. Also reviewed `JdbcProjection`.

I haven't made any edit or review of the `docs/`. We can address that on a separate PR.