### PR TITLE
First pass at apimaychange internalapi

### DIFF
--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraSettings.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraSettings.scala
@@ -22,7 +22,7 @@ private[projection] case class CassandraSettings(config: Config) {
 /**
  * INTERNAL API
  */
-@akka.annotation.InternalApi
+@InternalApi
 private[projection] object CassandraSettings {
 
   def apply(system: ActorSystem[_]): CassandraSettings =

--- a/akka-projection-core/src/main/scala/akka/projection/HandlerRecoveryStrategy.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/HandlerRecoveryStrategy.scala
@@ -6,16 +6,19 @@ package akka.projection
 
 import scala.concurrent.duration.FiniteDuration
 
+import akka.annotation.ApiMayChange
 import akka.annotation.InternalApi
 import akka.util.JavaDurationConverters._
 
 /**
  * Error handling strategy when processing an `Envelope` fails. The default is defined in configuration .
  */
+@ApiMayChange
 sealed trait HandlerRecoveryStrategy
 sealed trait StrictRecoveryStrategy extends HandlerRecoveryStrategy
 sealed trait RetryRecoveryStrategy extends HandlerRecoveryStrategy
 
+@ApiMayChange
 object HandlerRecoveryStrategy {
   import Internal._
 

--- a/akka-projection-core/src/main/scala/akka/projection/OffsetVerification.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/OffsetVerification.scala
@@ -6,10 +6,12 @@ package akka.projection
 
 import scala.util.control.NoStackTrace
 
+import akka.annotation.ApiMayChange
 import akka.annotation.InternalApi
 
 sealed trait OffsetVerification
 
+@ApiMayChange
 object OffsetVerification {
   case object VerificationSuccess extends OffsetVerification
 

--- a/akka-projection-core/src/main/scala/akka/projection/ProjectionBehavior.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/ProjectionBehavior.scala
@@ -14,9 +14,11 @@ import akka.actor.typed.SupervisorStrategy
 import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.StashBuffer
+import akka.annotation.ApiMayChange
 import akka.annotation.InternalApi
 import akka.projection.scaladsl.ProjectionManagement
 
+@ApiMayChange
 object ProjectionBehavior {
 
   sealed trait Command

--- a/akka-projection-core/src/main/scala/akka/projection/StatusObserver.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/StatusObserver.scala
@@ -4,10 +4,13 @@
 
 package akka.projection
 
+import akka.annotation.ApiMayChange
+
 /**
  * Track status of a projection by implementing a `StatusObserver` and install it using
  * [[Projection.withStatusObserver]].
  */
+@ApiMayChange
 abstract class StatusObserver[-Envelope] {
 
   /**

--- a/akka-projection-core/src/main/scala/akka/projection/javadsl/ActorHandler.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/javadsl/ActorHandler.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletionStage
 import akka.Done
 import akka.actor.typed.ActorRef
 import akka.actor.typed.Behavior
+import akka.annotation.ApiMayChange
 
 /**
  * This [[Handler]] gives support for spawning an actor of a given `Behavior` to delegate
@@ -18,6 +19,7 @@ import akka.actor.typed.Behavior
  * `Projection` is started and the `ActorRef` is passed in as a parameter to the `process` method.
  * The Actor is stopped when the `Projection` is stopped.
  */
+@ApiMayChange
 abstract class ActorHandler[Envelope, T](val behavior: Behavior[T]) extends Handler[Envelope] {
 
   /**

--- a/akka-projection-core/src/main/scala/akka/projection/javadsl/Projections.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/javadsl/Projections.scala
@@ -30,6 +30,7 @@ trait ExactlyOnceProjection[Offset, Envelope] extends Projection[Envelope] {
 
   def withRecoveryStrategy(recoveryStrategy: HandlerRecoveryStrategy): ExactlyOnceProjection[Offset, Envelope]
 }
+
 @DoNotInherit
 trait AtLeastOnceFlowProjection[Offset, Envelope] extends Projection[Envelope] {
   self: InternalProjection =>

--- a/akka-projection-core/src/main/scala/akka/projection/javadsl/SourceProvider.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/javadsl/SourceProvider.scala
@@ -10,7 +10,6 @@ import java.util.function.Supplier
 
 import akka.NotUsed
 import akka.annotation.ApiMayChange
-import akka.annotation.DoNotInherit
 import akka.projection.MergeableOffset
 import akka.projection.OffsetVerification
 

--- a/akka-projection-core/src/main/scala/akka/projection/javadsl/SourceProvider.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/javadsl/SourceProvider.scala
@@ -9,9 +9,12 @@ import java.util.concurrent.CompletionStage
 import java.util.function.Supplier
 
 import akka.NotUsed
+import akka.annotation.ApiMayChange
+import akka.annotation.DoNotInherit
 import akka.projection.MergeableOffset
 import akka.projection.OffsetVerification
 
+@ApiMayChange
 abstract class SourceProvider[Offset, Envelope] {
 
   def source(offset: Supplier[CompletionStage[Optional[Offset]]])

--- a/akka-projection-core/src/main/scala/akka/projection/scaladsl/ActorHandler.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/scaladsl/ActorHandler.scala
@@ -9,6 +9,7 @@ import scala.concurrent.Future
 import akka.Done
 import akka.actor.typed.ActorRef
 import akka.actor.typed.Behavior
+import akka.annotation.ApiMayChange
 import akka.projection.internal.ActorHandlerInit
 
 /**
@@ -19,6 +20,7 @@ import akka.projection.internal.ActorHandlerInit
  * `Projection` is started and the `ActorRef` is passed in as a parameter to the `process` method.
  * The Actor is stopped when the `Projection` is stopped.
  */
+@ApiMayChange
 abstract class ActorHandler[Envelope, T](val behavior: Behavior[T]) extends Handler[Envelope] with ActorHandlerInit[T] {
 
   /**

--- a/akka-projection-core/src/main/scala/akka/projection/scaladsl/SourceProvider.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/scaladsl/SourceProvider.scala
@@ -8,9 +8,11 @@ import scala.concurrent.Future
 
 import akka.projection.MergeableOffset
 import akka.NotUsed
+import akka.annotation.ApiMayChange
 import akka.projection.OffsetVerification
 import akka.stream.scaladsl.Source
 
+@ApiMayChange
 trait SourceProvider[Offset, Envelope] {
 
   def source(offset: () => Future[Option[Offset]]): Future[Source[Envelope, NotUsed]]

--- a/akka-projection-eventsourced/src/main/scala/akka/projection/eventsourced/EventEnvelope.scala
+++ b/akka-projection-eventsourced/src/main/scala/akka/projection/eventsourced/EventEnvelope.scala
@@ -4,10 +4,12 @@
 
 package akka.projection.eventsourced
 
+import akka.annotation.ApiMayChange
 import akka.annotation.InternalApi
 import akka.persistence.query.Offset
 import akka.util.HashCode
 
+@ApiMayChange
 object EventEnvelope {
 
   /**
@@ -35,6 +37,7 @@ object EventEnvelope {
     Some((arg.offset, arg.persistenceId, arg.sequenceNr, arg.event, arg.timestamp))
 }
 
+@ApiMayChange
 final class EventEnvelope[Event](
     val offset: Offset,
     val persistenceId: String,

--- a/akka-projection-eventsourced/src/main/scala/akka/projection/eventsourced/javadsl/EventSourcedProvider.scala
+++ b/akka-projection-eventsourced/src/main/scala/akka/projection/eventsourced/javadsl/EventSourcedProvider.scala
@@ -14,6 +14,7 @@ import scala.concurrent.Future
 
 import akka.NotUsed
 import akka.actor.typed.ActorSystem
+import akka.annotation.ApiMayChange
 import akka.annotation.InternalApi
 import akka.persistence.query.NoOffset
 import akka.persistence.query.Offset
@@ -24,6 +25,7 @@ import akka.projection.javadsl
 import akka.projection.javadsl.SourceProvider
 import akka.stream.javadsl.Source
 
+@ApiMayChange
 object EventSourcedProvider {
 
   def eventsByTag[Event](

--- a/akka-projection-eventsourced/src/main/scala/akka/projection/eventsourced/scaladsl/EventSourcedProvider.scala
+++ b/akka-projection-eventsourced/src/main/scala/akka/projection/eventsourced/scaladsl/EventSourcedProvider.scala
@@ -9,6 +9,7 @@ import scala.concurrent.Future
 
 import akka.NotUsed
 import akka.actor.typed.ActorSystem
+import akka.annotation.ApiMayChange
 import akka.annotation.InternalApi
 import akka.persistence.query.NoOffset
 import akka.persistence.query.Offset
@@ -18,6 +19,7 @@ import akka.projection.eventsourced.EventEnvelope
 import akka.projection.scaladsl.SourceProvider
 import akka.stream.scaladsl.Source
 
+@ApiMayChange
 object EventSourcedProvider {
 
   def eventsByTag[Event](

--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/JdbcSession.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/JdbcSession.scala
@@ -7,6 +7,7 @@ package akka.projection.jdbc
 import java.sql.Connection
 import java.sql.SQLException
 
+import akka.annotation.ApiMayChange
 import akka.japi.function.{ Function => JFunction }
 
 /**
@@ -25,6 +26,7 @@ import akka.japi.function.{ Function => JFunction }
  * lambda call and therefore can be used (see [[JdbcSession#withConnection]] method). Other JPA implementations may not provide this feature.
  *
  */
+@ApiMayChange
 trait JdbcSession {
 
   /**

--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/javadsl/JdbcHandler.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/javadsl/JdbcHandler.scala
@@ -4,9 +4,11 @@
 
 package akka.projection.jdbc.javadsl
 
+import akka.annotation.ApiMayChange
 import akka.projection.jdbc.JdbcHandlerLifecycle
 import akka.projection.jdbc.JdbcSession
 
+@ApiMayChange
 object JdbcHandler {
 
   /** Handler that can be defined from a simple function */
@@ -31,6 +33,7 @@ object JdbcHandler {
  * defined in configuration or using the `withRecoveryStrategy` method of a `Projection`
  * implementation.
  */
+@ApiMayChange
 abstract class JdbcHandler[Envelope, S <: JdbcSession] extends JdbcHandlerLifecycle {
 
   /**

--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/javadsl/JdbcProjection.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/javadsl/JdbcProjection.scala
@@ -11,6 +11,7 @@ import scala.compat.java8.FutureConverters._
 
 import akka.Done
 import akka.actor.typed.ActorSystem
+import akka.annotation.ApiMayChange
 import akka.projection.ProjectionContext
 import akka.projection.ProjectionId
 import akka.projection.internal.AtLeastOnce
@@ -34,6 +35,7 @@ import akka.projection.jdbc.internal.JdbcHandlerAdapter
 import akka.projection.jdbc.internal.JdbcProjectionImpl
 import akka.stream.javadsl.FlowWithContext
 
+@ApiMayChange
 object JdbcProjection {
 
   /**

--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/scaladsl/JdbcHandler.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/scaladsl/JdbcHandler.scala
@@ -4,6 +4,7 @@
 
 package akka.projection.jdbc.scaladsl
 
+import akka.annotation.ApiMayChange
 import akka.projection.jdbc.JdbcHandlerLifecycle
 import akka.projection.jdbc.JdbcSession
 
@@ -19,6 +20,7 @@ import akka.projection.jdbc.JdbcSession
  * defined in configuration or using the `withRecoveryStrategy` method of a `Projection`
  * implementation.
  */
+@ApiMayChange
 trait JdbcHandler[Envelope, S <: JdbcSession] extends JdbcHandlerLifecycle {
 
   /**
@@ -31,6 +33,7 @@ trait JdbcHandler[Envelope, S <: JdbcSession] extends JdbcHandlerLifecycle {
 
 }
 
+@ApiMayChange
 object JdbcHandler {
 
   /** JdbcHandler that can be define from a simple function */

--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/scaladsl/JdbcProjection.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/scaladsl/JdbcProjection.scala
@@ -10,6 +10,7 @@ import scala.concurrent.duration.Duration
 
 import akka.Done
 import akka.actor.typed.ActorSystem
+import akka.annotation.ApiMayChange
 import akka.projection.ProjectionContext
 import akka.projection.ProjectionId
 import akka.projection.internal.AtLeastOnce
@@ -28,6 +29,7 @@ import akka.projection.scaladsl.Handler
 import akka.projection.scaladsl.SourceProvider
 import akka.stream.scaladsl.FlowWithContext
 
+@ApiMayChange
 object JdbcProjection {
 
   /**

--- a/akka-projection-kafka/src/main/scala/akka/projection/kafka/KafkaOffsets.scala
+++ b/akka-projection-kafka/src/main/scala/akka/projection/kafka/KafkaOffsets.scala
@@ -5,10 +5,13 @@
 package akka.projection.kafka
 
 import java.lang.{ Long => JLong }
+
+import akka.annotation.ApiMayChange
 import akka.projection.MergeableOffset
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.TopicPartition
 
+@ApiMayChange
 object KafkaOffsets {
 
   private val separator = "-"

--- a/akka-projection-kafka/src/main/scala/akka/projection/kafka/javadsl/KafkaSourceProvider.scala
+++ b/akka-projection-kafka/src/main/scala/akka/projection/kafka/javadsl/KafkaSourceProvider.scala
@@ -5,7 +5,9 @@
 package akka.projection.kafka.javadsl
 
 import java.lang.{ Long => JLong }
+
 import akka.actor.typed.ActorSystem
+import akka.annotation.ApiMayChange
 import akka.kafka.ConsumerSettings
 import akka.projection.MergeableOffset
 import akka.projection.javadsl.SourceProvider
@@ -14,6 +16,7 @@ import akka.projection.kafka.internal.KafkaSourceProviderSettings
 import akka.projection.kafka.internal.MetadataClientAdapterImpl
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
+@ApiMayChange
 object KafkaSourceProvider {
 
   /**

--- a/akka-projection-kafka/src/main/scala/akka/projection/kafka/scaladsl/KafkaSourceProvider.scala
+++ b/akka-projection-kafka/src/main/scala/akka/projection/kafka/scaladsl/KafkaSourceProvider.scala
@@ -5,7 +5,9 @@
 package akka.projection.kafka.scaladsl
 
 import java.lang.{ Long => JLong }
+
 import akka.actor.typed.ActorSystem
+import akka.annotation.ApiMayChange
 import akka.kafka.ConsumerSettings
 import akka.projection.MergeableOffset
 import akka.projection.kafka.internal.KafkaSourceProviderImpl
@@ -14,6 +16,7 @@ import akka.projection.kafka.internal.MetadataClientAdapterImpl
 import akka.projection.scaladsl.SourceProvider
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
+@ApiMayChange
 object KafkaSourceProvider {
 
   /**

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
@@ -39,6 +39,10 @@ import akka.projection.scaladsl.SourceProvider
 import akka.stream.scaladsl.Source
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
+
+/**
+ * INTERNAL API
+ */
 @InternalApi
 private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile](
     val projectionId: ProjectionId,

--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/TestProjection.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/TestProjection.scala
@@ -10,6 +10,7 @@ import scala.concurrent.duration.FiniteDuration
 import akka.Done
 import akka.NotUsed
 import akka.actor.typed.ActorSystem
+import akka.annotation.ApiMayChange
 import akka.projection.Projection
 import akka.projection.ProjectionId
 import akka.projection.RunningProjection
@@ -25,6 +26,7 @@ import akka.stream.SharedKillSwitch
 import akka.stream.scaladsl.Source
 
 // FIXME: this should be refactored as part of #198
+@ApiMayChange
 object TestProjection {
   def apply[Offset, Envelope](
       system: ActorSystem[_],
@@ -35,6 +37,7 @@ object TestProjection {
     new TestProjection(projectionId, sourceProvider, startOffset, handler)(system)
 }
 
+@ApiMayChange
 class TestProjection[Offset, Envelope](
     val projectionId: ProjectionId,
     sourceProvider: SourceProvider[Offset, Envelope],
@@ -106,6 +109,7 @@ class TestProjection[Offset, Envelope](
 }
 
 // FIXME: this should be replaced as part of #198
+@ApiMayChange
 object TestSourceProvider {
   def apply[Offset, Envelope](
       sourceEvents: List[Envelope],
@@ -115,6 +119,7 @@ object TestSourceProvider {
   }
 }
 
+@ApiMayChange
 class TestSourceProvider[Offset, Envelope] private[projection] (
     sourceEvents: List[Envelope],
     _extractOffset: Envelope => Offset,


### PR DESCRIPTION
References #96

I focused on class-level annotations so there's probably some `private` fields/methods in publicly accessible classes that are missing `@InternalApi`.
