### PR TITLE
[Cassandra] Review ExecutionContext usage - Remove FIXME

### DIFF
--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
@@ -176,7 +176,6 @@ import akka.stream.scaladsl.Source
         statusObserver,
         settings) {
 
-    // FIXME maybe use the session-dispatcher config
     override implicit def executionContext: ExecutionContext = system.executionContext
     override def logger: LoggingAdapter = Logging(system.classicSystem, this.getClass)
 


### PR DESCRIPTION
References #148

All DB-related operations use the `CassandraSession` so they are all run on the configured `session-dispatcher`. The `InternalProjectionState` needs an `ExecutionContext` for a handful of operations but none is DB-related. On top of that, some of the operations in `InternalProjectionState` that need an `ExecutionContext` should better not run on the DB `ExecutionContext` (e.g. `statusObserver`, `telemetry`).


Mental note (for a separate PR): should any future running `statusObserver` or `telemetry` be bound to a dedicated dispatcher?