### PR TITLE
Use single tag in Getting Started Guide

### DIFF
--- a/docs/src/main/paradox/getting-started/running.md
+++ b/docs/src/main/paradox/getting-started/running.md
@@ -87,7 +87,7 @@ sbt "examples/test:runMain docs.guide.ShoppingCartApp"
 After a few seconds you should see the `DailyCheckoutProjectionHandler` logging that displays the current checkouts for the day:
 
 ```shell
-[2020-07-16 15:26:23,420] [INFO] [docs.guide.DailyCheckoutProjectionHandler] [] [ShoppingCartApp-akka.actor.default-dispatcher-5] - DailyCheckoutProjectionHandler(shopping-cart-001) current checkouts for the day [2020-07-16] is:                                                                                                 
+[2020-07-16 15:26:23,420] [INFO] [docs.guide.DailyCheckoutProjectionHandler] [] [ShoppingCartApp-akka.actor.default-dispatcher-5] - DailyCheckoutProjectionHandler(shopping-cart) current checkouts for the day [2020-07-16] is:                                                                                                 
 Date        Cart ID  Item ID             Quantity                                                                                                             
 2020-07-16  018db    akka t-shirt        0                                                                                                                    
 2020-07-16  018db    cat t-shirt         2                                                                                                                    

--- a/examples/src/test/scala/docs/guide/EventGeneratorApp.scala
+++ b/examples/src/test/scala/docs/guide/EventGeneratorApp.scala
@@ -27,7 +27,7 @@ object EventGeneratorApp extends App {
   sealed trait Command
   final case object Start extends Command
 
-  val shoppingCartsTag = "shopping-cart-001"
+  val shoppingCartsTag = "shopping-cart"
   val config = ConfigFactory.parseResources("guide-shopping-cart-app.conf")
 
   ActorSystem(Behaviors.setup[Command] {

--- a/examples/src/test/scala/docs/guide/ShoppingCartApp.scala
+++ b/examples/src/test/scala/docs/guide/ShoppingCartApp.scala
@@ -71,7 +71,7 @@ object ShoppingCartApp extends App {
 
       //#guideSetup
       //#guideSourceProviderSetup
-      val shoppingCartsTag = "shopping-cart-001"
+      val shoppingCartsTag = "shopping-cart"
       val sourceProvider: SourceProvider[Offset, EventEnvelope[ShoppingCartEvents.Event]] =
         EventSourcedProvider
           .eventsByTag[ShoppingCartEvents.Event](


### PR DESCRIPTION
I found a [comment from Patrik](https://github.com/akka/akka-projection/pull/270#discussion_r445370557) on the original Getting Started Guide that I think it makes sense. 

Basically, it's about starting with one tag like is usually done in Akka (pre-Lagom) and then, when we introduce `ShardedDaemonProcess` we can create sharded tags and explain why. 

We do have a single tag now, but we moved from one suffixed with `-eu`, giving the impression that it was about a datacenter, to one suffixed with `-001`. 

This PR changes the tag to `shopping-cart`.