### PR TITLE
Use a JDBC-backed handler to demo exactly-once

### DIFF
--- a/docs/src/main/paradox/kafka.md
+++ b/docs/src/main/paradox/kafka.md
@@ -63,13 +63,21 @@ Scala
 Java
 :  @@snip [KafkaDocExample.java](/examples/src/test/java/jdocs/kafka/KafkaDocExample.java) { #exactlyOnce }
 
-and the `WordCountHandler`:
+and the `WordCountJdbcHandler`:
 
 Scala
-:  @@snip [KafkaDocExample.scala](/examples/src/test/scala/docs/kafka/KafkaDocExample.scala) { #handler }
+:  @@snip [KafkaDocExample.scala](/examples/src/test/scala/docs/kafka/KafkaDocExample.scala) { #exactly-once-jdbc-handler }
 
 Java
-:  @@snip [KafkaDocExample.java](/examples/src/test/java/jdocs/kafka/KafkaDocExample.java) { #handler }
+:  @@snip [KafkaDocExample.java](/examples/src/test/java/jdocs/kafka/KafkaDocExample.java) { #exactly-once-jdbc-handler }
+
+Where the `WordRepository` is an implementation of:
+
+Scala
+:  @@snip [KafkaDocExample.scala](/examples/src/test/scala/docs/kafka/KafkaDocExample.scala) { #repository }
+
+Java
+:  @@snip [KafkaDocExample.java](/examples/src/test/java/jdocs/kafka/KafkaDocExample.java) { #repository }
 
 ## Committing offset in Kafka
 

--- a/examples/src/test/java/jdocs/jdbc/HibernateJdbcSession.java
+++ b/examples/src/test/java/jdocs/jdbc/HibernateJdbcSession.java
@@ -19,7 +19,7 @@ import java.sql.SQLException;
 // #hibernate-session
 public class HibernateJdbcSession implements JdbcSession {
 
-  final EntityManager entityManager;
+  public final EntityManager entityManager;
   private final EntityTransaction transaction;
 
   public HibernateJdbcSession(EntityManager entityManager) {

--- a/examples/src/test/scala/docs/kafka/KafkaDocExample.scala
+++ b/examples/src/test/scala/docs/kafka/KafkaDocExample.scala
@@ -166,11 +166,11 @@ object KafkaDocExample {
         projectionId,
         sourceProvider,
         () => sessionProvider.newInstance(),
-        handler = () => new WordCountSlickHandler(wordRepository))
+        handler = () => new WordCountJdbcHandler(wordRepository))
     //#exactlyOnce
 
     // #exactly-once-jdbc-handler
-    class WordCountSlickHandler(val wordRepository: WordRepository)
+    class WordCountJdbcHandler(val wordRepository: WordRepository)
         extends JdbcHandler[ConsumerRecord[String, String], HibernateJdbcSession] {
 
       @throws[Exception]


### PR DESCRIPTION
References #256

Copies the approach used in JDBC/Slick pages were the actual repository implementation is left out of the sample code/docs.
