### PR TITLE
Moving to GitHub Actions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Code style check and binary-compatibility check
         run: sbt "verifyCodeStyle; mimaReportBinaryIssues"
 
-  check-code-compililation:
+  check-code-compilation:
     name: Check Code Compilation
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,88 @@
+name: Basic checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags-ignore: [ v.* ]
+
+jobs:
+  check-code-style:
+    name: Check Code Style
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
+          fetch-depth: 0
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Set up JDK 11
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11.0-9
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v5
+
+      - name: Code style check and binary-compatibility check
+        run: sbt "verifyCodeStyle; mimaReportBinaryIssues"
+
+  check-code-compililation:
+    name: Check Code Compilation
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Set up JDK 11
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11.0-9
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v5
+
+      - name: Compile all code with fatal warnings for Java 11, Scala 2.12 and Scala 2.13
+        run: sbt "clean ; +IntegrationTest/compile"
+
+  check-docs:
+    name: Check Docs
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Set up JDK 11
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11.0-9
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v5
+
+      - name: Create all API docs for artifacts/website and all reference docs
+        run: sbt "unidoc; docs/paradox"

--- a/.github/workflows/integration-tests-cassandra.yml
+++ b/.github/workflows/integration-tests-cassandra.yml
@@ -1,4 +1,4 @@
-name: Integration Tests
+name: Integration Tests for Cassandra
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    name: Build and Test Integration
+    name: Build and Test Integration for Cassandra
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
@@ -38,7 +38,7 @@ jobs:
         uses: coursier/cache-action@v5
 
       - name: Run all integration tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
-        run: sbt "++${{ matrix.scala-version }} it:test" ${{ matrix.sbt-opts }}
+        run: sbt "++${{ matrix.scala-version }} akka-projection-cassandra/it:test" ${{ matrix.sbt-opts }}
 
       - name: Print logs on failure
         if: ${{ failure() }}

--- a/.github/workflows/integration-tests-cassandra.yml
+++ b/.github/workflows/integration-tests-cassandra.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Run all integration tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
         run: sbt "++${{ matrix.scala-version }} akka-projection-cassandra/it:test" ${{ matrix.sbt-opts }}
+        env: # Disable Ryuk resource reaper since we always spin up fresh VMs
+          TESTCONTAINERS_RYUK_DISABLED: true
 
       - name: Print logs on failure
         if: ${{ failure() }}

--- a/.github/workflows/integration-tests-jdbc.yml
+++ b/.github/workflows/integration-tests-jdbc.yml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Run all integration tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
         run: sbt "++${{ matrix.scala-version }} akka-projection-jdbc/it:test" ${{ matrix.sbt-opts }}
+        env: # Disable Ryuk resource reaper since we always spin up fresh VMs
+          TESTCONTAINERS_RYUK_DISABLED: true
 
       - name: Print logs on failure
         if: ${{ failure() }}

--- a/.github/workflows/integration-tests-jdbc.yml
+++ b/.github/workflows/integration-tests-jdbc.yml
@@ -1,0 +1,49 @@
+name: Integration Tests for JDBC
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags-ignore: [ v.* ]
+
+jobs:
+  test:
+    name: Build and Test Integration for JDBC
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { java-version: adopt@1.8,      scala-version: 2.13.3,  sbt-opts: '' }
+          - { java-version: adopt@1.11.0-9, scala-version: 2.13.3,  sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Copy license acceptance
+        run: |-
+          cp container-license-acceptance.txt akka-projection-jdbc/src/it/resources/container-license-acceptance.txt
+
+      - name: Setup JDK ${{ matrix.java-version }}
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: ${{ matrix.java-version }}
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v5        
+
+      - name: Run all integration tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
+        run: sbt "++${{ matrix.scala-version }} akka-projection-jdbc/it:test" ${{ matrix.sbt-opts }}
+
+      - name: Print logs on failure
+        if: ${{ failure() }}
+        run: find . -name "*.log" -exec ./scripts/cat-log.sh {} \;

--- a/.github/workflows/integration-tests-kafka.yml
+++ b/.github/workflows/integration-tests-kafka.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Run all integration tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
         run: sbt "++${{ matrix.scala-version }} akka-projection-kafka/it:test" ${{ matrix.sbt-opts }}
+        env: # Disable Ryuk resource reaper since we always spin up fresh VMs
+          TESTCONTAINERS_RYUK_DISABLED: true
 
       - name: Print logs on failure
         if: ${{ failure() }}

--- a/.github/workflows/integration-tests-kafka.yml
+++ b/.github/workflows/integration-tests-kafka.yml
@@ -1,0 +1,45 @@
+name: Integration Tests for Kafka
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags-ignore: [ v.* ]
+
+jobs:
+  test:
+    name: Build and Test Integration for Kafka
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { java-version: adopt@1.8,      scala-version: 2.13.3,  sbt-opts: '' }
+          - { java-version: adopt@1.11.0-9, scala-version: 2.13.3,  sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Setup JDK ${{ matrix.java-version }}
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: ${{ matrix.java-version }}
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v5
+
+      - name: Run all integration tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
+        run: sbt "++${{ matrix.scala-version }} akka-projection-kafka/it:test" ${{ matrix.sbt-opts }}
+
+      - name: Print logs on failure
+        if: ${{ failure() }}
+        run: find . -name "*.log" -exec ./scripts/cat-log.sh {} \;

--- a/.github/workflows/integration-tests-slick.yml
+++ b/.github/workflows/integration-tests-slick.yml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Run all integration tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
         run: sbt "++${{ matrix.scala-version }} akka-projection-slick/it:test" ${{ matrix.sbt-opts }}
+        env: # Disable Ryuk resource reaper since we always spin up fresh VMs
+          TESTCONTAINERS_RYUK_DISABLED: true
 
       - name: Print logs on failure
         if: ${{ failure() }}

--- a/.github/workflows/integration-tests-slick.yml
+++ b/.github/workflows/integration-tests-slick.yml
@@ -1,0 +1,49 @@
+name: Integration Tests for Slick
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags-ignore: [ v.* ]
+
+jobs:
+  test:
+    name: Build and Test Integration for Slick
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { java-version: adopt@1.8,      scala-version: 2.13.3,  sbt-opts: '' }
+          - { java-version: adopt@1.11.0-9, scala-version: 2.13.3,  sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Copy license acceptance
+        run: |-
+          cp container-license-acceptance.txt akka-projection-slick/src/it/resources/container-license-acceptance.txt
+
+      - name: Setup JDK ${{ matrix.java-version }}
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: ${{ matrix.java-version }}
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v5
+
+      - name: Run all integration tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
+        run: sbt "++${{ matrix.scala-version }} akka-projection-slick/it:test" ${{ matrix.sbt-opts }}
+
+      - name: Print logs on failure
+        if: ${{ failure() }}
+        run: find . -name "*.log" -exec ./scripts/cat-log.sh {} \;

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,4 +1,4 @@
-name: Unit Tests
+name: Integration Tests
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    name: Build and Test
+    name: Build and Test Integration
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
@@ -37,8 +37,8 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v5
 
-      - name: Run tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
-        run: sbt "++${{ matrix.scala-version }} test" ${{ matrix.sbt-opts }}
+      - name: Run all integration tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
+        run: sbt "++${{ matrix.scala-version }} it:test" ${{ matrix.sbt-opts }}
 
       - name: Print logs on failure
         if: ${{ failure() }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,5 @@ jobs:
           eval "$(ssh-agent -s)"
           echo $GUSTAV_KEY | base64 -di > .github/id_rsa
           chmod 600 .github/id_rsa
-          ssh-keygen -p -P "$GUSTAV_PASSPHRASE" -N "" -f .github/id_rsa
           ssh-add .github/id_rsa
-          sbt "++2.13.4 docs/publishRsync"
+          sbt "++2.13.3 docs/publishRsync"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+    tags: [ v.* ]
+
+jobs:
+  release:
+    # runs on main repo only
+    if: github.repository == 'akka/akka-projection'
+    name: Release
+    # the release environment provides access to secrets required in the release process
+    # https://github.com/akka/akka-projection/settings/environments
+    environment: release
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
+          fetch-depth: 0
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Setup Scala with JDK 8
+        uses: olafurpg/setup-scala@v10
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v5
+
+      - name: Whitesource check policies and update
+        env:
+          WHITESOURCE_PASSWORD: ${{ secrets.WHITESOURCE_PASSWORD }}
+        run: sbt ";whitesourceCheckPolicies ;whitesourceUpdate"
+
+      - name: Publish artifacts for all Scala versions
+        env:
+          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+          # note: although the sbt-bintray plugin expects a var name BINTRAY_PASS, we must pass a bintray key
+          BINTRAY_PASS: ${{ secrets.BINTRAY_KEY }}
+        run: sbt "+publish"
+
+      - name: Publish API and reference documentation
+        env:
+          GUSTAV_KEY: ${{ secrets.GUSTAV_KEY }}
+          GUSTAV_PASSPHRASE: ${{ secrets.GUSTAV_PASSPHRASE }}
+        run: |+
+          eval "$(ssh-agent -s)"
+          echo $GUSTAV_KEY | base64 -di > .github/id_rsa
+          chmod 600 .github/id_rsa
+          ssh-keygen -p -P "$GUSTAV_PASSPHRASE" -N "" -f .github/id_rsa
+          ssh-add .github/id_rsa
+          sbt "++2.13.4 docs/publishRsync"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,47 @@
+name: Unit Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags-ignore: [ v.* ]
+
+jobs:
+  test:
+    name: Build and Test
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { java-version: adopt@1.8,      scala-version: 2.12.11, sbt-opts: '' }
+          - { java-version: adopt@1.8,      scala-version: 2.13.3,  sbt-opts: '' }
+          - { java-version: adopt@1.11.0-9, scala-version: 2.12.11, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { java-version: adopt@1.11.0-9, scala-version: 2.13.3,  sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Checkout GitHub merge
+        if: github.event.pull_request
+        run: |-
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
+          git checkout scratch
+
+      - name: Setup JDK ${{ matrix.java-version }}
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: ${{ matrix.java-version }}
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v5
+
+      - name: Run tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
+        run: sbt "++${{ matrix.scala-version }} test" ${{ matrix.sbt-opts }}
+
+      - name: Print logs on failure
+        if: ${{ failure() }}
+        run: find . -name "*.log" -exec ./scripts/cat-log.sh {} \;

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,57 +26,11 @@ jobs:
     - stage: check
       env: CMD="verifyCodeStyle"
       name: "Code style check. Run locally with: sbt verifyCodeStyle"
-    - env: CMD="++2.12.11 IntegrationTest/compile"
-      name: "Compile all code with 2.12"
-    - env: CMD="IntegrationTest/compile"
-      name: "Compile all code with 2.13"
-    - env: CMD="unidoc; docs/paradox"
-      name: "Create API and reference documentation"
-
-    - stage: test
-      env:
-        - CMD="test"
-      name: "Run unit tests with Scala 2.13 and AdoptOpenJDK 8"
-    - env:
-        - JDK="adopt@~1.11-0"
-        - _JAVA_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
-        - CMD="test"
-      name: "Run unit tests with Scala 2.13 and AdoptOpenJDK 11"
-    - env:
-        - CMD="it:test"
-      name: "Run all integration tests with Scala 2.13 and AdoptOpenJDK 8"
-    - env:
-        - JDK="adopt@~1.11-0"
-        - _JAVA_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
-        - CMD="it:test"
-      name: "Run all integration tests with Scala 2.13 and AdoptOpenJDK 11"
-
-    - stage: whitesource
-      name: WhiteSource
-      script: git branch -f "$TRAVIS_BRANCH" && git checkout "$TRAVIS_BRANCH" && sbt -jvm-opts .jvmopts-travis whitesourceCheckPolicies whitesourceUpdate
-
-    - stage: publish
-      env: CMD="+publish"
-      name: "Publish artifacts to Bintray"
-    - script: openssl aes-256-cbc -K $encrypted_8fb0ea6dc959_key -iv $encrypted_8fb0ea6dc959_iv -in .travis/travis_gustav.enc -out .travis/id_rsa -d && eval "$(ssh-agent -s)" && chmod 600 .travis/id_rsa && ssh-add .travis/id_rsa && sbt -jvm-opts .jvmopts-travis docs/publishRsync
-      name: "Publish API and reference documentation"
 
 stages:
   # runs on master commits and PRs
   - name: check
     if: NOT tag =~ ^v
-
-  # runs on master commits and PRs
-  - name: test
-    if: NOT tag =~ ^v
-
-  # runs on main repo master commits and version-tagged commits
-  - name: whitesource
-    if: repo = akka/akka-projection AND ( ( branch = master AND type = push ) OR tag =~ ^v)
-
-  # runs on main repo master commits and version-tagged commits
-  - name: publish
-    if: repo = akka/akka-projection AND ( ( branch = master AND type = push ) OR tag =~ ^v )
 
 after_failure:
   - docker-compose logs

--- a/akka-projection-jdbc/src/it/scala/akka/projection/jdbc/JdbcContainerOffsetStoreSpec.scala
+++ b/akka-projection-jdbc/src/it/scala/akka/projection/jdbc/JdbcContainerOffsetStoreSpec.scala
@@ -100,6 +100,8 @@ object JdbcContainerOffsetStoreSpec {
   object OracleSpecConfig extends ContainerJdbcSpecConfig("oracle-dialect") {
     val name = "Oracle Database"
 
+    // related to https://github.com/testcontainers/testcontainers-java/issues/2313
+    // otherwise we get ORA-01882: timezone region not found
     System.setProperty("oracle.jdbc.timezoneAsRegion", "false")
     override def newContainer() = 
       new OracleContainer("oracleinanutshell/oracle-xe-11g:1.0.0")

--- a/akka-projection-jdbc/src/it/scala/akka/projection/jdbc/JdbcContainerOffsetStoreSpec.scala
+++ b/akka-projection-jdbc/src/it/scala/akka/projection/jdbc/JdbcContainerOffsetStoreSpec.scala
@@ -99,7 +99,9 @@ object JdbcContainerOffsetStoreSpec {
 
   object OracleSpecConfig extends ContainerJdbcSpecConfig("oracle-dialect") {
     val name = "Oracle Database"
-    override def newContainer() =
+
+    System.setProperty("oracle.jdbc.timezoneAsRegion", "false")
+    override def newContainer() = 
       new OracleContainer("oracleinanutshell/oracle-xe-11g:1.0.0")
         .withInitScript("db/oracle-init.sql")
   }

--- a/akka-projection-slick/src/it/scala/akka/projection/slick/SlickContainerOffsetStoreSpec.scala
+++ b/akka-projection-slick/src/it/scala/akka/projection/slick/SlickContainerOffsetStoreSpec.scala
@@ -110,6 +110,7 @@ object SlickContainerOffsetStoreSpec {
   class OracleSpecConfig extends ContainerJdbcSpecConfig {
 
     val name = "Oracle Database"
+    System.setProperty("oracle.jdbc.timezoneAsRegion", "false")
     val container = initContainer(new OracleContainer("oracleinanutshell/oracle-xe-11g:1.0.0"))
 
     override def config: Config =

--- a/akka-projection-slick/src/it/scala/akka/projection/slick/SlickContainerOffsetStoreSpec.scala
+++ b/akka-projection-slick/src/it/scala/akka/projection/slick/SlickContainerOffsetStoreSpec.scala
@@ -110,7 +110,11 @@ object SlickContainerOffsetStoreSpec {
   class OracleSpecConfig extends ContainerJdbcSpecConfig {
 
     val name = "Oracle Database"
+
+    // related to https://github.com/testcontainers/testcontainers-java/issues/2313
+    // otherwise we get ORA-01882: timezone region not found
     System.setProperty("oracle.jdbc.timezoneAsRegion", "false")
+    
     val container = initContainer(new OracleContainer("oracleinanutshell/oracle-xe-11g:1.0.0"))
 
     override def config: Config =

--- a/scripts/cat-log.sh
+++ b/scripts/cat-log.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# ---------- helper script to separate log files in build
+printf "\n\n\n"
+ls -lh $1
+printf "\n\n"
+cat $1


### PR DESCRIPTION
Moves Akka Projection to GitHub Actions, mainly because we have experienced issues with docker and travis. 

### TODOs

- [x] minimal travis file to keep current PR checks happy
- [x] basic checks workflow file
- [x] release workflow file (no credentials configured yet) 
- [x] unit tests - H2 only
- [x] integration tests using docker (test-containers)
- [x] configure release credentials - moving to sonatype will follow in separate PR
- [ ] cron job using Akka and Alpakka Kafka snapshots (may be on another PR)

The travis job have two snapshots variables (`$AKKA_SNAPSHOT` and `$ALPAKKA_KAFKA_SNAPSHOT`) but they were not being set. We probably want to do something about it. Maybe on another PR later. 