### PR TITLE
Guide ShoppingCartTest/Spec log test 0 until 9

### DIFF
--- a/examples/src/test/java/jdocs/guide/ShoppingCartAppTest.java
+++ b/examples/src/test/java/jdocs/guide/ShoppingCartAppTest.java
@@ -100,7 +100,7 @@ public class ShoppingCartAppTest {
     Source<EventEnvelope<ShoppingCartEvents.Event>, NotUsed> events =
         Source.fromJavaStream(
             () ->
-                IntStream.rangeClosed(0, (int) eventsNum)
+                IntStream.range(0, (int) eventsNum)
                     .boxed()
                     .map(
                         i ->

--- a/examples/src/test/scala/docs/guide/ShoppingCartAppSpec.scala
+++ b/examples/src/test/scala/docs/guide/ShoppingCartAppSpec.scala
@@ -76,7 +76,7 @@ class ShoppingCartAppSpec extends ScalaTestWithActorTestKit() with AnyWordSpecLi
       val repo = new MockItemPopularityRepository
       val handler = new ItemPopularityProjectionHandler("tag", system, repo)
 
-      val events = (0L to 10L).map { i =>
+      val events = (0L until 10L).map { i =>
         createEnvelope(ShoppingCartEvents.ItemAdded("a7098", "bowling shoes", 1), i)
       }
 


### PR DESCRIPTION
Generate integers 0..9 for test so that slow execution can't cause an 11th message to be logged for test assertion.

Noticed the failure here:

https://travis-ci.com/github/akka/akka-projection/jobs/378449397#L650