### PR TITLE
Bump alpakka-kafka to fix cp-kafka image changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ target
 akka-projection-jdbc/src/it/resources/container-license-acceptance.txt
 akka-projection-slick/src/it/resources/container-license-acceptance.txt
 
+.bsp

--- a/akka-projection-cassandra/src/it/scala/akka/projection/cassandra/ContainerSessionProvider.scala
+++ b/akka-projection-cassandra/src/it/scala/akka/projection/cassandra/ContainerSessionProvider.scala
@@ -14,6 +14,7 @@ import akka.stream.alpakka.cassandra.CqlSessionProvider
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint
 import org.testcontainers.containers.CassandraContainer
+import org.testcontainers.utility.DockerImageName
 
 /**
  * Use testcontainers to lazily provide a single CqlSession for all Cassandra tests
@@ -33,7 +34,7 @@ final class ContainerSessionProvider extends CqlSessionProvider {
 object ContainerSessionProvider {
   private val disabled = java.lang.Boolean.getBoolean("disable-cassandra-testcontainer")
 
-  private lazy val container: CassandraContainer[_] = new CassandraContainer()
+  private lazy val container: CassandraContainer[_] = new CassandraContainer(DockerImageName.parse("cassandra:3.11.9"))
 
   lazy val started: Future[Unit] = {
     if (disabled)

--- a/akka-projection-jdbc/src/it/scala/akka/projection/jdbc/JdbcContainerOffsetStoreSpec.scala
+++ b/akka-projection-jdbc/src/it/scala/akka/projection/jdbc/JdbcContainerOffsetStoreSpec.scala
@@ -87,7 +87,7 @@ object JdbcContainerOffsetStoreSpec {
   object OracleSpecConfig extends ContainerJdbcSpecConfig("oracle-dialect") {
     val name = "Oracle Database"
     override def newContainer() =
-      new OracleContainer("oracleinanutshell/oracle-xe-11g:1.0.01")
+      new OracleContainer("oracleinanutshell/oracle-xe-11g:1.0.0")
         .withInitScript("db/oracle-init.sql")
   }
 

--- a/akka-projection-jdbc/src/it/scala/akka/projection/jdbc/JdbcContainerOffsetStoreSpec.scala
+++ b/akka-projection-jdbc/src/it/scala/akka/projection/jdbc/JdbcContainerOffsetStoreSpec.scala
@@ -66,23 +66,29 @@ object JdbcContainerOffsetStoreSpec {
 
   object PostgresSpecConfig extends ContainerJdbcSpecConfig("postgres-dialect") {
     val name = "Postgres Database"
-    override def newContainer(): JdbcDatabaseContainer[_] = new PostgreSQLContainer().withInitScript("db/default-init.sql")
+    override def newContainer(): JdbcDatabaseContainer[_] =
+      new PostgreSQLContainer("postgres:13.1").withInitScript("db/default-init.sql")
   }
 
   object MySQLSpecConfig extends ContainerJdbcSpecConfig("mysql-dialect") {
     val name = "MySQL Database"
-    override def newContainer(): JdbcDatabaseContainer[_] = new MySQLContainer().withDatabaseName(schemaName)
+    override def newContainer(): JdbcDatabaseContainer[_] =
+      new MySQLContainer("mysql:8.0.22").withDatabaseName(schemaName)
   }
 
   object MSSQLServerSpecConfig extends ContainerJdbcSpecConfig("mssql-dialect") {
     val name = "MS SQL Server Database"
     override val tag: Tag = TestTags.FlakyDb
-    override def newContainer(): JdbcDatabaseContainer[_] = new MSSQLServerContainer().withInitScript("db/default-init.sql")
+    override def newContainer(): JdbcDatabaseContainer[_] =
+      new MSSQLServerContainer("mcr.microsoft.com/mssql/server:2019-CU8-ubuntu-16.04")
+        .withInitScript("db/default-init.sql")
   }
 
   object OracleSpecConfig extends ContainerJdbcSpecConfig("oracle-dialect") {
     val name = "Oracle Database"
-    override def newContainer() = new OracleContainer("oracleinanutshell/oracle-xe-11g").withInitScript("db/oracle-init.sql")
+    override def newContainer() =
+      new OracleContainer("oracleinanutshell/oracle-xe-11g:1.0.01")
+        .withInitScript("db/oracle-init.sql")
   }
 
 }

--- a/akka-projection-kafka/src/it/scala/akka/projection/kafka/KafkaSourceProviderSpec.scala
+++ b/akka-projection-kafka/src/it/scala/akka/projection/kafka/KafkaSourceProviderSpec.scala
@@ -21,7 +21,7 @@ class KafkaSourceProviderSpec extends KafkaSpecBase {
     "resume from provided offsets" in assertAllStagesStopped {
       val topic = createTopic()
       val groupId = createGroupId()
-      val settings = consumerDefaults().withGroupId(groupId)
+      val settings = consumerDefaults(StringDeserializer, StringDeserializer).withGroupId(groupId)
 
       Await.result(produce(topic, 1 to 100), remainingOrDefault)
 
@@ -43,7 +43,7 @@ class KafkaSourceProviderSpec extends KafkaSpecBase {
     "resume from beginning offsets when none are provided" in assertAllStagesStopped {
       val topic = createTopic()
       val groupId = createGroupId()
-      val settings = consumerDefaults().withGroupId(groupId)
+      val settings = consumerDefaults(StringDeserializer, StringDeserializer).withGroupId(groupId)
 
       Await.result(produce(topic, 1 to 100), remainingOrDefault)
 

--- a/akka-projection-kafka/src/it/scala/akka/projection/kafka/KafkaSourceProviderSpec.scala
+++ b/akka-projection-kafka/src/it/scala/akka/projection/kafka/KafkaSourceProviderSpec.scala
@@ -21,7 +21,7 @@ class KafkaSourceProviderSpec extends KafkaSpecBase {
     "resume from provided offsets" in assertAllStagesStopped {
       val topic = createTopic()
       val groupId = createGroupId()
-      val settings = consumerDefaults(StringDeserializer, StringDeserializer).withGroupId(groupId)
+      val settings = consumerDefaults.withGroupId(groupId)
 
       Await.result(produce(topic, 1 to 100), remainingOrDefault)
 
@@ -43,7 +43,7 @@ class KafkaSourceProviderSpec extends KafkaSpecBase {
     "resume from beginning offsets when none are provided" in assertAllStagesStopped {
       val topic = createTopic()
       val groupId = createGroupId()
-      val settings = consumerDefaults(StringDeserializer, StringDeserializer).withGroupId(groupId)
+      val settings = consumerDefaults.withGroupId(groupId)
 
       Await.result(produce(topic, 1 to 100), remainingOrDefault)
 

--- a/akka-projection-kafka/src/it/scala/akka/projection/kafka/KafkaSpecBase.scala
+++ b/akka-projection-kafka/src/it/scala/akka/projection/kafka/KafkaSpecBase.scala
@@ -8,6 +8,7 @@ import akka.actor.ActorSystem
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.scaladsl.adapter._
+import akka.kafka.testkit.KafkaTestkitTestcontainersSettings
 import akka.kafka.testkit.internal.TestFrameworkInterface
 import akka.kafka.testkit.scaladsl.KafkaSpec
 import akka.kafka.testkit.scaladsl.TestcontainersKafkaPerClassLike
@@ -45,4 +46,7 @@ abstract class KafkaSpecBase(val config: Config, kafkaPort: Int)
 
   implicit val actorSystem = testKit.system
   implicit val dispatcher = testKit.system.executionContext
+
+  override val testcontainersSettings =
+    KafkaTestkitTestcontainersSettings(system).withConfluentPlatformVersion("6.0.1")
 }

--- a/akka-projection-kafka/src/it/scala/akka/projection/kafka/integration/KafkaToSlickIntegrationSpec.scala
+++ b/akka-projection-kafka/src/it/scala/akka/projection/kafka/integration/KafkaToSlickIntegrationSpec.scala
@@ -145,7 +145,7 @@ class KafkaToSlickIntegrationSpec extends KafkaSpecBase(ConfigFactory.load().wit
       val kafkaSourceProvider: SourceProvider[MergeableOffset[JLong], ConsumerRecord[String, String]] =
         KafkaSourceProvider(
           system.toTyped,
-          consumerDefaults(StringDeserializer, StringDeserializer)
+          consumerDefaults
             .withGroupId(groupId),
           Set(topicName))
 
@@ -179,7 +179,7 @@ class KafkaToSlickIntegrationSpec extends KafkaSpecBase(ConfigFactory.load().wit
       val kafkaSourceProvider: SourceProvider[MergeableOffset[JLong], ConsumerRecord[String, String]] =
         KafkaSourceProvider(
           system.toTyped,
-          consumerDefaults(StringDeserializer, StringDeserializer)
+          consumerDefaults
             .withGroupId(groupId),
           Set(topicName))
 
@@ -225,7 +225,7 @@ class KafkaToSlickIntegrationSpec extends KafkaSpecBase(ConfigFactory.load().wit
       val kafkaSourceProvider: SourceProvider[MergeableOffset[JLong], ConsumerRecord[String, String]] =
         KafkaSourceProvider(
           system.toTyped,
-          consumerDefaults(StringDeserializer, StringDeserializer)
+          consumerDefaults
             .withGroupId(groupId),
           Set(topicName))
 

--- a/akka-projection-kafka/src/it/scala/akka/projection/kafka/integration/KafkaToSlickIntegrationSpec.scala
+++ b/akka-projection-kafka/src/it/scala/akka/projection/kafka/integration/KafkaToSlickIntegrationSpec.scala
@@ -143,7 +143,11 @@ class KafkaToSlickIntegrationSpec extends KafkaSpecBase(ConfigFactory.load().wit
       produceEvents(topicName)
 
       val kafkaSourceProvider: SourceProvider[MergeableOffset[JLong], ConsumerRecord[String, String]] =
-        KafkaSourceProvider(system.toTyped, consumerDefaults().withGroupId(groupId), Set(topicName))
+        KafkaSourceProvider(
+          system.toTyped,
+          consumerDefaults(StringDeserializer, StringDeserializer)
+            .withGroupId(groupId),
+          Set(topicName))
 
       val slickProjection =
         SlickProjection.exactlyOnce(
@@ -173,7 +177,11 @@ class KafkaToSlickIntegrationSpec extends KafkaSpecBase(ConfigFactory.load().wit
       produceEvents(topicName)
 
       val kafkaSourceProvider: SourceProvider[MergeableOffset[JLong], ConsumerRecord[String, String]] =
-        KafkaSourceProvider(system.toTyped, consumerDefaults().withGroupId(groupId), Set(topicName))
+        KafkaSourceProvider(
+          system.toTyped,
+          consumerDefaults(StringDeserializer, StringDeserializer)
+            .withGroupId(groupId),
+          Set(topicName))
 
       // repository will fail to insert the "AddToCart" event type once only
       val failedOnce = new AtomicBoolean
@@ -215,7 +223,11 @@ class KafkaToSlickIntegrationSpec extends KafkaSpecBase(ConfigFactory.load().wit
       produceEvents(topicName)
 
       val kafkaSourceProvider: SourceProvider[MergeableOffset[JLong], ConsumerRecord[String, String]] =
-        KafkaSourceProvider(system.toTyped, consumerDefaults().withGroupId(groupId), Set(topicName))
+        KafkaSourceProvider(
+          system.toTyped,
+          consumerDefaults(StringDeserializer, StringDeserializer)
+            .withGroupId(groupId),
+          Set(topicName))
 
       def slickProjection() = {
 

--- a/akka-projection-slick/src/it/scala/akka/projection/slick/SlickContainerOffsetStoreSpec.scala
+++ b/akka-projection-slick/src/it/scala/akka/projection/slick/SlickContainerOffsetStoreSpec.scala
@@ -55,7 +55,7 @@ object SlickContainerOffsetStoreSpec {
   class PostgresSpecConfig extends ContainerJdbcSpecConfig {
 
     val name = "Postgres Database"
-    val container = initContainer(new PostgreSQLContainer("postgres"))
+    val container = initContainer(new PostgreSQLContainer("postgres:13.1"))
 
     override def config: Config =
       super.config.withFallback(ConfigFactory.parseString("""
@@ -68,7 +68,7 @@ object SlickContainerOffsetStoreSpec {
   class MySQLSpecConfig extends ContainerJdbcSpecConfig {
 
     val name = "MySQL Database"
-    val container = initContainer(new MySQLContainer("mysql"))
+    val container = initContainer(new MySQLContainer("mysql:8.0.22"))
 
     override def config: Config =
       super.config.withFallback(ConfigFactory.parseString("""
@@ -82,7 +82,7 @@ object SlickContainerOffsetStoreSpec {
     val name = "MS SQL Server Database"
     override val tag = TestTags.FlakyDb
 
-    val container = initContainer(new MSSQLServerContainer("mcr.microsoft.com/mssql/server"))
+    val container = initContainer(new MSSQLServerContainer("mcr.microsoft.com/mssql/server:2019-CU8-ubuntu-16.04"))
 
     override def config: Config =
       super.config.withFallback(ConfigFactory.parseString("""
@@ -94,7 +94,7 @@ object SlickContainerOffsetStoreSpec {
   class OracleSpecConfig extends ContainerJdbcSpecConfig {
 
     val name = "Oracle Database"
-    val container = initContainer(new OracleContainer("oracleinanutshell/oracle-xe-11g"))
+    val container = initContainer(new OracleContainer("oracleinanutshell/oracle-xe-11g:1.0.0"))
 
     override def config: Config =
       super.config.withFallback(ConfigFactory.parseString("""

--- a/akka-projection-slick/src/it/scala/akka/projection/slick/SlickContainerOffsetStoreSpec.scala
+++ b/akka-projection-slick/src/it/scala/akka/projection/slick/SlickContainerOffsetStoreSpec.scala
@@ -55,7 +55,7 @@ object SlickContainerOffsetStoreSpec {
   class PostgresSpecConfig extends ContainerJdbcSpecConfig {
 
     val name = "Postgres Database"
-    val container = initContainer(new PostgreSQLContainer)
+    val container = initContainer(new PostgreSQLContainer("postgres"))
 
     override def config: Config =
       super.config.withFallback(ConfigFactory.parseString("""
@@ -68,7 +68,7 @@ object SlickContainerOffsetStoreSpec {
   class MySQLSpecConfig extends ContainerJdbcSpecConfig {
 
     val name = "MySQL Database"
-    val container = initContainer(new MySQLContainer)
+    val container = initContainer(new MySQLContainer("mysql"))
 
     override def config: Config =
       super.config.withFallback(ConfigFactory.parseString("""
@@ -82,7 +82,7 @@ object SlickContainerOffsetStoreSpec {
     val name = "MS SQL Server Database"
     override val tag = TestTags.FlakyDb
 
-    val container = initContainer(new MSSQLServerContainer)
+    val container = initContainer(new MSSQLServerContainer("mcr.microsoft.com/mssql/server"))
 
     override def config: Config =
       super.config.withFallback(ConfigFactory.parseString("""

--- a/container-license-acceptance.txt
+++ b/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-mcr.microsoft.com/mssql/server:2017-CU12
+mcr.microsoft.com/mssql/server:2019-CU8-ubuntu-16.04

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,12 +16,13 @@ object Dependencies {
   object Versions {
     val akka = sys.props.getOrElse("build.akka.version", "2.6.10")
     val alpakka = "2.0.2"
-    val alpakkaKafka = sys.props.getOrElse("build.alpakka.kafka.version", "2.0.5")
+    val alpakkaKafka = sys.props.getOrElse("build.alpakka.kafka.version", "2.1.0-M1")
     val slick = "3.3.3"
     val scalaTest = "3.1.1"
     val testContainers = "1.14.3"
     val junit = "4.13.1"
     val h2Driver = "1.4.200"
+    val jackson = "2.10.5" // this should match the version of jackson used by akka-serialization-jackson
   }
 
   object Compile {
@@ -39,6 +40,9 @@ object Dependencies {
     val alpakkaCassandra = "com.lightbend.akka" %% "akka-stream-alpakka-cassandra" % Versions.alpakka
 
     val alpakkaKafka = "com.typesafe.akka" %% "akka-stream-kafka" % Versions.alpakkaKafka
+
+    // must be provided on classpath when using Apache Kafka 2.6.0+
+    val jackson = "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson
 
     // not really used in lib code, but in example and test
     val h2Driver = "com.h2database" % "h2" % Versions.h2Driver
@@ -166,6 +170,7 @@ object Dependencies {
   val kafka =
     deps ++= Seq(
         Compile.alpakkaKafka,
+        Compile.jackson,
         Test.scalatest,
         Test.akkaTypedTestkit,
         Test.akkaStreamTestkit,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
     val alpakkaKafka = sys.props.getOrElse("build.alpakka.kafka.version", "2.1.0-M1")
     val slick = "3.3.3"
     val scalaTest = "3.1.1"
-    val testContainers = "1.14.3"
+    val testContainers = "1.15.1"
     val junit = "4.13.1"
     val h2Driver = "1.4.200"
     val jackson = "2.10.5" // this should match the version of jackson used by akka-serialization-jackson


### PR DESCRIPTION
Older `confluentinc/cp-kafka` docker images have been removed from DockerHub. I assume in response to new space-related policies. Confluent made structural changes to `cp-kafka` images as of Apache Kafka 2.5.0 (CP 5.5.0) that were backported to patch releases of older `cp-kafka` images, breaking compatibility with testcontainers readiness and start scripts.

This PR will get tests working again by using the latest Alpakka Kafka milestone release, but we should wait for a final artifact of Alpakka Kafka 2.0.x or 2.1.0 before releasing projections.