### PR TITLE
Wait for onError stream event

### DIFF
--- a/akka-projection-jdbc/src/test/java/akka/projection/jdbc/JdbcProjectionTest.java
+++ b/akka-projection-jdbc/src/test/java/akka/projection/jdbc/JdbcProjectionTest.java
@@ -327,6 +327,12 @@ public class JdbcProjectionTest extends JUnitSuite {
     projectionTestKit.runWithTestSink(
         projection,
         (probe) -> {
+          /*
+           * We only want to process 3 elements through the handler, but given buffering within the projections
+           * at-least-once impl. we actually process +1 element than we requested with the TestSink.probe.
+           *
+           * See https://github.com/akka/akka-projection/issues/462 for a possible solution.
+           */
           probe.request(2);
           probe.expectNextN(2);
           assertEquals("abc|def|ghi|", str.toString());

--- a/akka-projection-jdbc/src/test/java/akka/projection/jdbc/JdbcProjectionTest.java
+++ b/akka-projection-jdbc/src/test/java/akka/projection/jdbc/JdbcProjectionTest.java
@@ -182,7 +182,7 @@ public class JdbcProjectionTest extends JUnitSuite {
   @NotNull
   private JavaPartialFunction<TestSubscriber.SubscriberEvent, Object> expectErrorMessage(
       String msg) {
-    return new JavaPartialFunction<>() {
+    return new JavaPartialFunction<TestSubscriber.SubscriberEvent, Object>() {
       public String apply(TestSubscriber.SubscriberEvent in, boolean isCheck) {
         if (in instanceof TestSubscriber.OnError) {
           TestSubscriber.OnError err = (TestSubscriber.OnError) in;


### PR DESCRIPTION
Fixes #397

My suspicion is that #397 is caused by a race condition where the string builder assertion of current state passes, but the next envelope to generate the exception has not yet been processed. This change will assert the error event from the stream directly using a probe.
