### PR TITLE
Configurable path of dispatcher for JDBC projections

### DIFF
--- a/akka-projection-jdbc/src/main/mima-filters/1.1.0.backwards.excludes/jdbc-settings.excludes
+++ b/akka-projection-jdbc/src/main/mima-filters/1.1.0.backwards.excludes/jdbc-settings.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.jdbc.internal.JdbcSettings.dispatcherConfigPath")

--- a/akka-projection-jdbc/src/main/resources/reference.conf
+++ b/akka-projection-jdbc/src/main/resources/reference.conf
@@ -5,6 +5,7 @@
 akka.projection.jdbc {
   # choose one of: mysql-dialect, postgres-dialect, mssql-dialect, oracle-dialect or h2-dialect (testing)
   dialect = ""
+  dispatcher = "akka.projection.jdbc.blocking-jdbc-dispatcher"
   blocking-jdbc-dispatcher {
     type = Dispatcher
     executor = "thread-pool-executor"

--- a/akka-projection-jdbc/src/main/resources/reference.conf
+++ b/akka-projection-jdbc/src/main/resources/reference.conf
@@ -5,7 +5,7 @@
 akka.projection.jdbc {
   # choose one of: mysql-dialect, postgres-dialect, mssql-dialect, oracle-dialect or h2-dialect (testing)
   dialect = ""
-  dispatcher = "akka.projection.jdbc.blocking-jdbc-dispatcher"
+  use-dispatcher = "akka.projection.jdbc.blocking-jdbc-dispatcher"
   blocking-jdbc-dispatcher {
     type = Dispatcher
     executor = "thread-pool-executor"

--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcSettings.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcSettings.scala
@@ -57,7 +57,7 @@ private[projection] case class JdbcSettings(config: Config, executionContext: Ex
 private[projection] object JdbcSettings {
 
   val configPath = "akka.projection.jdbc"
-  val dispatcherPath: String = configPath + ".dispatcher"
+  val dispatcherPath: String = configPath + ".use-dispatcher"
 
   private def checkDispatcherConfig(system: ActorSystem[_]) = {
 

--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcSettings.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcSettings.scala
@@ -57,10 +57,11 @@ private[projection] case class JdbcSettings(config: Config, executionContext: Ex
 private[projection] object JdbcSettings {
 
   val configPath = "akka.projection.jdbc"
-  val dispatcherConfigPath = configPath + ".blocking-jdbc-dispatcher"
+  val dispatcherPath: String = configPath + ".dispatcher"
 
   private def checkDispatcherConfig(system: ActorSystem[_]) = {
 
+    val dispatcherConfigPath = system.settings.config.getString(dispatcherPath)
     val config = system.settings.config.getConfig(dispatcherConfigPath)
     val pathToPoolSize = "thread-pool-executor.fixed-pool-size"
 
@@ -96,6 +97,7 @@ private[projection] object JdbcSettings {
 
   def apply(system: ActorSystem[_]): JdbcSettings = {
     checkDispatcherConfig(system)
+    val dispatcherConfigPath = system.settings.config.getString(dispatcherPath)
     val blockingDbDispatcher = system.dispatchers.lookup(DispatcherSelector.fromConfig(dispatcherConfigPath))
     JdbcSettings(system.settings.config.getConfig(configPath), blockingDbDispatcher)
   }

--- a/akka-projection-jdbc/src/test/java/akka/projection/jdbc/JdbcProjectionTest.java
+++ b/akka-projection-jdbc/src/test/java/akka/projection/jdbc/JdbcProjectionTest.java
@@ -55,7 +55,7 @@ public class JdbcProjectionTest extends JUnitSuite {
     configuration.put("akka.projection.jdbc.dialect", "h2-dialect");
     configuration.put("akka.projection.jdbc.offset-store.schema", "");
     configuration.put("akka.projection.jdbc.offset-store.table", "akka_projection_offset_store");
-    configuration.put("akka.projection.jdbc.dispatcher", "database.dispatcher");
+    configuration.put("akka.projection.jdbc.use-dispatcher", "database.dispatcher");
     configuration.put("database.dispatcher.executor", "thread-pool-executor");
     configuration.put("database.dispatcher.throughput", 1);
     configuration.put("database.dispatcher.thread-pool-executor.fixed-pool-size", 5);

--- a/akka-projection-jdbc/src/test/java/akka/projection/jdbc/JdbcProjectionTest.java
+++ b/akka-projection-jdbc/src/test/java/akka/projection/jdbc/JdbcProjectionTest.java
@@ -55,8 +55,10 @@ public class JdbcProjectionTest extends JUnitSuite {
     configuration.put("akka.projection.jdbc.dialect", "h2-dialect");
     configuration.put("akka.projection.jdbc.offset-store.schema", "");
     configuration.put("akka.projection.jdbc.offset-store.table", "akka_projection_offset_store");
-    configuration.put(
-        "akka.projection.jdbc.blocking-jdbc-dispatcher.thread-pool-executor.fixed-pool-size", 5);
+    configuration.put("akka.projection.jdbc.dispatcher", "database.dispatcher");
+    configuration.put("database.dispatcher.executor", "thread-pool-executor");
+    configuration.put("database.dispatcher.throughput", 1);
+    configuration.put("database.dispatcher.thread-pool-executor.fixed-pool-size", 5);
   }
 
   private static final Config config = ConfigFactory.parseMap(configuration);


### PR DESCRIPTION
Main reason: we using Play [JPAApi](https://www.playframework.com/documentation/2.8.x/JavaJPA#Using-play.db.jpa.JPAApi) and already have a dispatcher ([Using a CustomExecutionContext](https://www.playframework.com/documentation/2.8.x/JavaJPA#Using-a-CustomExecutionContext)). 

It will be good if we can sharing exist connection pool and dispatcher for Akka Projection.