### PR TITLE
Review API applying InternalApi annotations and comment

### DIFF
--- a/akka-projection-core/src/main/scala/akka/projection/javadsl/Handler.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/javadsl/Handler.scala
@@ -15,9 +15,9 @@ import akka.annotation.InternalApi
 object Handler {
 
   /**
-   * Handler that can be defined from a simple function
-   *
    * INTERNAL API
+   *
+   * Handler that can be defined from a simple function
    */
   @InternalApi
   private class HandlerFunction[Envelope](handler: Envelope => CompletionStage[Done]) extends Handler[Envelope] {

--- a/akka-projection-core/src/main/scala/akka/projection/javadsl/Handler.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/javadsl/Handler.scala
@@ -9,11 +9,17 @@ import java.util.concurrent.CompletionStage
 
 import akka.Done
 import akka.annotation.ApiMayChange
+import akka.annotation.InternalApi
 
 @ApiMayChange
 object Handler {
 
-  /** Handler that can be defined from a simple function */
+  /**
+   * Handler that can be defined from a simple function
+   *
+   * INTERNAL API
+   */
+  @InternalApi
   private class HandlerFunction[Envelope](handler: Envelope => CompletionStage[Done]) extends Handler[Envelope] {
     override def process(envelope: Envelope): CompletionStage[Done] = handler(envelope)
   }

--- a/akka-projection-core/src/main/scala/akka/projection/scaladsl/ProjectionManagement.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/scaladsl/ProjectionManagement.scala
@@ -51,12 +51,7 @@ import akka.util.Timeout
     })
   }
 
-  /**
-   * INTERNAL API: ProjectionBehavior registers when started.
-   */
-  @InternalApi private[projection] def register(
-      projectionId: ProjectionId,
-      projection: ActorRef[OffsetManagementCommand]): Unit = {
+  private[projection] def register(projectionId: ProjectionId, projection: ActorRef[OffsetManagementCommand]): Unit = {
     topic(projectionId.name) ! Topic.Subscribe(projection)
   }
 

--- a/akka-projection-core/src/main/scala/akka/projection/scaladsl/ProjectionManagement.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/scaladsl/ProjectionManagement.scala
@@ -50,6 +50,9 @@ import akka.util.Timeout
     })
   }
 
+  /**
+   * ProjectionBehavior registers when started
+   */
   private[projection] def register(projectionId: ProjectionId, projection: ActorRef[OffsetManagementCommand]): Unit = {
     topic(projectionId.name) ! Topic.Subscribe(projection)
   }

--- a/akka-projection-core/src/main/scala/akka/projection/scaladsl/ProjectionManagement.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/scaladsl/ProjectionManagement.scala
@@ -17,7 +17,6 @@ import akka.actor.typed.ExtensionId
 import akka.actor.typed.pubsub.Topic
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.annotation.ApiMayChange
-import akka.annotation.InternalApi
 import akka.projection.ProjectionBehavior
 import akka.projection.ProjectionId
 import akka.util.Timeout

--- a/akka-projection-eventsourced/src/main/scala/akka/projection/eventsourced/scaladsl/EventSourcedProvider.scala
+++ b/akka-projection-eventsourced/src/main/scala/akka/projection/eventsourced/scaladsl/EventSourcedProvider.scala
@@ -33,10 +33,6 @@ object EventSourcedProvider {
     new EventsByTagSourceProvider(eventsByTagQuery, tag, system)
   }
 
-  /**
-   * INTERNAL API
-   */
-  @InternalApi
   private class EventsByTagSourceProvider[Event](
       eventsByTagQuery: EventsByTagQuery,
       tag: String,

--- a/akka-projection-eventsourced/src/main/scala/akka/projection/eventsourced/scaladsl/EventSourcedProvider.scala
+++ b/akka-projection-eventsourced/src/main/scala/akka/projection/eventsourced/scaladsl/EventSourcedProvider.scala
@@ -10,7 +10,6 @@ import scala.concurrent.Future
 import akka.NotUsed
 import akka.actor.typed.ActorSystem
 import akka.annotation.ApiMayChange
-import akka.annotation.InternalApi
 import akka.persistence.query.NoOffset
 import akka.persistence.query.Offset
 import akka.persistence.query.PersistenceQuery

--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/javadsl/JdbcHandler.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/javadsl/JdbcHandler.scala
@@ -5,13 +5,19 @@
 package akka.projection.jdbc.javadsl
 
 import akka.annotation.ApiMayChange
+import akka.annotation.InternalApi
 import akka.projection.jdbc.JdbcHandlerLifecycle
 import akka.projection.jdbc.JdbcSession
 
 @ApiMayChange
 object JdbcHandler {
 
-  /** Handler that can be defined from a simple function */
+  /**
+   * Handler that can be defined from a simple function
+   *
+   * INTERNAL API
+   */
+  @InternalApi
   private class HandlerFunction[Envelope, S <: JdbcSession](handler: (S, Envelope) => Unit)
       extends JdbcHandler[Envelope, S] {
     override def process(session: S, envelope: Envelope): Unit = handler(session, envelope)

--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/TestProjection.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/TestProjection.scala
@@ -11,6 +11,7 @@ import akka.Done
 import akka.NotUsed
 import akka.actor.typed.ActorSystem
 import akka.annotation.ApiMayChange
+import akka.annotation.InternalApi
 import akka.projection.Projection
 import akka.projection.ProjectionId
 import akka.projection.RunningProjection
@@ -61,11 +62,19 @@ class TestProjection[Offset, Envelope](
       groupAfterEnvelopes: Int,
       groupAfterDuration: FiniteDuration): TestProjection[Offset, Envelope] = this
 
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
   private[akka] def actorHandlerInit[T]: Option[ActorHandlerInit[T]] = None
 
   override def run()(implicit system: ActorSystem[_]): RunningProjection =
     new InternalProjectionState(sourceProvider, handler).newRunningInstance()
 
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
   private[projection] def mappedSource()(implicit system: ActorSystem[_]): Source[Done, Future[Done]] =
     new InternalProjectionState(sourceProvider, handler).mappedSource()
 
@@ -74,6 +83,7 @@ class TestProjection[Offset, Envelope](
    * This internal class will hold the KillSwitch that is needed
    * when building the mappedSource and when running the projection (to stop)
    */
+  @InternalApi
   private class InternalProjectionState(sourceProvider: SourceProvider[Offset, Envelope], handler: Handler[Envelope])(
       implicit val system: ActorSystem[_]) {
 
@@ -96,6 +106,10 @@ class TestProjection[Offset, Envelope](
       new TestRunningProjection(mappedSource(), killSwitch)
   }
 
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
   private class TestRunningProjection(val source: Source[Done, _], killSwitch: SharedKillSwitch)
       extends RunningProjection {
 

--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/javadsl/ProjectionTestKit.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/javadsl/ProjectionTestKit.scala
@@ -18,6 +18,7 @@ import akka.actor.typed.SupervisorStrategy
 import akka.actor.typed.javadsl.Adapter
 import akka.actor.typed.scaladsl.Behaviors
 import akka.annotation.ApiMayChange
+import akka.annotation.InternalApi
 import akka.japi.function.Effect
 import akka.japi.function.Procedure
 import akka.projection.Projection
@@ -92,6 +93,10 @@ final class ProjectionTestKit private[projection] (testKit: ActorTestKit) {
   def run(projection: Projection[_], max: Duration, interval: Duration, assertFunction: Effect): Unit =
     runInternal(projection, assertFunction, max, interval)
 
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
   private def runInternal(
       projection: Projection[_],
       assertFunction: Effect,
@@ -137,6 +142,10 @@ final class ProjectionTestKit private[projection] (testKit: ActorTestKit) {
     }
   }
 
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
   private def spawnActorHandler(projection: Projection[_]): Option[ActorRef[_]] = {
     projection.actorHandlerInit[Any].map { init =>
       val ref = testKit.spawn(Behaviors.supervise(init.behavior).onFailure(SupervisorStrategy.restart))


### PR DESCRIPTION
References #96

In #359 I focused on class-level annotation. Here I'm digging deeper. I'm reviewing 3 types of cases:

 - use of `@InternalApi` in scaladsl is not necessary so I removed it.
 - missing use of `@InternalApi` in javadsl
 - missing use of `@InternalApi` in non-API especific, non-internal code.
