### PR TITLE
Akka 2.6.10, and use akka.stream.RestartSettings, #466

### DIFF
--- a/akka-projection-cassandra/src/main/mima-filters/1.0.0.backwards.excludes/akka-2.6.10.excludes
+++ b/akka-projection-cassandra/src/main/mima-filters/1.0.0.backwards.excludes/akka-2.6.10.excludes
@@ -1,0 +1,2 @@
+# Changing internals to akka.stream.RestartSettings
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.projection.cassandra.internal.CassandraProjectionImpl.withRestartBackoffSettings")

--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
@@ -7,6 +7,7 @@ package akka.projection.cassandra.internal
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
+
 import akka.Done
 import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
@@ -28,11 +29,11 @@ import akka.projection.internal.InternalProjection
 import akka.projection.internal.InternalProjectionState
 import akka.projection.internal.OffsetStrategy
 import akka.projection.internal.ProjectionSettings
-import akka.projection.internal.RestartBackoffSettings
 import akka.projection.internal.SettingsImpl
 import akka.projection.javadsl
 import akka.projection.scaladsl
 import akka.projection.scaladsl.SourceProvider
+import akka.stream.RestartSettings
 import akka.stream.scaladsl.Source
 
 /**
@@ -42,7 +43,7 @@ import akka.stream.scaladsl.Source
     override val projectionId: ProjectionId,
     sourceProvider: SourceProvider[Offset, Envelope],
     settingsOpt: Option[ProjectionSettings],
-    restartBackoffOpt: Option[RestartBackoffSettings],
+    restartBackoffOpt: Option[RestartSettings],
     val offsetStrategy: OffsetStrategy,
     handlerStrategy: HandlerStrategy,
     override val statusObserver: StatusObserver[Envelope])
@@ -59,7 +60,7 @@ import akka.stream.scaladsl.Source
 
   private def copy(
       settingsOpt: Option[ProjectionSettings] = this.settingsOpt,
-      restartBackoffOpt: Option[RestartBackoffSettings] = this.restartBackoffOpt,
+      restartBackoffOpt: Option[RestartSettings] = this.restartBackoffOpt,
       offsetStrategy: OffsetStrategy = this.offsetStrategy,
       handlerStrategy: HandlerStrategy = this.handlerStrategy,
       statusObserver: StatusObserver[Envelope] = this.statusObserver): CassandraProjectionImpl[Offset, Envelope] =
@@ -83,8 +84,7 @@ import akka.stream.scaladsl.Source
     }
   }
 
-  override def withRestartBackoffSettings(
-      restartBackoff: RestartBackoffSettings): CassandraProjectionImpl[Offset, Envelope] =
+  override def withRestartBackoffSettings(restartBackoff: RestartSettings): CassandraProjectionImpl[Offset, Envelope] =
     copy(restartBackoffOpt = Some(restartBackoff))
 
   /**

--- a/akka-projection-core/src/main/mima-filters/1.0.0.backwards.excludes/akka-2.6.10.excludes
+++ b/akka-projection-core/src/main/mima-filters/1.0.0.backwards.excludes/akka-2.6.10.excludes
@@ -1,0 +1,11 @@
+# Changing internals to akka.stream.RestartSettings
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.projection.internal.ProjectionSettings.apply")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.projection.internal.ProjectionSettings.restartBackoff")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.projection.internal.ProjectionSettings.copy")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.projection.internal.ProjectionSettings.copy$default$1")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.projection.internal.ProjectionSettings.this")
+ProblemFilters.exclude[MissingClassProblem]("akka.projection.internal.RestartBackoffSettings$")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.projection.internal.SettingsImpl.withRestartBackoffSettings")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.projection.internal.SettingsImpl.withRestartBackoffSettings")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.projection.internal.ProjectionSettings.apply")
+ProblemFilters.exclude[MissingClassProblem]("akka.projection.internal.RestartBackoffSettings")

--- a/akka-projection-core/src/main/scala/akka/projection/Projection.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/Projection.scala
@@ -102,9 +102,8 @@ private[projection] object RunningProjection {
   case object AbortProjectionException extends RuntimeException("Projection aborted.") with NoStackTrace
 
   def withBackoff(source: () => Source[Done, _], settings: ProjectionSettings): Source[Done, _] = {
-    val backoff = settings.restartBackoff
     RestartSource
-      .onFailuresWithBackoff(backoff.minBackoff, backoff.maxBackoff, backoff.randomFactor, backoff.maxRestarts) { () =>
+      .onFailuresWithBackoff(settings.restartBackoff) { () =>
         source()
           .recoverWithRetries(1, {
             case AbortProjectionException => Source.empty // don't restart

--- a/akka-projection-jdbc/src/main/mima-filters/1.0.0.backwards.excludes/akka-2.6.10.excludes
+++ b/akka-projection-jdbc/src/main/mima-filters/1.0.0.backwards.excludes/akka-2.6.10.excludes
@@ -1,0 +1,4 @@
+# Changing internals to akka.stream.RestartSettings
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.projection.jdbc.internal.JdbcProjectionImpl.withRestartBackoffSettings")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.projection.slick.internal.SlickProjectionImpl.withRestartBackoffSettings")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.projection.testkit.internal.TestProjectionImpl.withRestartBackoffSettings")

--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcProjectionImpl.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcProjectionImpl.scala
@@ -30,7 +30,6 @@ import akka.projection.internal.InternalProjection
 import akka.projection.internal.InternalProjectionState
 import akka.projection.internal.OffsetStrategy
 import akka.projection.internal.ProjectionSettings
-import akka.projection.internal.RestartBackoffSettings
 import akka.projection.internal.SettingsImpl
 import akka.projection.javadsl
 import akka.projection.jdbc.JdbcSession
@@ -38,6 +37,7 @@ import akka.projection.jdbc.scaladsl.JdbcHandler
 import akka.projection.scaladsl
 import akka.projection.scaladsl.Handler
 import akka.projection.scaladsl.SourceProvider
+import akka.stream.RestartSettings
 import akka.stream.scaladsl.Source
 
 /**
@@ -137,7 +137,7 @@ private[projection] class JdbcProjectionImpl[Offset, Envelope, S <: JdbcSession]
     sourceProvider: SourceProvider[Offset, Envelope],
     sessionFactory: () => S,
     settingsOpt: Option[ProjectionSettings],
-    restartBackoffOpt: Option[RestartBackoffSettings],
+    restartBackoffOpt: Option[RestartSettings],
     val offsetStrategy: OffsetStrategy,
     handlerStrategy: HandlerStrategy,
     override val statusObserver: StatusObserver[Envelope],
@@ -155,7 +155,7 @@ private[projection] class JdbcProjectionImpl[Offset, Envelope, S <: JdbcSession]
 
   private def copy(
       settingsOpt: Option[ProjectionSettings] = this.settingsOpt,
-      restartBackoffOpt: Option[RestartBackoffSettings] = this.restartBackoffOpt,
+      restartBackoffOpt: Option[RestartSettings] = this.restartBackoffOpt,
       offsetStrategy: OffsetStrategy = this.offsetStrategy,
       handlerStrategy: HandlerStrategy = this.handlerStrategy,
       statusObserver: StatusObserver[Envelope] = this.statusObserver): JdbcProjectionImpl[Offset, Envelope, S] =
@@ -183,8 +183,7 @@ private[projection] class JdbcProjectionImpl[Offset, Envelope, S <: JdbcSession]
     }
   }
 
-  override def withRestartBackoffSettings(
-      restartBackoff: RestartBackoffSettings): JdbcProjectionImpl[Offset, Envelope, S] =
+  override def withRestartBackoffSettings(restartBackoff: RestartSettings): JdbcProjectionImpl[Offset, Envelope, S] =
     copy(restartBackoffOpt = Some(restartBackoff))
 
   /**

--- a/akka-projection-slick/src/main/mima-filters/1.0.0.backwards.excludes/akka-2.6.10.excludes
+++ b/akka-projection-slick/src/main/mima-filters/1.0.0.backwards.excludes/akka-2.6.10.excludes
@@ -1,0 +1,3 @@
+# Changing internals to akka.stream.RestartSettings
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.projection.slick.internal.SlickProjectionImpl.withRestartBackoffSettings")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.projection.testkit.internal.TestProjectionImpl.withRestartBackoffSettings")

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
@@ -29,13 +29,13 @@ import akka.projection.internal.InternalProjection
 import akka.projection.internal.InternalProjectionState
 import akka.projection.internal.OffsetStrategy
 import akka.projection.internal.ProjectionSettings
-import akka.projection.internal.RestartBackoffSettings
 import akka.projection.internal.SettingsImpl
 import akka.projection.scaladsl.AtLeastOnceFlowProjection
 import akka.projection.scaladsl.AtLeastOnceProjection
 import akka.projection.scaladsl.ExactlyOnceProjection
 import akka.projection.scaladsl.GroupedProjection
 import akka.projection.scaladsl.SourceProvider
+import akka.stream.RestartSettings
 import akka.stream.scaladsl.Source
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
@@ -49,7 +49,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
     sourceProvider: SourceProvider[Offset, Envelope],
     databaseConfig: DatabaseConfig[P],
     settingsOpt: Option[ProjectionSettings],
-    restartBackoffOpt: Option[RestartBackoffSettings],
+    restartBackoffOpt: Option[RestartSettings],
     val offsetStrategy: OffsetStrategy,
     handlerStrategy: HandlerStrategy,
     override val statusObserver: StatusObserver[Envelope],
@@ -63,7 +63,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
 
   private def copy(
       settingsOpt: Option[ProjectionSettings] = this.settingsOpt,
-      restartBackoffOpt: Option[RestartBackoffSettings] = this.restartBackoffOpt,
+      restartBackoffOpt: Option[RestartSettings] = this.restartBackoffOpt,
       offsetStrategy: OffsetStrategy = this.offsetStrategy,
       handlerStrategy: HandlerStrategy = this.handlerStrategy,
       statusObserver: StatusObserver[Envelope] = this.statusObserver): SlickProjectionImpl[Offset, Envelope, P] =
@@ -89,8 +89,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
     }
   }
 
-  override def withRestartBackoffSettings(
-      restartBackoff: RestartBackoffSettings): SlickProjectionImpl[Offset, Envelope, P] =
+  override def withRestartBackoffSettings(restartBackoff: RestartSettings): SlickProjectionImpl[Offset, Envelope, P] =
     copy(restartBackoffOpt = Some(restartBackoff))
 
   /**

--- a/akka-projection-testkit/src/main/mima-filters/1.0.0.backwards.excludes/akka-2.6.10.excludes
+++ b/akka-projection-testkit/src/main/mima-filters/1.0.0.backwards.excludes/akka-2.6.10.excludes
@@ -1,0 +1,2 @@
+# Changing internals to akka.stream.RestartSettings
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.projection.testkit.internal.TestProjectionImpl.withRestartBackoffSettings")

--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/internal/TestProjectionImpl.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/internal/TestProjectionImpl.scala
@@ -23,12 +23,12 @@ import akka.projection.internal.HandlerStrategy
 import akka.projection.internal.InternalProjectionState
 import akka.projection.internal.OffsetStrategy
 import akka.projection.internal.ProjectionSettings
-import akka.projection.internal.RestartBackoffSettings
 import akka.projection.internal.SettingsImpl
 import akka.projection.scaladsl.SourceProvider
 import akka.projection.testkit.javadsl
 import akka.projection.testkit.scaladsl.TestOffsetStore
 import akka.projection.testkit.scaladsl.TestProjection
+import akka.stream.RestartSettings
 import akka.stream.SharedKillSwitch
 import akka.stream.scaladsl.Source
 
@@ -86,8 +86,7 @@ private[projection] class TestProjectionImpl[Offset, Envelope] private[projectio
     copy(offsetStrategy = strategy)
 
   // FIXME: Should any of the following settings be exposed by the TestProjection?
-  final override def withRestartBackoffSettings(
-      restartBackoff: RestartBackoffSettings): TestProjectionImpl[Offset, Envelope] =
+  final override def withRestartBackoffSettings(restartBackoff: RestartSettings): TestProjectionImpl[Offset, Envelope] =
     this
   override def withSaveOffset(
       afterEnvelopes: Int,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   val AlpakkaKafkaVersionInDocs = "2.0"
 
   object Versions {
-    val akka = sys.props.getOrElse("build.akka.version", "2.6.9")
+    val akka = sys.props.getOrElse("build.akka.version", "2.6.10")
     val alpakka = "2.0.2"
     val alpakkaKafka = sys.props.getOrElse("build.alpakka.kafka.version", "2.0.5")
     val slick = "3.3.3"


### PR DESCRIPTION
The reason for updating is the incompatibility in the TestKit as described in the issue https://github.com/akka/akka-projection/issues/466

Also changed internals to use the new `akka.stream.RestartSettings`. Old signature was deprecated. 

References #466
