### PR TITLE
fix github.base_url

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -127,6 +127,7 @@ lazy val docs = project
     Compile / paradoxProperties ++= Map(
         "project.url" -> "https://doc.akka.io/docs/akka-projection/current/",
         "canonical.base_url" -> "https://doc.akka.io/docs/akka-projection/current",
+        "github.base_url" -> "https://github.com/akka/akka-projection",
         "akka.version" -> Dependencies.Versions.akka,
         // Akka
         "extref.akka.base_url" -> s"https://doc.akka.io/docs/akka/${Dependencies.AkkaVersionInDocs}/%s",


### PR DESCRIPTION
Current links in docs are poing to https://github.com/akka/akka-projection.git, should be https://github.com/akka/akka-projection