### PR TITLE
ProjectionTestBehaviorSpec lifecycle fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,15 @@ script:
 
 jobs:
   include:
-    - stage: check
-      env: CMD="verifyCodeStyle"
-      name: "Code style check. Run locally with: sbt verifyCodeStyle"
-    - env: CMD="++2.12.11 IntegrationTest/compile"
-      name: "Compile all code with 2.12"
-    - env: CMD="IntegrationTest/compile"
-      name: "Compile all code with 2.13"
-    - env: CMD="unidoc; docs/paradox"
-      name: "Create API and reference documentation"
+#    - stage: check
+#      env: CMD="verifyCodeStyle"
+#      name: "Code style check. Run locally with: sbt verifyCodeStyle"
+#    - env: CMD="++2.12.11 IntegrationTest/compile"
+#      name: "Compile all code with 2.12"
+#    - env: CMD="IntegrationTest/compile"
+#      name: "Compile all code with 2.13"
+#    - env: CMD="unidoc; docs/paradox"
+#      name: "Create API and reference documentation"
 
     - stage: test
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,15 @@ script:
 
 jobs:
   include:
-#    - stage: check
-#      env: CMD="verifyCodeStyle"
-#      name: "Code style check. Run locally with: sbt verifyCodeStyle"
-#    - env: CMD="++2.12.11 IntegrationTest/compile"
-#      name: "Compile all code with 2.12"
-#    - env: CMD="IntegrationTest/compile"
-#      name: "Compile all code with 2.13"
-#    - env: CMD="unidoc; docs/paradox"
-#      name: "Create API and reference documentation"
+    - stage: check
+      env: CMD="verifyCodeStyle"
+      name: "Code style check. Run locally with: sbt verifyCodeStyle"
+    - env: CMD="++2.12.11 IntegrationTest/compile"
+      name: "Compile all code with 2.12"
+    - env: CMD="IntegrationTest/compile"
+      name: "Compile all code with 2.13"
+    - env: CMD="unidoc; docs/paradox"
+      name: "Create API and reference documentation"
 
     - stage: test
       env:

--- a/akka-projection-core-test/src/test/scala/akka/projection/ProjectionBehaviorSpec.scala
+++ b/akka-projection-core-test/src/test/scala/akka/projection/ProjectionBehaviorSpec.scala
@@ -45,10 +45,12 @@ object ProjectionBehaviorSpec {
   private val TestProjectionId = ProjectionId("test-projection", "00")
 
   def handler(probe: TestProbe[ProbeMessage]): Handler[Int] = new Handler[Int] {
+    println("Handler initialized")
     val strBuffer: StringBuffer = new StringBuffer()
     override def process(env: Int): Future[Done] = {
       concat(env)
       probe.ref ! Consumed(env, strBuffer.toString)
+      println(s"Consumed: $env, ${strBuffer.toString}")
       Future.successful(Done)
     }
 
@@ -139,6 +141,7 @@ object ProjectionBehaviorSpec {
       import system.executionContext
 
       testProbe.ref ! StartObserved
+      println("StartObserved")
 
       override def stop(): Future[Done] = {
         val stopFut =
@@ -155,6 +158,7 @@ object ProjectionBehaviorSpec {
           .andThen {
             case _ =>
               testProbe.ref ! StopObserved
+              println("StopObserved")
           }
       }
 

--- a/akka-projection-core-test/src/test/scala/akka/projection/ProjectionBehaviorSpec.scala
+++ b/akka-projection-core-test/src/test/scala/akka/projection/ProjectionBehaviorSpec.scala
@@ -47,7 +47,7 @@ object ProjectionBehaviorSpec {
   private val TestProjectionId = ProjectionId("test-projection", "00")
 
   def handler(probe: TestProbe[ProbeMessage], logger: Logger): Handler[Int] = new Handler[Int] {
-    println("Handler initialized")
+    logger.info("Handler initialized")
     val strBuffer: StringBuffer = new StringBuffer()
     override def process(env: Int): Future[Done] = {
       concat(env)

--- a/akka-projection-core-test/src/test/scala/akka/projection/ProjectionBehaviorSpec.scala
+++ b/akka-projection-core-test/src/test/scala/akka/projection/ProjectionBehaviorSpec.scala
@@ -144,8 +144,11 @@ object ProjectionBehaviorSpec {
         with ProjectionOffsetManagement[Int] {
       import system.executionContext
 
-      testProbe.ref ! StartObserved
-      logger.info("StartObserved")
+      override protected def run(): Future[Done] = {
+        testProbe.ref ! StartObserved
+        logger.info("StartObserved")
+        source.run()
+      }
 
       override def stop(): Future[Done] = {
         val stopFut =

--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/internal/TestProjectionImpl.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/internal/TestProjectionImpl.scala
@@ -177,7 +177,9 @@ private[projection] class TestRunningProjection(val source: Source[Done, _], kil
     implicit val system: ActorSystem[_])
     extends RunningProjection {
 
-  protected val futureDone: Future[Done] = source.run()
+  protected val futureDone: Future[Done] = run()
+
+  protected def run(): Future[Done] = source.run()
 
   override def stop(): Future[Done] = {
     killSwitch.shutdown()


### PR DESCRIPTION
Fixes https://github.com/akka/akka-projection/issues/393

Corrected source stream initialization in test projection used by `ProjectionBehaviorSpec`