### PR TITLE
Compile with Scala3

### DIFF
--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
@@ -178,7 +178,7 @@ import akka.stream.scaladsl.Source
         settings) {
 
     override implicit def executionContext: ExecutionContext = system.executionContext
-    override val logger: LoggingAdapter = Logging(system.classicSystem, this.getClass)
+    override val logger: LoggingAdapter = Logging(system.classicSystem, classOf[CassandraInternalProjectionState])
 
     private val offsetStore = new CassandraOffsetStore(system)
 
@@ -193,7 +193,10 @@ import akka.stream.scaladsl.Source
       offsetStore.saveOffset(projectionId, offset)
 
     private[projection] def newRunningInstance(): RunningProjection = {
-      new CassandraRunningProjection(RunningProjection.withBackoff(() => mappedSource(), settings), offsetStore, this)
+      new CassandraRunningProjection(
+        RunningProjection.withBackoff(() => this.mappedSource(), settings),
+        offsetStore,
+        this)
     }
 
   }

--- a/akka-projection-core/src/main/scala/akka/projection/ProjectionBehavior.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/ProjectionBehavior.scala
@@ -3,6 +3,8 @@
  */
 
 package akka.projection
+import scala.reflect.ClassTag
+
 import akka.actor.typed.scaladsl.LoggerOps
 import scala.util.Failure
 import scala.util.Success
@@ -68,6 +70,8 @@ object ProjectionBehavior {
    */
   def stopMessage(): Command = Stop
 
+  type Thr <: Throwable
+
   /**
    * Scala API: creates a ProjectionBehavior for the passed projections.
    */
@@ -75,8 +79,12 @@ object ProjectionBehavior {
     Behaviors.setup[Command] { ctx =>
       Behaviors.withStash[Command](1000) { stashBuffer =>
         ctx.log.info("Starting projection [{}]", projection.projectionId)
+
+        val throwableClassTag = implicitly[ClassTag[Throwable]]
+
         projection.actorHandlerInit[Any].foreach { init =>
-          val ref = ctx.spawnAnonymous(Behaviors.supervise(init.behavior).onFailure(SupervisorStrategy.restart))
+          val ref = ctx.spawnAnonymous(
+            Behaviors.supervise(init.behavior).onFailure(SupervisorStrategy.restart)(throwableClassTag))
           init.setActor(ref)
           ctx.log.debug2("Started actor handler [{}] for projection [{}]", ref, projection.projectionId)
         }
@@ -102,7 +110,7 @@ object ProjectionBehavior {
 
   private def projectionId = projection.projectionId
 
-  private def started(running: RunningProjection): Behavior[Command] =
+  private[projection] def started(running: RunningProjection): Behavior[Command] =
     Behaviors.receiveMessagePartial {
       case Stop =>
         context.log.debug("Projection [{}] is being stopped", projectionId)
@@ -112,9 +120,9 @@ object ProjectionBehavior {
         context.pipeToSelf(stoppedFut)(_ => Stopped)
         stopping()
 
-      case getOffset: GetOffset[Offset] =>
+      case getOffset: GetOffset[Offset] @unchecked =>
         running match {
-          case mgmt: RunningProjectionManagement[Offset] =>
+          case mgmt: RunningProjectionManagement[Offset] @unchecked =>
             if (getOffset.projectionId == projectionId) {
               context.pipeToSelf(mgmt.getOffset()) {
                 case Success(offset) => GetOffsetResult(offset, getOffset.replyTo)
@@ -125,12 +133,12 @@ object ProjectionBehavior {
           case _ => Behaviors.unhandled
         }
 
-      case result: GetOffsetResult[Offset] =>
+      case result: GetOffsetResult[Offset] @unchecked =>
         receiveGetOffsetResult(result)
 
-      case setOffset: SetOffset[Offset] =>
+      case setOffset: SetOffset[Offset] @unchecked =>
         running match {
-          case mgmt: RunningProjectionManagement[Offset] =>
+          case mgmt: RunningProjectionManagement[Offset] @unchecked =>
             if (setOffset.projectionId == projectionId) {
               context.log.info2(
                 "Offset will be changed to [{}] for projection [{}]. The Projection will be restarted.",

--- a/akka-projection-core/src/main/scala/akka/projection/ProjectionId.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/ProjectionId.scala
@@ -84,7 +84,7 @@ object ProjectionId {
    * @return an [[java.util.Set]] of [[ProjectionId]]s
    */
   def of(name: String, keys: java.util.Set[String]): java.util.Set[ProjectionId] =
-    keys.asScala.map { key: String => new ProjectionId(name, key) }.asJava
+    keys.asScala.map { key => new ProjectionId(name, key) }.asJava
 }
 
 @ApiMayChange

--- a/akka-projection-core/src/main/scala/akka/projection/internal/InternalProjectionState.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/InternalProjectionState.scala
@@ -123,7 +123,7 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
     val atLeastOnceHandlerFlow
         : Flow[ProjectionContextImpl[Offset, Envelope], ProjectionContextImpl[Offset, Envelope], NotUsed] =
       handlerStrategy match {
-        case single: SingleHandlerStrategy[Envelope] =>
+        case single: SingleHandlerStrategy[Envelope] @unchecked =>
           val handler = single.handler()
           val handlerRecovery =
             HandlerRecoveryImpl[Offset, Envelope](projectionId, recoveryStrategy, logger, statusObserver, telemetry)
@@ -145,7 +145,7 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
 
           }
 
-        case grouped: GroupedHandlerStrategy[Envelope] =>
+        case grouped: GroupedHandlerStrategy[Envelope] @unchecked =>
           val groupAfterEnvelopes = grouped.afterEnvelopes.getOrElse(settings.groupAfterEnvelopes)
           val groupAfterDuration = grouped.orAfterDuration.getOrElse(settings.groupAfterDuration)
           val handler = grouped.handler()
@@ -171,11 +171,11 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
               handlerRecovery
                 .applyRecovery(first.envelope, first.offset, last.offset, abort.future, measured)
                 .map { _ =>
-                  last.copy(groupSize = envelopes.length)
+                  last.withGroupSize(envelopes.length)
                 }
             }
 
-        case f: FlowHandlerStrategy[Envelope] =>
+        case f: FlowHandlerStrategy[Envelope] @unchecked =>
           val flow =
             f.flowCtx.asFlow.watchTermination() {
               case (_, futDone) =>
@@ -251,7 +251,7 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
       }
 
       sourceProvider match {
-        case _: MergeableOffsetSourceProvider[Offset, Envelope] =>
+        case _: MergeableOffsetSourceProvider[Offset, Envelope] @unchecked =>
           val batches = envelopesAndOffsets
             .flatMap {
               case context @ ProjectionContextImpl(offset: MergeableOffset[_] @unchecked, _, _, _) =>
@@ -284,7 +284,7 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
     }
 
     handlerStrategy match {
-      case single: SingleHandlerStrategy[Envelope] =>
+      case single: SingleHandlerStrategy[Envelope] @unchecked =>
         val handler: Handler[Envelope] = single.handler()
         source
           .mapAsync(1) { context =>
@@ -308,7 +308,7 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
 
           }
 
-      case grouped: GroupedHandlerStrategy[Envelope] =>
+      case grouped: GroupedHandlerStrategy[Envelope] @unchecked =>
         val groupAfterEnvelopes = grouped.afterEnvelopes.getOrElse(settings.groupAfterEnvelopes)
         val groupAfterDuration = grouped.orAfterDuration.getOrElse(settings.groupAfterDuration)
         val handler = grouped.handler()
@@ -344,7 +344,7 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
       HandlerRecoveryImpl[Offset, Envelope](projectionId, recoveryStrategy, logger, statusObserver, telemetry)
 
     handlerStrategy match {
-      case single: SingleHandlerStrategy[Envelope] =>
+      case single: SingleHandlerStrategy[Envelope] @unchecked =>
         val handler = single.handler()
         source
           .mapAsync(parallelism = 1) { context =>

--- a/akka-projection-core/src/main/scala/akka/projection/internal/ProjectionContextImpl.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/ProjectionContextImpl.scala
@@ -17,7 +17,10 @@ import akka.projection.ProjectionContext
     envelope: Envelope,
     externalContext: AnyRef,
     groupSize: Int)
-    extends ProjectionContext
+    extends ProjectionContext {
+
+  def withGroupSize(groupSize: Int) = copy(groupSize = groupSize)
+}
 
 /**
  * INTERNAL API

--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcProjectionImpl.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcProjectionImpl.scala
@@ -251,7 +251,7 @@ private[projection] class JdbcProjectionImpl[Offset, Envelope, S <: JdbcSession]
         settings) {
 
     implicit val executionContext: ExecutionContext = system.executionContext
-    override val logger: LoggingAdapter = Logging(system.classicSystem, this.getClass)
+    override val logger: LoggingAdapter = Logging(system.classicSystem, classOf[JdbcInternalProjectionState])
 
     override def readPaused(): Future[Boolean] =
       offsetStore.readManagementState(projectionId).map(_.exists(_.paused))
@@ -263,7 +263,7 @@ private[projection] class JdbcProjectionImpl[Offset, Envelope, S <: JdbcSession]
       offsetStore.saveOffset(projectionId, offset)
 
     private[projection] def newRunningInstance(): RunningProjection =
-      new JdbcRunningProjection(RunningProjection.withBackoff(() => mappedSource(), settings), this)
+      new JdbcRunningProjection(RunningProjection.withBackoff(() => this.mappedSource(), settings), this)
   }
 
   private class JdbcRunningProjection(source: Source[Done, _], projectionState: JdbcInternalProjectionState)(

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
@@ -188,7 +188,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
       databaseConfig.db.run(offsetStore.saveOffset(projectionId, offset)).map(_ => Done)
 
     private[projection] def newRunningInstance(): RunningProjection =
-      new SlickRunningProjection(RunningProjection.withBackoff(() => mappedSource(), settings), this)
+      new SlickRunningProjection(RunningProjection.withBackoff(() => this.mappedSource(), settings), this)
 
   }
 

--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/internal/TestProjectionImpl.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/internal/TestProjectionImpl.scala
@@ -157,7 +157,8 @@ private[projection] class TestInternalProjectionState[Offset, Envelope](
 
   startOffset.foreach(offset => offsetStore.saveOffset(projectionId, offset))
 
-  override val logger: LoggingAdapter = Logging(system.classicSystem, this.getClass)
+  override val logger: LoggingAdapter =
+    Logging(system.classicSystem, classOf[TestInternalProjectionState[Offset, Envelope]])
 
   override def readPaused(): Future[Boolean] =
     offsetStore.readManagementState(projectionId).map(_.exists(_.paused))

--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/scaladsl/ProjectionTestKit.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/scaladsl/ProjectionTestKit.scala
@@ -6,6 +6,7 @@ package akka.projection.testkit.scaladsl
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import scala.reflect.ClassTag
 
 import akka.Done
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
@@ -131,8 +132,11 @@ final class ProjectionTestKit private[projection] (system: ActorSystem[_]) {
   }
 
   private def spawnActorHandler(projection: Projection[_]): Option[ActorRef[_]] = {
+
+    val throwableClassTag = implicitly[ClassTag[Throwable]]
     projection.actorHandlerInit[Any].map { init =>
-      val ref = testKit.spawn(Behaviors.supervise(init.behavior).onFailure(SupervisorStrategy.restart))
+      val ref =
+        testKit.spawn(Behaviors.supervise(init.behavior).onFailure(SupervisorStrategy.restart)(throwableClassTag))
       init.setActor(ref)
       ref
     }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -37,7 +37,7 @@ object Common extends AutoPlugin {
     projectInfoVersion := (if (isSnapshot.value) "snapshot" else version.value),
     crossVersion := CrossVersion.binary,
     crossScalaVersions := Dependencies.ScalaVersions,
-    scalaVersion := Dependencies.Scala213,
+    scalaVersion := Dependencies.getScalaVersion(),
     javacOptions ++= List("-Xlint:unchecked", "-Xlint:deprecation"),
     Compile / doc / scalacOptions := scalacOptions.value ++ Seq(
         "-doc-title",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,39 +7,55 @@ object Dependencies {
 
   val Scala213 = "2.13.3"
   val Scala212 = "2.12.13"
+  val Scala3 = "3.0.1-RC1"
   val ScalaVersions = Seq(Scala213, Scala212)
 
   val AkkaVersionInDocs = "2.6"
   val AlpakkaVersionInDocs = "2.0"
   val AlpakkaKafkaVersionInDocs = "2.0"
 
+  def getScalaVersion() = {
+    // don't mandate patch not specified to allow builds to migrate
+    System.getProperty("akka.build.scalaVersion", "default") match {
+      case twoThirteen if twoThirteen.startsWith("2.13") => Scala213
+      case twoTwelve if twoTwelve.startsWith("2.12")     => Scala212
+      case three if three.startsWith("3.")               => Scala3
+      case "default"                                     => Scala213
+      case other =>
+        throw new IllegalArgumentException(s"Unsupported scala version [$other]. Must be 2.12, 2.13 or 3.x.")
+    }
+  }
+
   object Versions {
     val akka = sys.props.getOrElse("build.akka.version", "2.6.14")
     val alpakka = "2.0.2"
     val alpakkaKafka = sys.props.getOrElse("build.alpakka.kafka.version", "2.0.7")
     val slick = "3.3.3"
-    val scalaTest = "3.1.1"
+    val scalaTest = 
+      if (getScalaVersion().startsWith("3.")) "3.2.9"
+      else "3.1.4"
     val testContainers = "1.15.3"
     val junit = "4.13.2"
     val h2Driver = "1.4.200"
     val jackson = "2.11.4" // this should match the version of jackson used by akka-serialization-jackson
   }
 
+  def for3Use2_13(module: ModuleID) = module.cross(CrossVersion.for3Use2_13) 
   object Compile {
-    val akkaActorTyped = "com.typesafe.akka" %% "akka-actor-typed" % Versions.akka
-    val akkaStream = "com.typesafe.akka" %% "akka-stream" % Versions.akka
-    val akkaProtobufV3 = "com.typesafe.akka" %% "akka-protobuf-v3" % Versions.akka
-    val akkaPersistenceQuery = "com.typesafe.akka" %% "akka-persistence-query" % Versions.akka
+    val akkaActorTyped = for3Use2_13("com.typesafe.akka" %% "akka-actor-typed" % Versions.akka)
+    val akkaStream = for3Use2_13("com.typesafe.akka" %% "akka-stream" % Versions.akka)
+    val akkaProtobufV3 = for3Use2_13("com.typesafe.akka" %% "akka-protobuf-v3" % Versions.akka)
+    val akkaPersistenceQuery = for3Use2_13("com.typesafe.akka" %% "akka-persistence-query" % Versions.akka)
 
     // TestKit in compile scope for ProjectionTestKit
-    val akkaTypedTestkit = "com.typesafe.akka" %% "akka-actor-testkit-typed" % Versions.akka
-    val akkaStreamTestkit = "com.typesafe.akka" %% "akka-stream-testkit" % Versions.akka
+    val akkaTypedTestkit = for3Use2_13("com.typesafe.akka" %% "akka-actor-testkit-typed" % Versions.akka)
+    val akkaStreamTestkit = for3Use2_13("com.typesafe.akka" %% "akka-stream-testkit" % Versions.akka)
 
-    val slick = "com.typesafe.slick" %% "slick" % Versions.slick
+    val slick = for3Use2_13("com.typesafe.slick" %% "slick" % Versions.slick)
 
-    val alpakkaCassandra = "com.lightbend.akka" %% "akka-stream-alpakka-cassandra" % Versions.alpakka
+    val alpakkaCassandra = for3Use2_13("com.lightbend.akka" %% "akka-stream-alpakka-cassandra" % Versions.alpakka)
 
-    val alpakkaKafka = "com.typesafe.akka" %% "akka-stream-kafka" % Versions.alpakkaKafka
+    val alpakkaKafka = for3Use2_13("com.typesafe.akka" %% "akka-stream-kafka" % Versions.alpakkaKafka)
 
     // must be provided on classpath when using Apache Kafka 2.6.0+
     val jackson = "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson
@@ -57,7 +73,7 @@ object Dependencies {
     val akkaStreamTestkit = Compile.akkaStreamTestkit % allTestConfig
 
     val scalatest = "org.scalatest" %% "scalatest" % Versions.scalaTest % allTestConfig
-    val scalatestJUnit = "org.scalatestplus" %% "junit-4-12" % (Versions.scalaTest + ".0") % allTestConfig
+    val scalatestJUnit = "org.scalatestplus" %% "junit-4-13" % (Versions.scalaTest + ".0") % allTestConfig
     val junit = "junit" % "junit" % Versions.junit % allTestConfig
 
     val h2Driver = Compile.h2Driver % allTestConfig
@@ -81,17 +97,17 @@ object Dependencies {
       "org.testcontainers" % "oracle-xe" % Versions.testContainers % allTestConfig
 
     val alpakkaKafkaTestkit =
-      "com.typesafe.akka" %% "akka-stream-kafka-testkit" % Versions.alpakkaKafka % allTestConfig
+      for3Use2_13("com.typesafe.akka" %% "akka-stream-kafka-testkit" % Versions.alpakkaKafka) % allTestConfig
   }
 
   object Examples {
     val hibernate = "org.hibernate" % "hibernate-core" % "5.4.32.Final"
 
-    val akkaPersistenceTyped = "com.typesafe.akka" %% "akka-persistence-typed" % Versions.akka
-    val akkaClusterShardingTyped = "com.typesafe.akka" %% "akka-cluster-sharding-typed" % Versions.akka
-    val akkaPersistenceCassandra = "com.typesafe.akka" %% "akka-persistence-cassandra" % "1.0.3"
-    val akkaPersistenceJdbc = "com.lightbend.akka" %% "akka-persistence-jdbc" % "5.0.1"
-    val akkaSerializationJackson = "com.typesafe.akka" %% "akka-serialization-jackson" % Versions.akka
+    val akkaPersistenceTyped = for3Use2_13("com.typesafe.akka" %% "akka-persistence-typed" % Versions.akka)
+    val akkaClusterShardingTyped = for3Use2_13("com.typesafe.akka" %% "akka-cluster-sharding-typed" % Versions.akka)
+    val akkaPersistenceCassandra = for3Use2_13("com.typesafe.akka" %% "akka-persistence-cassandra" % "1.0.3")
+    val akkaPersistenceJdbc = for3Use2_13("com.lightbend.akka" %% "akka-persistence-jdbc" % "5.0.1")
+    val akkaSerializationJackson = for3Use2_13("com.typesafe.akka" %% "akka-serialization-jackson" % Versions.akka)
   }
 
   private val deps = libraryDependencies

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.7
+sbt.version=1.5.4


### PR DESCRIPTION
Still very draft. 

Most dependencies are on Scala 2.13. 

## Blocker:

The main issue is Slick and its macro usage.
Eventually, we can exclude it from the Scala 3 build.

```scala
[error] -- Error: /Users/renato/GitHub/akka/projection/compile-with-scala3/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickOffsetStore.scala:137:20 
[error] 137 |  val offsetTable = TableQuery[OffsetStoreTable]
[error]     |                    ^
[error]     |Scala 2 macro cannot be used in Dotty. See https://dotty.epfl.ch/docs/reference/dropped-features/macros.html
[error]     |To turn this error into a warning, pass -Xignore-scala2-macros to the compiler

```