### PR TITLE
Document caveats when using exactly-once with Kafka source

### DIFF
--- a/akka-projection-kafka/src/main/resources/reference.conf
+++ b/akka-projection-kafka/src/main/resources/reference.conf
@@ -1,7 +1,7 @@
 # The time to wait before retrieving the last saved offsets. Due to the asynchronous nature of Akka Streams, when a
 # Kafka Consumer Group rebalance occurs it's possible that some messages from a revoked partitions are still in-flight
-# and have not yet been committed to the offset store yet. Projections will attempt to filter out such messages, but
-# it's not possible to guarantee all the time. This delay adds a small buffer of time between when the Kafka Source
+# and have not yet been committed to the offset store. Projections will attempt to filter out such messages, but
+# it's not possible to guarantee it all the time. This delay adds a small buffer of time between when the Kafka Source
 # Provider starts up, or when it's assigned a new partition, to retrieve the map of partitions to offsets to give
 # any projections running in parallel a chance to drain in-flight messages.
 akka.projection.kafka.read-offset-delay = 500 ms

--- a/akka-projection-kafka/src/main/resources/reference.conf
+++ b/akka-projection-kafka/src/main/resources/reference.conf
@@ -10,5 +10,4 @@ akka.projection.kafka {
   # to drain in-flight messages.
   read-offset-delay = 500 ms
 }
-
 //#config

--- a/akka-projection-kafka/src/main/resources/reference.conf
+++ b/akka-projection-kafka/src/main/resources/reference.conf
@@ -1,7 +1,14 @@
-# The time to wait before retrieving the last saved offsets. Due to the asynchronous nature of Akka Streams, when a
-# Kafka Consumer Group rebalance occurs it's possible that some messages from a revoked partitions are still in-flight
-# and have not yet been committed to the offset store. Projections will attempt to filter out such messages, but
-# it's not possible to guarantee it all the time. This delay adds a small buffer of time between when the Kafka Source
-# Provider starts up, or when it's assigned a new partition, to retrieve the map of partitions to offsets to give
-# any projections running in parallel a chance to drain in-flight messages.
-akka.projection.kafka.read-offset-delay = 500 ms
+
+//#config
+akka.projection.kafka {
+  # The time to wait before retrieving the last saved offsets. Due to the asynchronous nature of Akka Streams, 
+  # when a Kafka Consumer Group rebalance occurs it's possible that some messages from a revoked partitions 
+  # are still in-flight and have not yet been committed to the offset store. Projections will attempt to 
+  # filter out such messages, but it's not possible to guarantee it all the time. This delay adds a small 
+  # buffer of time between when the Kafka Source Provider starts up, or when it's assigned a new partition, 
+  # to retrieve the map of partitions to offsets to give any projections running in parallel a chance 
+  # to drain in-flight messages.
+  read-offset-delay = 500 ms
+}
+
+//#config

--- a/docs/src/main/paradox/kafka.md
+++ b/docs/src/main/paradox/kafka.md
@@ -7,7 +7,7 @@ The @apidoc[KafkaSourceProvider$] uses consumer group assignments from Kafka and
 Akka Projections can store the offsets from Kafka in a @ref:[relational DB with JDBC](jdbc.md)
 or in @ref:[relational DB with Slick](slick.md).
 
-The `JdbcProjection` @scala[or `SlickProjection`] envelope handler will be run by the projection. This means that the target database operations can be run in the same transaction as the storage of the offset, which means when used @ref:[exactly-once](jdbc.md#exactly-once) the offsets will be persisted on the same transaction as the projected model (see @ref:[exactly-once caveats](#committing-offset-on-db)). It also offers @ref:[at-least-once](jdbc.md#at-least-once) semantics.
+The `JdbcProjection` @scala[or `SlickProjection`] envelope handler will be run by the projection. This means that the target database operations can be run in the same transaction as the storage of the offset, which means when used @ref:[exactly-once](jdbc.md#exactly-once) the offsets will be persisted on the same transaction as the projected model (see @ref:[Committing offset outside Kafka](#committing-offset-outside-kafka)). It also offers @ref:[at-least-once](jdbc.md#at-least-once) semantics.
 
 @@@ note
 

--- a/docs/src/main/paradox/kafka.md
+++ b/docs/src/main/paradox/kafka.md
@@ -1,13 +1,13 @@
 # Messages from and to Kafka
 
-A typical source for Projections is messages from Kafka. Akka Projections has integration with [Alpakka Kafka](https://doc.akka.io/docs/alpakka-kafka/current/), which is described in here.
+A typical source for Projections is messages from Kafka. Akka Projections supports integration with Kafka using [Alpakka Kafka](https://doc.akka.io/docs/alpakka-kafka/current/).
 
 The @apidoc[KafkaSourceProvider$] uses consumer group assignments from Kafka and can resume from offsets stored in a database.
 
 Akka Projections can store the offsets from Kafka in a @ref:[relational DB with JDBC](jdbc.md)
 or in @ref:[relational DB with Slick](slick.md).
 
-The `JdbcProjection` @scala[or `SlickProjection`] envelope handler will be run by the projection. This means that the target database operations can be run in the same transaction as the storage of the offset, which means when used @ref:[exactly-once](jdbc.md#exactly-once) the offsets will be persisted on the same transaction as the projected model (see @ref:[Committing offset outside Kafka](#committing-offset-outside-kafka)). It also offers @ref:[at-least-once](jdbc.md#at-least-once) semantics.
+The `JdbcProjection` @scala[or `SlickProjection`] envelope handler will be run by the projection. This means that the target database operations can be run in the same transaction as the storage of the offset, which means when used with @ref:[exactly-once](jdbc.md#exactly-once) the offsets will be persisted on the same transaction as the projected model (see @ref:[Committing offset outside Kafka](#committing-offset-outside-kafka)). It also offers @ref:[at-least-once](jdbc.md#at-least-once) semantics.
 
 @@@ note
 

--- a/docs/src/main/paradox/kafka.md
+++ b/docs/src/main/paradox/kafka.md
@@ -1,22 +1,18 @@
 # Messages from and to Kafka
 
-A typical source for Projections is messages from Kafka. Akka Projections has integration with 
-[Alpakka Kafka](https://doc.akka.io/docs/alpakka-kafka/current/), which is described in here.
+A typical source for Projections is messages from Kafka. Akka Projections has integration with [Alpakka Kafka](https://doc.akka.io/docs/alpakka-kafka/current/), which is described in here.
 
-The @apidoc[KafkaSourceProvider$] uses consumer group assignments from Kafka and can resume from offsets stored in
-a database.
+The @apidoc[KafkaSourceProvider$] uses consumer group assignments from Kafka and can resume from offsets stored in a database.
 
 Akka Projections can store the offsets from Kafka in a @ref:[relational DB with JDBC](jdbc.md)
 or in @ref:[relational DB with Slick](slick.md).
 
-The `JdbcProjection` @scala[or `SlickProjection`] envelope handler will be run by the projection. This means that the target database
-operations can be run in the same transaction as the storage of the offset, which means that @ref:[exactly-once](jdbc.md#exactly-once)
-processing semantics is supported. It also offers @ref:[at-least-once](jdbc.md#at-least-once) semantics.
+The `JdbcProjection` @scala[or `SlickProjection`] envelope handler will be run by the projection. This means that the target database operations can be run in the same transaction as the storage of the offset, which means when used @ref:[exactly-once](jdbc.md#exactly-once) the offsets will be persisted on the same transaction as the projected model (see @ref:[exactly-once caveats](#committing-offset-on-db)). It also offers @ref:[at-least-once](jdbc.md#at-least-once) semantics.
 
 @@@ note
 
 Offset storage of Kafka offsets are not implemented for Cassandra yet, see [issue #97](https://github.com/akka/akka-projection/issues/97).
- 
+
 @@@
 
 A `Projection` can also @ref:[send messages to Kafka](#sending-to-kafka).
@@ -71,15 +67,17 @@ Scala
 Java
 :  @@snip [KafkaDocExample.java](/examples/src/test/java/jdocs/kafka/KafkaDocExample.java) { #handler }
 
+## Committing offset outside Kafka
+
+The `KafkaSourceProvider` described above stores the Kafka offsets in a database. The main advantage of storing the offsets in a database is that exactly-once processing semantics can be achieved if the target database operations of the projection can be run in the same transaction as the storage of the offset.
+
+However, there is a caveat when chosing for `exactly-once`. When the Kafka Consumer Group rebalance occurs it's possible that some messages from a revoked partitions are still in-flight and have not yet been committed to the offset store. Projections will attempt to filter out such messages, but it's not possible to guarantee it all the time.
+
+To mitigate that risk, you can increase the value of `akka.projection.kafka.read-offset-delay` (defaults to 500ms). This delay adds a buffer of time between when the Kafka Source Provider starts up, or when it's assigned a new partition, to retrieve the map of partitions to offsets to give any projections running in parallel a chance to drain in-flight messages.
+
 ## Committing offset in Kafka
 
-The `KafkaSourceProvider` described above stores the Kafka offsets in a database. It is more common to
-commit the offsets back to Kafka. The main advantage of storing the offsets in a database is that exactly-once
-processing semantics can be achieved if the target database operations of the projection can be run in the same
-transaction as the storage of the offset.
-
-When using the approach of committing the offsets back to Kafka the [Alpakka Kafka comittableSource](https://doc.akka.io/docs/alpakka-kafka/current/consumer.html)
-can be used, and Akka Projections is not needed for that usage.
+When using the approach of committing the offsets back to Kafka the [Alpakka Kafka comittableSource](https://doc.akka.io/docs/alpakka-kafka/current/consumer.html) can be used, and Akka Projections is not needed for that usage.
 
 ## Sending to Kafka
 
@@ -132,4 +130,3 @@ To begin consuming from Kafka using offsets stored in a projection's offset stor
 The Kafka offset map is modelled as multiple rows in the projection offset table, where each row includes the projection name, a surrogate projection key that represents the Kafka topic partition, and the offset as a `java.lang.Long`.
 When a projection with @apidoc[KafkaSourceProvider$] is started, or when a Kafka consumer group rebalance occurs, we read all the rows from the offset table for a projection name.
 When an offset is committed we persist one or more rows of the Kafka offset map back to the projection offset table.
-

--- a/docs/src/main/paradox/kafka.md
+++ b/docs/src/main/paradox/kafka.md
@@ -130,3 +130,11 @@ To begin consuming from Kafka using offsets stored in a projection's offset stor
 The Kafka offset map is modelled as multiple rows in the projection offset table, where each row includes the projection name, a surrogate projection key that represents the Kafka topic partition, and the offset as a `java.lang.Long`.
 When a projection with @apidoc[KafkaSourceProvider$] is started, or when a Kafka consumer group rebalance occurs, we read all the rows from the offset table for a projection name.
 When an offset is committed we persist one or more rows of the Kafka offset map back to the projection offset table.
+
+## Configuration
+
+Make your edits/overrides in your application.conf.
+
+The reference configuration file with the default values:
+
+@@snip [reference.conf](/akka-projection-kafka/src/main/resources/reference.conf) { #config }


### PR DESCRIPTION
References #214
