### PR TITLE
fix: remove silencer plugin

### DIFF
--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/internal/TestOffsetStoreAdapter.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/internal/TestOffsetStoreAdapter.scala
@@ -4,7 +4,7 @@
 
 package akka.projection.testkit.internal
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.OptionConverters._
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.Future
@@ -14,15 +14,13 @@ import akka.annotation.InternalApi
 import akka.projection.ProjectionId
 import akka.projection.internal.ManagementState
 import akka.projection.testkit.scaladsl.TestOffsetStore
-import com.github.ghik.silencer.silent
-
 @InternalApi private[projection] class TestOffsetStoreAdapter[Offset](
     delegate: akka.projection.testkit.javadsl.TestOffsetStore[Offset])
     extends TestOffsetStore[Offset] {
 
   override def lastOffset(): Option[Offset] = delegate.lastOffset().asScala
 
-  @silent override def allOffsets(): List[(ProjectionId, Offset)] = delegate.allOffsets().asScala.map(_.toScala).toList
+  override def allOffsets(): List[(ProjectionId, Offset)] = delegate.allOffsets().asScala.map(_.toScala).toList
 
   override def readOffsets(): Future[Option[Offset]] = {
     implicit val ec = akka.dispatch.ExecutionContexts.parasitic

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -20,17 +20,9 @@ object AkkaDisciplinePlugin extends AutoPlugin {
   // We allow warnings in docs to get the 'snippets' right
   val nonFatalWarningsFor = Set("docs")
 
-  lazy val silencerSettings = {
-    val silencerVersion = "1.7.3"
-    Seq(
-      libraryDependencies ++= Seq(
-          compilerPlugin(("com.github.ghik" %% "silencer-plugin" % silencerVersion).cross(CrossVersion.patch)),
-          ("com.github.ghik" %% "silencer-lib" % silencerVersion % Provided).cross(CrossVersion.patch)))
-  }
-
   lazy val disciplineSettings =
     if (enabled) {
-      silencerSettings ++ Seq(
+      Seq(
         Compile / scalacOptions ++= (
             if (!nonFatalWarningsFor(name.value)) Seq("-Xfatal-warnings")
             else Seq.empty
@@ -58,8 +50,7 @@ object AkkaDisciplinePlugin extends AutoPlugin {
         // having discipline warnings in console is just an annoyance
         Compile / console / scalacOptions --= disciplineScalacOptions.toSeq)
     } else {
-      // we still need these in opt-out since the annotations are present
-      silencerSettings ++ Seq(Compile / scalacOptions += "-deprecation")
+      Seq(Compile / scalacOptions += "-deprecation")
     }
 
   val testUndicipline = Seq("-Ywarn-dead-code" // '???' used in compile only specs

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,6 +46,8 @@ object Dependencies {
 
     // not really used in lib code, but in example and test
     val h2Driver = "com.h2database" % "h2" % Versions.h2Driver
+
+    val collectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0"
   }
 
   object Test {
@@ -119,6 +121,7 @@ object Dependencies {
     deps ++= Seq(
         Compile.akkaTypedTestkit,
         Compile.akkaStreamTestkit,
+        Compile.collectionCompat,
         Test.scalatest,
         Test.scalatestJUnit,
         Test.junit,


### PR DESCRIPTION
This is in preparation for compiling with Scala 3. 

There is no plugin for scala 3 and it doesn't make sense to continue use it, because...

1. we should use Scala's @nowarn
2. the only place we used is better solved by using `"org.scala-lang.modules" %% "scala-collection-compat"`, which is now introduced in this PR.