### PR TITLE
Retry management operations if timeout, #531

### DIFF
--- a/akka-projection-core/src/main/resources/reference.conf
+++ b/akka-projection-core/src/main/resources/reference.conf
@@ -60,6 +60,8 @@ akka.projection {
   management {
     # timeout for the operations in ProjectionManagement
     operation-timeout = 10 s
+    # timeout for individual management requests, they are retried in case of timeout until the operation-timeout
+    ask-timeout = 3 s
   }
 }
 

--- a/akka-projection-kafka/src/it/scala/akka/projection/kafka/integration/KafkaToSlickIntegrationSpec.scala
+++ b/akka-projection-kafka/src/it/scala/akka/projection/kafka/integration/KafkaToSlickIntegrationSpec.scala
@@ -241,7 +241,6 @@ class KafkaToSlickIntegrationSpec extends KafkaSpecBase(ConfigFactory.load().wit
               val eventType = envelope.value()
               val userEvent = UserEvent(userId, eventType)
               // do something with the record, payload in record.value
-              println(s"# process ${envelope.offset()}: $userId $eventType") // FIXME
               repository.incrementCount(projectionId, userEvent.eventType)
             })
       }


### PR DESCRIPTION
* because of race condition of topic registration and early management operation
* also problem in cluster when publish happens before subscribers are know

References #531
