### PR TITLE
DRY TestProjection usages for internal tests

### DIFF
--- a/akka-projection-core-test/src/test/resources/logback-test.xml
+++ b/akka-projection-core-test/src/test/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!-- Silence initial setup logging from Logback -->
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+  <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />
+
+  <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >
+    <appender-ref ref="STDOUT"/>
+  </logger>
+
+  <root level="DEBUG">
+    <appender-ref ref="CapturingAppender" />
+  </root>
+</configuration>

--- a/akka-projection-core-test/src/test/scala/akka/projection/ProjectionBehaviorSpec.scala
+++ b/akka-projection-core-test/src/test/scala/akka/projection/ProjectionBehaviorSpec.scala
@@ -4,11 +4,10 @@
 
 package akka.projection
 
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
-import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.concurrent.Future
 
 import akka.Done
 import akka.NotUsed
@@ -17,12 +16,16 @@ import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
-import akka.projection.internal.ActorHandlerInit
-import akka.projection.internal.NoopStatusObserver
-import akka.projection.internal.RestartBackoffSettings
-import akka.projection.internal.SettingsImpl
+import akka.projection.internal.AtMostOnce
+import akka.projection.internal.HandlerStrategy
+import akka.projection.internal.OffsetStrategy
+import akka.projection.internal.SingleHandlerStrategy
+import akka.projection.scaladsl.Handler
 import akka.projection.scaladsl.ProjectionManagement
-import akka.stream.KillSwitches
+import akka.projection.scaladsl.SourceProvider
+import akka.projection.testkit.TestInMemoryOffsetStore
+import akka.projection.testkit.TestProjection
+import akka.projection.testkit.TestSourceProvider
 import akka.stream.OverflowStrategy
 import akka.stream.SharedKillSwitch
 import akka.stream.scaladsl.Source
@@ -37,78 +40,83 @@ object ProjectionBehaviorSpec {
 
   private val TestProjectionId = ProjectionId("test-projection", "00")
 
+  def handler(probe: TestProbe[ProbeMessage]): Handler[Int] = new Handler[Int] {
+    val strBuffer: StringBuffer = new StringBuffer()
+    override def process(env: Int): Future[Done] = {
+      concat(env)
+      probe.ref ! Consumed(env, strBuffer.toString)
+      Future.successful(Done)
+    }
+
+    def concat(i: Int) = {
+      if (strBuffer.toString.isEmpty) strBuffer.append(i)
+      else strBuffer.append("-").append(i)
+    }
+  }
+
   /*
    * This TestProjection has a internal state that we can use to prove that on restart,
    * the actor is taking a new projection instance.
    */
-  private[projection] case class TestProjection(
-      src: Source[Int, NotUsed],
+  private[projection] object ProjectionBehaviourTestProjection {
+    def apply(
+        src: Source[Int, NotUsed],
+        probe: TestProbe[ProbeMessage],
+        projectionId: ProjectionId = TestProjectionId,
+        failToStop: Boolean = false): ProjectionBehaviourTestProjection = {
+      val handlerStrategy = new SingleHandlerStrategy[Int](() => handler(probe))
+      val sourceProvider = TestSourceProvider(src, (i: Int) => i)
+      new ProjectionBehaviourTestProjection(projectionId, sourceProvider, handlerStrategy, probe, failToStop)
+    }
+  }
+
+  private[projection] class ProjectionBehaviourTestProjection(
+      projectionId: ProjectionId,
+      sourceProvider: SourceProvider[Int, Int],
+      handlerStrategy: HandlerStrategy,
       testProbe: TestProbe[ProbeMessage],
-      failToStop: Boolean = false,
-      override val projectionId: ProjectionId = ProjectionBehaviorSpec.TestProjectionId)
-      extends Projection[Int]
-      with SettingsImpl[TestProjection] {
+      failToStop: Boolean)
+      extends TestProjection(projectionId, sourceProvider, handlerStrategy, AtMostOnce(), None) {
 
-    private val offsetStore = new AtomicInteger
+    override private[projection] def newState(implicit system: ActorSystem[_]): TestInternalProjectionState =
+      new ProjectionBehaviourTestInternalProjectionState(
+        projectionId,
+        sourceProvider,
+        handlerStrategy,
+        offsetStrategy,
+        testProbe,
+        failToStop)
 
-    private[projection] def actorHandlerInit[T]: Option[ActorHandlerInit[T]] = None
-
-    override private[projection] def run()(implicit system: ActorSystem[_]): RunningProjection =
-      new InternalProjectionState(testProbe, failToStop).newRunningInstance()
-
-    override private[projection] def mappedSource()(implicit system: ActorSystem[_]): Source[Done, Future[Done]] =
-      new InternalProjectionState(testProbe, failToStop).mappedSource()
-
-    override val statusObserver: StatusObserver[Int] = NoopStatusObserver
-
-    override def withStatusObserver(observer: StatusObserver[Int]): Projection[Int] =
-      this // no need for StatusObserver in tests
-
-    override def withRestartBackoffSettings(restartBackoff: RestartBackoffSettings): TestProjection = this
-    override def withSaveOffset(afterEnvelopes: Int, afterDuration: FiniteDuration): TestProjection = this
-    override def withGroup(groupAfterEnvelopes: Int, groupAfterDuration: FiniteDuration): TestProjection = this
-
-    /*
-     * INTERNAL API
-     * This internal class will hold the KillSwitch that is needed
-     * when building the mappedSource and when running the projection (to stop)
-     */
-    private class InternalProjectionState(testProbe: TestProbe[ProbeMessage], failToStop: Boolean = false)(
-        implicit val system: ActorSystem[_]) {
-
-      private val strBuffer = new StringBuffer("")
-
-      private val killSwitch = KillSwitches.shared(projectionId.id)
-
-      def mappedSource(): Source[Done, Future[Done]] =
-        src.via(killSwitch.flow).mapAsync(1)(i => process(i)).mapMaterializedValue(_ => Future.successful(Done))
-
-      private def process(i: Int): Future[Done] = {
-
-        if (strBuffer.toString.isEmpty) strBuffer.append(i)
-        else strBuffer.append("-").append(i)
-
-        offsetStore.incrementAndGet()
-
-        testProbe.ref ! Consumed(i, strBuffer.toString)
-        Future.successful(Done)
-      }
-
-      def newRunningInstance(): RunningProjection =
-        new TestRunningProjection(mappedSource(), testProbe, failToStop, killSwitch)
+    private[projection] class ProjectionBehaviourTestInternalProjectionState(
+        projectionId: ProjectionId,
+        sourceProvider: SourceProvider[Int, Int],
+        handlerStrategy: HandlerStrategy,
+        offsetStrategy: OffsetStrategy,
+        testProbe: TestProbe[ProbeMessage],
+        failToStop: Boolean)(implicit system: ActorSystem[_])
+        extends TestInternalProjectionState(projectionId, sourceProvider, handlerStrategy, offsetStrategy, None) {
+      override def newRunningInstance(): RunningProjection =
+        new ProjectionBehaviourTestRunningProjection(
+          projectionId,
+          mappedSource(),
+          killSwitch,
+          offsetStore,
+          testProbe,
+          failToStop)
     }
 
-    private class TestRunningProjection(
-        source: Source[Done, Future[Done]],
+    private[projection] class ProjectionBehaviourTestRunningProjection(
+        projectionId: ProjectionId,
+        source: Source[Done, _],
+        killSwitch: SharedKillSwitch,
+        offsetStore: TestInMemoryOffsetStore[Int],
         testProbe: TestProbe[ProbeMessage],
-        failToStop: Boolean = false,
-        killSwitch: SharedKillSwitch)(implicit system: ActorSystem[_])
-        extends RunningProjection
+        failToStop: Boolean)(implicit _system: ActorSystem[_])
+        extends TestRunningProjection(source, killSwitch)
         with ProjectionOffsetManagement[Int] {
       import system.executionContext
 
       testProbe.ref ! StartObserved
-      private val futureDone = source.run()
 
       override def stop(): Future[Done] = {
         val stopFut =
@@ -129,26 +137,27 @@ object ProjectionBehaviorSpec {
       }
 
       override def getOffset(): Future[Option[Int]] = {
-        offsetStore.get() match {
-          case 0 => Future.successful(None)
-          case n => Future.successful(Some(n))
+        offsetStore.lastOffset() match {
+          case Some(0) => Future.successful(None)
+          case Some(n) => Future.successful(Some(n))
+          case _       => Future.failed(new IllegalStateException("No offset has been stored"))
         }
       }
 
       override def setOffset(offset: Option[Int]): Future[Done] = {
         offset match {
           case None =>
-            offsetStore.set(0)
+            offsetStore.saveOffset(projectionId, 0)
             Future.successful(Done)
           case Some(n) =>
             if (n <= 3) {
-              offsetStore.set(n)
+              offsetStore.saveOffset(projectionId, n)
               Future.successful(Done)
             } else {
               import akka.actor.typed.scaladsl.adapter._
               import akka.pattern.after
               after(100.millis, system.toClassic.scheduler) {
-                offsetStore.set(n)
+                offsetStore.saveOffset(projectionId, n)
                 Future.successful(Done)
               }
             }
@@ -156,7 +165,6 @@ object ProjectionBehaviorSpec {
 
       }
     }
-
   }
 }
 class ProjectionBehaviorSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
@@ -174,9 +182,9 @@ class ProjectionBehaviorSpec extends ScalaTestWithActorTestKit with AnyWordSpecL
           srcRef.set(ref.toTyped)
           NotUsed
       }
-
     val testProbe = testKit.createTestProbe[ProbeMessage]()
-    val projectionRef = testKit.spawn(ProjectionBehavior(TestProjection(src, testProbe, projectionId = projectionId)))
+    val projectionRef =
+      testKit.spawn(ProjectionBehavior(ProjectionBehaviourTestProjection(src, testProbe, projectionId)))
     eventually {
       srcRef.get() should not be null
     }
@@ -189,7 +197,7 @@ class ProjectionBehaviorSpec extends ScalaTestWithActorTestKit with AnyWordSpecL
 
       val testProbe = testKit.createTestProbe[ProbeMessage]()
       val src = Source(1 to 2)
-      testKit.spawn(ProjectionBehavior(TestProjection(src, testProbe)))
+      testKit.spawn(ProjectionBehavior(ProjectionBehaviourTestProjection(src, testProbe)))
 
       testProbe.expectMessage(StartObserved)
       testProbe.expectMessage(Consumed(1, "1"))
@@ -202,7 +210,7 @@ class ProjectionBehaviorSpec extends ScalaTestWithActorTestKit with AnyWordSpecL
 
       val testProbe = testKit.createTestProbe[ProbeMessage]()
       val src = Source(1 to 2)
-      val projectionRef = testKit.spawn(ProjectionBehavior(TestProjection(src, testProbe)))
+      val projectionRef = testKit.spawn(ProjectionBehavior(ProjectionBehaviourTestProjection(src, testProbe)))
 
       testProbe.expectMessage(StartObserved)
       testProbe.expectMessage(Consumed(1, "1"))
@@ -220,7 +228,8 @@ class ProjectionBehaviorSpec extends ScalaTestWithActorTestKit with AnyWordSpecL
 
       val testProbe = testKit.createTestProbe[ProbeMessage]()
       val src = Source(1 to 2)
-      val projectionRef = testKit.spawn(ProjectionBehavior(TestProjection(src, testProbe, failToStop = true)))
+      val projectionRef =
+        testKit.spawn(ProjectionBehavior(ProjectionBehaviourTestProjection(src, testProbe, failToStop = true)))
 
       testProbe.expectMessage(StartObserved)
       testProbe.expectMessage(Consumed(1, "1"))

--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/TestProjection.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/TestProjection.scala
@@ -4,25 +4,38 @@
 
 package akka.projection.testkit
 
+import java.util.Optional
+import java.util.function.Supplier
+
+import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
+import scala.compat.java8.OptionConverters._
 
 import akka.Done
 import akka.NotUsed
 import akka.actor.typed.ActorSystem
 import akka.annotation.ApiMayChange
 import akka.annotation.InternalApi
+import akka.event.Logging
+import akka.event.LoggingAdapter
 import akka.projection.Projection
 import akka.projection.ProjectionId
 import akka.projection.RunningProjection
 import akka.projection.StatusObserver
 import akka.projection.internal.ActorHandlerInit
+import akka.projection.internal.AtLeastOnce
+import akka.projection.internal.HandlerAdapter
+import akka.projection.internal.HandlerStrategy
+import akka.projection.internal.InternalProjectionState
 import akka.projection.internal.NoopStatusObserver
+import akka.projection.internal.ProjectionSettings
 import akka.projection.internal.RestartBackoffSettings
 import akka.projection.internal.SettingsImpl
+import akka.projection.internal.SingleHandlerStrategy
+import akka.projection.internal.SourceProviderAdapter
 import akka.projection.scaladsl.Handler
 import akka.projection.scaladsl.SourceProvider
-import akka.stream.KillSwitches
 import akka.stream.SharedKillSwitch
 import akka.stream.scaladsl.Source
 
@@ -30,24 +43,43 @@ import akka.stream.scaladsl.Source
 @ApiMayChange
 object TestProjection {
   def apply[Offset, Envelope](
-      system: ActorSystem[_],
       projectionId: ProjectionId,
       sourceProvider: SourceProvider[Offset, Envelope],
-      startOffset: Offset,
-      handler: Handler[Envelope]): Projection[Envelope] =
-    new TestProjection(projectionId, sourceProvider, startOffset, handler)(system)
+      handler: () => Handler[Envelope],
+      startOffset: Option[Offset]): Projection[Envelope] =
+    new TestProjection(projectionId, sourceProvider, SingleHandlerStrategy(handler), startOffset)
+
+  /**
+   * Java API
+   */
+  def create[Offset, Envelope](
+      projectionId: ProjectionId,
+      sourceProvider: akka.projection.javadsl.SourceProvider[Offset, Envelope],
+      handler: Supplier[akka.projection.javadsl.Handler[Envelope]],
+      startOffset: Optional[Offset]): Projection[Envelope] =
+    new TestProjection(
+      projectionId,
+      new SourceProviderAdapter(sourceProvider),
+      SingleHandlerStrategy(() => HandlerAdapter(handler.get())),
+      startOffset.asScala)
 }
 
 @ApiMayChange
-class TestProjection[Offset, Envelope](
+class TestProjection[Offset, Envelope] private (
     val projectionId: ProjectionId,
     sourceProvider: SourceProvider[Offset, Envelope],
-    startOffset: Offset,
-    handler: Handler[Envelope])(implicit val system: ActorSystem[_])
+    handlerStrategy: HandlerStrategy,
+    startOffset: Option[Offset])
     extends Projection[Envelope]
     with SettingsImpl[TestProjection[Offset, Envelope]] {
 
-  @volatile var currentOffset: Offset = startOffset
+  private var state: Option[TestInternalProjectionState] = None
+
+  def offsetStore: TestInMemoryOffsetStore[Offset] =
+    state
+      .map(_.offsetStore)
+      .getOrElse(throw new IllegalStateException(
+        "The OffsetStore is not available because the InternalProjectionState has not been initialized (the projection has not been run)"))
 
   override val statusObserver: StatusObserver[Envelope] = NoopStatusObserver
 
@@ -56,8 +88,10 @@ class TestProjection[Offset, Envelope](
 
   final override def withRestartBackoffSettings(
       restartBackoff: RestartBackoffSettings): TestProjection[Offset, Envelope] = this
+
   override def withSaveOffset(afterEnvelopes: Int, afterDuration: FiniteDuration): TestProjection[Offset, Envelope] =
     this
+
   override def withGroup(
       groupAfterEnvelopes: Int,
       groupAfterDuration: FiniteDuration): TestProjection[Offset, Envelope] = this
@@ -68,15 +102,21 @@ class TestProjection[Offset, Envelope](
   @InternalApi
   private[projection] def actorHandlerInit[T]: Option[ActorHandlerInit[T]] = None
 
+  private def newOrExistingState(implicit system: ActorSystem[_]): TestInternalProjectionState = {
+    if (state.isEmpty)
+      state = Some(new TestInternalProjectionState(projectionId, sourceProvider, handlerStrategy, startOffset))
+    state.get
+  }
+
   override def run()(implicit system: ActorSystem[_]): RunningProjection =
-    new InternalProjectionState(sourceProvider, handler).newRunningInstance()
+    newOrExistingState.newRunningInstance()
 
   /**
    * INTERNAL API
    */
   @InternalApi
   private[projection] def mappedSource()(implicit system: ActorSystem[_]): Source[Done, Future[Done]] =
-    new InternalProjectionState(sourceProvider, handler).mappedSource()
+    newOrExistingState.mappedSource()
 
   /*
    * INTERNAL API
@@ -84,23 +124,35 @@ class TestProjection[Offset, Envelope](
    * when building the mappedSource and when running the projection (to stop)
    */
   @InternalApi
-  private class InternalProjectionState(sourceProvider: SourceProvider[Offset, Envelope], handler: Handler[Envelope])(
-      implicit val system: ActorSystem[_]) {
+  private class TestInternalProjectionState(
+      projectionId: ProjectionId,
+      sourceProvider: SourceProvider[Offset, Envelope],
+      handlerStrategy: HandlerStrategy,
+      startOffset: Option[Offset])(implicit val system: ActorSystem[_])
+      extends InternalProjectionState[Offset, Envelope](
+        projectionId,
+        sourceProvider,
+        // Disable batching so that `ProjectionTestKit.runWithTestSink` emits 1 `Done` per envelope.
+        // FIXME: Is there any reason to let the user choose the `OffsetStrategy` in tests?
+        AtLeastOnce(afterEnvelopes = Some(1)),
+        handlerStrategy,
+        NoopStatusObserver, // FIXME: Always disable metrics during tests?
+        ProjectionSettings(system)) {
 
-    implicit val ec = system.classicSystem.dispatcher
+    override implicit val executionContext: ExecutionContext = system.executionContext
 
-    private val killSwitch = KillSwitches.shared(projectionId.id)
-
-    def mappedSource(): Source[Done, Future[Done]] = {
-      Source
-        .futureSource(
-          handler
-            .tryStart()
-            .flatMap(_ => sourceProvider.source(() => Future.successful(Option(currentOffset)))))
-        .via(killSwitch.flow)
-        .mapAsync(1)(i => handler.process(i))
-        .mapMaterializedValue(_ => Future.successful(Done))
+    val offsetStore: TestInMemoryOffsetStore[Offset] = {
+      val store = new TestInMemoryOffsetStore[Offset]()
+      startOffset.foreach(offset => store.saveOffset(projectionId, offset))
+      store
     }
+
+    override def logger: LoggingAdapter = Logging(system.classicSystem, this.getClass)
+
+    override def readOffsets(): Future[Option[Offset]] = offsetStore.readOffsets()
+
+    override def saveOffset(projectionId: ProjectionId, offset: Offset): Future[Done] =
+      offsetStore.saveOffset(projectionId, offset)
 
     def newRunningInstance(): RunningProjection =
       new TestRunningProjection(mappedSource(), killSwitch)
@@ -110,7 +162,8 @@ class TestProjection[Offset, Envelope](
    * INTERNAL API
    */
   @InternalApi
-  private class TestRunningProjection(val source: Source[Done, _], killSwitch: SharedKillSwitch)
+  private class TestRunningProjection(val source: Source[Done, _], killSwitch: SharedKillSwitch)(
+      implicit val system: ActorSystem[_])
       extends RunningProjection {
 
     private val futureDone = source.run()
@@ -147,4 +200,18 @@ class TestSourceProvider[Offset, Envelope] private[projection] (
   override def extractOffset(envelope: Envelope): Offset = _extractOffset(envelope)
 
   override def extractCreationTime(envelope: Envelope): Long = _extractCreationTime(envelope)
+}
+
+@ApiMayChange
+class TestInMemoryOffsetStore[Offset](implicit val system: ActorSystem[_]) {
+  private implicit val executionContext: ExecutionContext = system.executionContext
+
+  private var savedOffsets = List[(ProjectionId, Offset)]()
+
+  def readOffsets(): Future[Option[Offset]] = Future(savedOffsets.headOption.map { case (_, offset) => offset })
+
+  def saveOffset(projectionId: ProjectionId, offset: Offset): Future[Done] = {
+    savedOffsets = (projectionId -> offset) +: savedOffsets
+    Future.successful(Done)
+  }
 }

--- a/akka-projection-testkit/src/test/scala/akka/projection/testkit/scaladsl/ProjectionTestKitSpec.scala
+++ b/akka-projection-testkit/src/test/scala/akka/projection/testkit/scaladsl/ProjectionTestKitSpec.scala
@@ -8,20 +8,12 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 import akka.Done
-import akka.NotUsed
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.typed.ActorSystem
-import akka.projection.Projection
 import akka.projection.ProjectionId
-import akka.projection.RunningProjection
-import akka.projection.StatusObserver
-import akka.projection.internal.ActorHandlerInit
-import akka.projection.internal.NoopStatusObserver
-import akka.projection.internal.RestartBackoffSettings
-import akka.projection.internal.SettingsImpl
+import akka.projection.scaladsl.Handler
+import akka.projection.testkit.TestProjection
+import akka.projection.testkit.TestSourceProvider
 import akka.stream.DelayOverflowStrategy
-import akka.stream.KillSwitches
-import akka.stream.SharedKillSwitch
 import akka.stream.scaladsl.DelayStrategy
 import akka.stream.scaladsl.Source
 import org.scalatest.exceptions.TestFailedException
@@ -30,13 +22,26 @@ import org.scalatest.wordspec.AnyWordSpecLike
 class ProjectionTestKitSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {
 
   val projectionTestKit: ProjectionTestKit = ProjectionTestKit(testKit)
+  val projectionId: ProjectionId = ProjectionId("name", "key")
+
+  def handler(strBuffer: StringBuffer, predicate: Int => Boolean): Handler[Int] = new Handler[Int] {
+    override def process(env: Int): Future[Done] = {
+      if (predicate(env)) concat(env)
+      Future.successful(Done)
+    }
+
+    def concat(i: Int) = {
+      if (strBuffer.toString.isEmpty) strBuffer.append(i)
+      else strBuffer.append("-").append(i)
+    }
+  }
 
   "ProjectionTestKit" must {
 
     "assert progress of a projection" in {
-
       val strBuffer = new StringBuffer()
-      val prj = TestProjection(Source(1 to 20), strBuffer, _ <= 6)
+      val sp = TestSourceProvider(Source(1 to 20), (i: Int) => i)
+      val prj = TestProjection(projectionId, sp, () => handler(strBuffer, _ <= 6))
 
       // stop as soon we observe that all expected elements passed through
       projectionTestKit.run(prj) {
@@ -45,14 +50,12 @@ class ProjectionTestKitSpec extends ScalaTestWithActorTestKit with AnyWordSpecLi
     }
 
     "retry assertion function until it succeeds within a max timeout" in {
-
       val strBuffer = new StringBuffer()
-
       // simulate slow stream by adding some delay on each element
       val delayedSrc = Source(1 to 20)
         .delayWith(() => DelayStrategy.linearIncreasingDelay(200.millis, _ => true), DelayOverflowStrategy.backpressure)
-
-      val prj = TestProjection(delayedSrc, strBuffer, _ <= 6)
+      val sp = TestSourceProvider(delayedSrc, (i: Int) => i)
+      val prj = TestProjection(projectionId, sp, () => handler(strBuffer, _ <= 6))
 
       // total processing time expected to be around 1.2 seconds
       projectionTestKit.run(prj, max = 2.seconds) {
@@ -61,15 +64,13 @@ class ProjectionTestKitSpec extends ScalaTestWithActorTestKit with AnyWordSpecLi
     }
 
     "retry assertion function and fail when timeout expires" in {
-
       val strBuffer = new StringBuffer()
-
       // simulate slow stream by adding some delay on each element
       val delayedSrc = Source(1 to 20).delayWith(
         () => DelayStrategy.linearIncreasingDelay(1000.millis, _ => true),
         DelayOverflowStrategy.backpressure)
-
-      val prj = TestProjection(delayedSrc, strBuffer, _ <= 2)
+      val sp = TestSourceProvider(delayedSrc, (i: Int) => i)
+      val prj = TestProjection(projectionId, sp, () => handler(strBuffer, _ <= 2))
 
       assertThrows[TestFailedException] {
         projectionTestKit.run(prj, max = 1.seconds) {
@@ -79,15 +80,14 @@ class ProjectionTestKitSpec extends ScalaTestWithActorTestKit with AnyWordSpecLi
     }
 
     "failure inside Projection propagates to TestKit" in {
-
       val streamFailureMsg = "stream failure"
-
       val strBuffer = new StringBuffer()
-
-      val prj = TestProjection(Source(1 to 20), strBuffer, {
+      val predicate: Int => Boolean = {
         case envelope if envelope < 3 => true
         case _                        => throw new RuntimeException(streamFailureMsg)
-      })
+      }
+      val sp = TestSourceProvider(Source(1 to 20), (i: Int) => i)
+      val prj = TestProjection(projectionId, sp, () => handler(strBuffer, predicate))
 
       val exp =
         intercept[RuntimeException] {
@@ -100,15 +100,12 @@ class ProjectionTestKitSpec extends ScalaTestWithActorTestKit with AnyWordSpecLi
     }
 
     "failure inside Stream propagates to TestKit" in {
-
       val streamFailureMsg = "stream failure"
-
       val strBuffer = new StringBuffer()
-
       // this source will 'emit' an exception and fail the stream
       val failingSource = Source.single(1).concat(Source.failed(new RuntimeException(streamFailureMsg)))
-
-      val prj = TestProjection(failingSource, strBuffer, _ <= 4)
+      val sp = TestSourceProvider(failingSource, (i: Int) => i)
+      val prj = TestProjection(projectionId, sp, () => handler(strBuffer, _ <= 4))
 
       val exp =
         intercept[RuntimeException] {
@@ -121,11 +118,15 @@ class ProjectionTestKitSpec extends ScalaTestWithActorTestKit with AnyWordSpecLi
     }
 
     "run a projection with a TestSink" in {
-
       val strBuffer = new StringBuffer()
-      val projection = TestProjection(Source(1 to 5), strBuffer, _ <= 5)
+      val sp = TestSourceProvider(
+        Source(1 to 5),
+        extractOffset = (i: Int) => i,
+        extractCreationTime = (_: Int) => 0L,
+        allowCompletion = true)
+      val prj = TestProjection(projectionId, sp, () => handler(strBuffer, _ <= 5))
 
-      projectionTestKit.runWithTestSink(projection) { sinkProbe =>
+      projectionTestKit.runWithTestSink(prj) { sinkProbe =>
         sinkProbe.request(5)
         sinkProbe.expectNextN(5)
         sinkProbe.expectComplete()
@@ -136,68 +137,4 @@ class ProjectionTestKitSpec extends ScalaTestWithActorTestKit with AnyWordSpecLi
 
   }
 
-  private[projection] case class TestProjection(
-      src: Source[Int, NotUsed],
-      strBuffer: StringBuffer,
-      predicate: Int => Boolean)
-      extends Projection[Int]
-      with SettingsImpl[TestProjection] {
-
-    override val statusObserver: StatusObserver[Int] = NoopStatusObserver
-
-    override def withStatusObserver(observer: StatusObserver[Int]): Projection[Int] =
-      this // no need for StatusObserver in tests
-
-    override def withRestartBackoffSettings(restartBackoff: RestartBackoffSettings): TestProjection = this
-    override def withSaveOffset(afterEnvelopes: Int, afterDuration: FiniteDuration): TestProjection = this
-    override def withGroup(groupAfterEnvelopes: Int, groupAfterDuration: FiniteDuration): TestProjection = this
-
-    override def projectionId: ProjectionId = ProjectionId("test-projection", "00")
-
-    private[projection] def actorHandlerInit[T]: Option[ActorHandlerInit[T]] = None
-
-    override def run()(implicit system: ActorSystem[_]): RunningProjection =
-      new InternalProjectionState(strBuffer, predicate).newRunningInstance()
-
-    private[projection] def mappedSource()(implicit system: ActorSystem[_]): Source[Done, Future[Done]] =
-      new InternalProjectionState(strBuffer, predicate).mappedSource()
-
-    /*
-     * INTERNAL API
-     * This internal class will hold the KillSwitch that is needed
-     * when building the mappedSource and when running the projection (to stop)
-     */
-    private class InternalProjectionState(strBuffer: StringBuffer, predicate: Int => Boolean)(
-        implicit val system: ActorSystem[_]) {
-
-      private val killSwitch = KillSwitches.shared(projectionId.id)
-
-      def mappedSource(): Source[Done, Future[Done]] =
-        src.via(killSwitch.flow).mapAsync(1)(i => process(i)).mapMaterializedValue(_ => Future.successful(Done))
-
-      private def process(elt: Int): Future[Done] = {
-        if (predicate(elt)) concat(elt)
-        Future.successful(Done)
-      }
-
-      private def concat(i: Int) = {
-        if (strBuffer.toString.isEmpty) strBuffer.append(i)
-        else strBuffer.append("-").append(i)
-      }
-
-      def newRunningInstance(): RunningProjection =
-        new TestRunningProjection(mappedSource(), killSwitch)
-    }
-
-    private class TestRunningProjection(val source: Source[Done, _], killSwitch: SharedKillSwitch)
-        extends RunningProjection {
-
-      private val futureDone = source.run()
-
-      override def stop(): Future[Done] = {
-        killSwitch.shutdown()
-        futureDone
-      }
-    }
-  }
 }

--- a/akka-projection-testkit/src/test/scala/akka/projection/testkit/scaladsl/ProjectionTestKitSpec.scala
+++ b/akka-projection-testkit/src/test/scala/akka/projection/testkit/scaladsl/ProjectionTestKitSpec.scala
@@ -119,11 +119,8 @@ class ProjectionTestKitSpec extends ScalaTestWithActorTestKit with AnyWordSpecLi
 
     "run a projection with a TestSink" in {
       val strBuffer = new StringBuffer()
-      val sp = TestSourceProvider(
-        Source(1 to 5),
-        extractOffset = (i: Int) => i,
-        extractCreationTime = (_: Int) => 0L,
-        allowCompletion = true)
+      val sp = TestSourceProvider(Source(1 to 5), extractOffset = (i: Int) => i)
+        .withAllowCompletion(true)
       val prj = TestProjection(projectionId, sp, () => handler(strBuffer, _ <= 5))
 
       projectionTestKit.runWithTestSink(prj) { sinkProbe =>

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,15 @@ lazy val core =
           "Automatic-Module-Name" -> "akka.projection.core"))
     .settings(Protobuf.settings)
 
+lazy val coreTest =
+  Project(id = "akka-projection-core-test", base = file("akka-projection-core-test"))
+    .configs(IntegrationTest)
+    .settings(Defaults.itSettings)
+    .settings(Protobuf.settings)
+    .settings(publish / skip := true)
+    .dependsOn(core % "compile->compile;test->test")
+    .dependsOn(testkit % "test->test")
+
 lazy val testkit =
   Project(id = "akka-projection-testkit", base = file("akka-projection-testkit"))
     .configs(IntegrationTest)
@@ -125,7 +134,7 @@ lazy val docs = project
     apidocRootPackage := "akka")
 
 lazy val root = Project(id = "akka-projection", base = file("."))
-  .aggregate(core, testkit, jdbc, slick, cassandra, eventsourced, kafka, examples, docs)
+  .aggregate(core, coreTest, testkit, jdbc, slick, cassandra, eventsourced, kafka, examples, docs)
   .settings(publish / skip := true, whitesourceIgnore := true)
   .enablePlugins(ScalaUnidocPlugin)
   .disablePlugins(SitePlugin)

--- a/examples/src/test/scala/docs/guide/ShoppingCartAppSpec.scala
+++ b/examples/src/test/scala/docs/guide/ShoppingCartAppSpec.scala
@@ -14,6 +14,7 @@ import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.persistence.query.Offset
 import akka.projection.ProjectionId
 import akka.projection.eventsourced.EventEnvelope
+import akka.stream.scaladsl.Source
 // #testKitImports
 import akka.projection.testkit.TestProjection
 import akka.projection.testkit.TestSourceProvider
@@ -49,14 +50,15 @@ class ShoppingCartAppSpec extends ScalaTestWithActorTestKit() with AnyWordSpecLi
       val repo = new MockCheckoutRepository
       val handler = new CheckoutProjectionHandler("tag", system, repo)
 
-      val events = List[EventEnvelope[ShoppingCartEvents.Event]](
-        createEnvelope(ShoppingCartEvents.ItemAdded("a7098", "batteries", 1), 0L),
-        createEnvelope(ShoppingCartEvents.ItemQuantityAdjusted("a7098", "batteries", 2), 1L),
-        createEnvelope(ShoppingCartEvents.CheckedOut("a7098", Instant.parse("2020-01-01T12:10:00.00Z")), 2L),
-        createEnvelope(ShoppingCartEvents.ItemAdded("0d12d", "crayons", 1), 3L),
-        createEnvelope(ShoppingCartEvents.ItemAdded("0d12d", "pens", 1), 4L),
-        createEnvelope(ShoppingCartEvents.ItemRemoved("0d12d", "pens"), 5L),
-        createEnvelope(ShoppingCartEvents.CheckedOut("0d12d", Instant.parse("2020-01-01T08:00:00.00Z")), 6L))
+      val events = Source(
+        List[EventEnvelope[ShoppingCartEvents.Event]](
+          createEnvelope(ShoppingCartEvents.ItemAdded("a7098", "batteries", 1), 0L),
+          createEnvelope(ShoppingCartEvents.ItemQuantityAdjusted("a7098", "batteries", 2), 1L),
+          createEnvelope(ShoppingCartEvents.CheckedOut("a7098", Instant.parse("2020-01-01T12:10:00.00Z")), 2L),
+          createEnvelope(ShoppingCartEvents.ItemAdded("0d12d", "crayons", 1), 3L),
+          createEnvelope(ShoppingCartEvents.ItemAdded("0d12d", "pens", 1), 4L),
+          createEnvelope(ShoppingCartEvents.ItemRemoved("0d12d", "pens"), 5L),
+          createEnvelope(ShoppingCartEvents.CheckedOut("0d12d", Instant.parse("2020-01-01T08:00:00.00Z")), 6L)))
 
       val projectionId = ProjectionId("name", "key")
       val sourceProvider =
@@ -89,7 +91,7 @@ class ShoppingCartAppSpec extends ScalaTestWithActorTestKit() with AnyWordSpecLi
       val projectionId = ProjectionId("name", "key")
       val sourceProvider =
         TestSourceProvider[Offset, EventEnvelope[ShoppingCartEvents.Event]](
-          events.toList,
+          Source(events),
           extractOffset = env => env.offset)
       val projection =
         TestProjection[Offset, EventEnvelope[ShoppingCartEvents.Event]](projectionId, sourceProvider, () => handler)

--- a/examples/src/test/scala/docs/guide/ShoppingCartAppSpec.scala
+++ b/examples/src/test/scala/docs/guide/ShoppingCartAppSpec.scala
@@ -62,11 +62,7 @@ class ShoppingCartAppSpec extends ScalaTestWithActorTestKit() with AnyWordSpecLi
       val sourceProvider =
         TestSourceProvider[Offset, EventEnvelope[ShoppingCartEvents.Event]](events, extractOffset = env => env.offset)
       val projection =
-        TestProjection[Offset, EventEnvelope[ShoppingCartEvents.Event]](
-          projectionId,
-          sourceProvider,
-          () => handler,
-          Some(Offset.sequence(0L)))
+        TestProjection[Offset, EventEnvelope[ShoppingCartEvents.Event]](projectionId, sourceProvider, () => handler)
 
       projectionTestKit.run(projection) {
         repo.checkouts shouldBe List(
@@ -96,11 +92,7 @@ class ShoppingCartAppSpec extends ScalaTestWithActorTestKit() with AnyWordSpecLi
           events.toList,
           extractOffset = env => env.offset)
       val projection =
-        TestProjection[Offset, EventEnvelope[ShoppingCartEvents.Event]](
-          projectionId,
-          sourceProvider,
-          () => handler,
-          Some(Offset.sequence(0L)))
+        TestProjection[Offset, EventEnvelope[ShoppingCartEvents.Event]](projectionId, sourceProvider, () => handler)
 
       LoggingTestKit
         .info("""CheckoutProjectionHandler(tag) last [10] checkouts: 

--- a/examples/src/test/scala/docs/guide/ShoppingCartAppSpec.scala
+++ b/examples/src/test/scala/docs/guide/ShoppingCartAppSpec.scala
@@ -63,11 +63,10 @@ class ShoppingCartAppSpec extends ScalaTestWithActorTestKit() with AnyWordSpecLi
         TestSourceProvider[Offset, EventEnvelope[ShoppingCartEvents.Event]](events, extractOffset = env => env.offset)
       val projection =
         TestProjection[Offset, EventEnvelope[ShoppingCartEvents.Event]](
-          system,
           projectionId,
           sourceProvider,
-          Offset.sequence(0L),
-          handler)
+          () => handler,
+          Some(Offset.sequence(0L)))
 
       projectionTestKit.run(projection) {
         repo.checkouts shouldBe List(
@@ -98,11 +97,10 @@ class ShoppingCartAppSpec extends ScalaTestWithActorTestKit() with AnyWordSpecLi
           extractOffset = env => env.offset)
       val projection =
         TestProjection[Offset, EventEnvelope[ShoppingCartEvents.Event]](
-          system,
           projectionId,
           sourceProvider,
-          Offset.sequence(0L),
-          handler)
+          () => handler,
+          Some(Offset.sequence(0L)))
 
       LoggingTestKit
         .info("""CheckoutProjectionHandler(tag) last [10] checkouts: 

--- a/examples/src/test/scala/docs/kafka/KafkaDocExample.scala
+++ b/examples/src/test/scala/docs/kafka/KafkaDocExample.scala
@@ -170,7 +170,7 @@ object KafkaDocExample {
   object IllustrateExactlyOnce {
     import IllustrateSourceProvider._
 
-    val wordRepository: WordRepository = ???
+    val wordRepository: WordRepository = null
     //#exactlyOnce
     val sessionProvider = new HibernateSessionFactory
 


### PR DESCRIPTION
* Replaces several internal `TestProjection` implementations in tests.
* New sub-project `akka-projection-core-test` was created so that `ProjectionBehaviorSpec` could reference the testkit.  Should we move all core tests here?
* Incremental development of `TestProjection` in testkit to be cleaned up for external usage in #198

TODO

- [x] DRY `TestSourceProvider`.  I'll do this in a follow up PR.
  - See #381 
 