### PR TITLE
make it compile with scala 3

### DIFF
--- a/akka-projection-core/src/main/scala/akka/projection/ProjectionId.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/ProjectionId.scala
@@ -84,7 +84,7 @@ object ProjectionId {
    * @return an [[java.util.Set]] of [[ProjectionId]]s
    */
   def of(name: String, keys: java.util.Set[String]): java.util.Set[ProjectionId] =
-    keys.asScala.map { key: String => new ProjectionId(name, key) }.asJava
+    keys.asScala.map { key => new ProjectionId(name, key) }.asJava
 }
 
 @ApiMayChange

--- a/akka-projection-core/src/main/scala/akka/projection/internal/InternalProjectionState.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/InternalProjectionState.scala
@@ -136,7 +136,7 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
     val atLeastOnceHandlerFlow
         : Flow[ProjectionContextImpl[Offset, Envelope], ProjectionContextImpl[Offset, Envelope], NotUsed] =
       handlerStrategy match {
-        case single: SingleHandlerStrategy[Envelope] =>
+        case single: SingleHandlerStrategy[Envelope] @unchecked =>
           val handler = single.handler()
           val handlerRecovery =
             HandlerRecoveryImpl[Offset, Envelope](projectionId, recoveryStrategy, logger, statusObserver, telemetry)
@@ -158,7 +158,7 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
 
           }
 
-        case grouped: GroupedHandlerStrategy[Envelope] =>
+        case grouped: GroupedHandlerStrategy[Envelope] @unchecked =>
           val groupAfterEnvelopes = grouped.afterEnvelopes.getOrElse(settings.groupAfterEnvelopes)
           val groupAfterDuration = grouped.orAfterDuration.getOrElse(settings.groupAfterDuration)
           val handler = grouped.handler()
@@ -184,11 +184,11 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
               handlerRecovery
                 .applyRecovery(first.envelope, first.offset, last.offset, abort.future, measured)
                 .map { _ =>
-                  last.copy(groupSize = envelopes.length)
+                  last.withGroupSize(envelopes.length)
                 }
             }
 
-        case f: FlowHandlerStrategy[Envelope] =>
+        case f: FlowHandlerStrategy[Envelope] @unchecked =>
           val flow =
             f.flowCtx.asFlow.watchTermination() {
               case (_, futDone) =>
@@ -259,7 +259,7 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
       }
 
       sourceProvider match {
-        case _: MergeableOffsetSourceProvider[Offset, Envelope] =>
+        case _: MergeableOffsetSourceProvider[Offset, Envelope] @unchecked =>
           val batches = envelopesAndOffsets
             .flatMap {
               case context @ ProjectionContextImpl(offset: MergeableOffset[_] @unchecked, _, _, _) =>
@@ -292,7 +292,7 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
     }
 
     handlerStrategy match {
-      case single: SingleHandlerStrategy[Envelope] =>
+      case single: SingleHandlerStrategy[Envelope] @unchecked =>
         val handler: Handler[Envelope] = single.handler()
         source
           .mapAsync(1) { context =>
@@ -316,7 +316,7 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
 
           }
 
-      case grouped: GroupedHandlerStrategy[Envelope] =>
+      case grouped: GroupedHandlerStrategy[Envelope] @unchecked =>
         val groupAfterEnvelopes = grouped.afterEnvelopes.getOrElse(settings.groupAfterEnvelopes)
         val groupAfterDuration = grouped.orAfterDuration.getOrElse(settings.groupAfterDuration)
         val handler = grouped.handler()
@@ -352,7 +352,7 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
       HandlerRecoveryImpl[Offset, Envelope](projectionId, recoveryStrategy, logger, statusObserver, telemetry)
 
     handlerStrategy match {
-      case single: SingleHandlerStrategy[Envelope] =>
+      case single: SingleHandlerStrategy[Envelope] @unchecked =>
         val handler = single.handler()
         source
           .mapAsync(parallelism = 1) { context =>

--- a/akka-projection-core/src/main/scala/akka/projection/internal/ProjectionContextImpl.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/ProjectionContextImpl.scala
@@ -17,7 +17,10 @@ import akka.projection.ProjectionContext
     envelope: Envelope,
     externalContext: AnyRef,
     groupSize: Int)
-    extends ProjectionContext
+    extends ProjectionContext {
+
+  def withGroupSize(groupSize: Int) = copy(groupSize = groupSize)
+}
 
 /**
  * INTERNAL API

--- a/akka-projection-durable-state/src/main/scala/akka/projection/state/javadsl/DurableStateSourceProvider.scala
+++ b/akka-projection-durable-state/src/main/scala/akka/projection/state/javadsl/DurableStateSourceProvider.scala
@@ -69,7 +69,7 @@ object DurableStateSourceProvider {
     override def extractCreationTime(stateChange: DurableStateChange[A]): Long =
       stateChange match {
         case u: UpdatedDurableState[_] => u.timestamp
-        case _                         => 0L // FIXME handle DeletedDurableState when that is added
+        case null                      => 0L // FIXME handle DeletedDurableState when that is added
       }
   }
 
@@ -128,10 +128,10 @@ object DurableStateSourceProvider {
     override def extractCreationTime(stateChange: DurableStateChange[A]): Long =
       stateChange match {
         case u: UpdatedDurableState[_] => u.timestamp
-        case other                     =>
+        case null                      =>
           // FIXME case DeletedDurableState when that is added
           throw new IllegalArgumentException(
-            s"DurableStateChange [${other.getClass.getName}] not implemented yet. Please report bug at https://github.com/akka/akka-persistence-r2dbc/issues")
+            "DurableStateChange [DeletedDurableState] not implemented yet. Please report bug at https://github.com/akka/akka-persistence-r2dbc/issues")
       }
 
     override def getObject(persistenceId: String): CompletionStage[GetObjectResult[A]] =

--- a/akka-projection-durable-state/src/main/scala/akka/projection/state/scaladsl/DurableStateSourceProvider.scala
+++ b/akka-projection-durable-state/src/main/scala/akka/projection/state/scaladsl/DurableStateSourceProvider.scala
@@ -60,7 +60,7 @@ object DurableStateSourceProvider {
     override def extractCreationTime(stateChange: DurableStateChange[A]): Long =
       stateChange match {
         case u: UpdatedDurableState[_] => u.timestamp
-        case _                         => 0L // FIXME handle DeletedDurableState when that is added
+        case null                      => 0L // FIXME handle DeletedDurableState when that is added
       }
   }
 
@@ -117,10 +117,10 @@ object DurableStateSourceProvider {
     override def extractCreationTime(stateChange: DurableStateChange[A]): Long =
       stateChange match {
         case u: UpdatedDurableState[_] => u.timestamp
-        case other                     =>
+        case null                      =>
           // FIXME case DeletedDurableState when that is added
           throw new IllegalArgumentException(
-            s"DurableStateChange [${other.getClass.getName}] not implemented yet. Please report bug at https://github.com/akka/akka-persistence-r2dbc/issues")
+            "DurableStateChange [DeletedDurableState] not implemented yet. Please report bug at https://github.com/akka/akka-persistence-r2dbc/issues")
       }
 
     override def getObject(persistenceId: String): Future[GetObjectResult[A]] =

--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcProjectionImpl.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcProjectionImpl.scala
@@ -251,7 +251,7 @@ private[projection] class JdbcProjectionImpl[Offset, Envelope, S <: JdbcSession]
         settings) {
 
     implicit val executionContext: ExecutionContext = system.executionContext
-    override val logger: LoggingAdapter = Logging(system.classicSystem, this.getClass)
+    override val logger: LoggingAdapter = Logging(system.classicSystem, classOf[JdbcInternalProjectionState])
 
     override def readPaused(): Future[Boolean] =
       offsetStore.readManagementState(projectionId).map(_.exists(_.paused))
@@ -263,7 +263,7 @@ private[projection] class JdbcProjectionImpl[Offset, Envelope, S <: JdbcSession]
       offsetStore.saveOffset(projectionId, offset)
 
     private[projection] def newRunningInstance(): RunningProjection =
-      new JdbcRunningProjection(RunningProjection.withBackoff(() => mappedSource(), settings), this)
+      new JdbcRunningProjection(RunningProjection.withBackoff(() => this.mappedSource(), settings), this)
   }
 
   private class JdbcRunningProjection(source: Source[Done, _], projectionState: JdbcInternalProjectionState)(

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
@@ -176,7 +176,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
         settings) {
 
     implicit val executionContext: ExecutionContext = system.executionContext
-    override val logger: LoggingAdapter = Logging(system.classicSystem, this.getClass)
+    override val logger: LoggingAdapter = Logging(system.classicSystem, classOf[SlickInternalProjectionState])
 
     override def readPaused(): Future[Boolean] =
       offsetStore.readManagementState(projectionId).map(_.exists(_.paused))
@@ -188,7 +188,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
       databaseConfig.db.run(offsetStore.saveOffset(projectionId, offset)).map(_ => Done)
 
     private[projection] def newRunningInstance(): RunningProjection =
-      new SlickRunningProjection(RunningProjection.withBackoff(() => mappedSource(), settings), this)
+      new SlickRunningProjection(RunningProjection.withBackoff(() => this.mappedSource(), settings), this)
 
   }
 

--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/internal/TestProjectionImpl.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/internal/TestProjectionImpl.scala
@@ -157,7 +157,7 @@ private[projection] class TestInternalProjectionState[Offset, Envelope](
 
   startOffset.foreach(offset => offsetStore.saveOffset(projectionId, offset))
 
-  override val logger: LoggingAdapter = Logging(system.classicSystem, this.getClass)
+  override val logger: LoggingAdapter = Logging(system.classicSystem, classOf[TestInternalProjectionState[_, _]])
 
   override def readPaused(): Future[Boolean] =
     offsetStore.readManagementState(projectionId).map(_.exists(_.paused))

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -37,7 +37,7 @@ object Common extends AutoPlugin {
     projectInfoVersion := (if (isSnapshot.value) "snapshot" else version.value),
     crossVersion := CrossVersion.binary,
     crossScalaVersions := Dependencies.ScalaVersions,
-    scalaVersion := Dependencies.Scala213,
+    scalaVersion := Dependencies.getScalaVersion(),
     javacOptions ++= List("-Xlint:unchecked", "-Xlint:deprecation"),
     Compile / doc / scalacOptions := scalacOptions.value ++ Seq(
         "-doc-title",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,25 +7,38 @@ object Dependencies {
 
   val Scala213 = "2.13.3"
   val Scala212 = "2.12.15"
-  val ScalaVersions = Seq(Scala213, Scala212)
+  val Scala3 = "3.1.1-RC1"
+  val ScalaVersions = Seq(Scala213, Scala3, Scala212)
 
-  val AkkaVersionInDocs = "2.6.16"
+  val AkkaVersionInDocs = "2.6.18"
   val AlpakkaVersionInDocs = "2.0"
   val AlpakkaKafkaVersionInDocs = "2.0"
 
+    def getScalaVersion() = {
+    // don't mandate patch not specified to allow builds to migrate
+    System.getProperty("akka.build.scalaVersion", "default") match {
+      case twoThirteen if twoThirteen.startsWith("2.13") => Scala213
+      case twoTwelve if twoTwelve.startsWith("2.12")     => Scala212
+      case three if three.startsWith("3.")               => Scala3
+      case "default"                                     => Scala213
+      case other =>
+        throw new IllegalArgumentException(s"Unsupported scala version [$other]. Must be 2.12, 2.13 or 3.x.")
+    }
+  }
   object Versions {
     val akka = sys.props.getOrElse("build.akka.version", "2.6.18")
     val akkaPersistenceJdbc = "5.0.2"
     val alpakka = "2.0.2"
     val alpakkaKafka = sys.props.getOrElse("build.alpakka.kafka.version", "2.0.7")
     val slick = "3.3.3"
-    val scalaTest = "3.1.1"
+    val scalaTest = "3.2.10"
     val testContainers = "1.15.3"
     val junit = "4.13.2"
     val h2Driver = "1.4.200"
     val jackson = "2.11.4" // this should match the version of jackson used by akka-serialization-jackson
   }
 
+  def for3Use2_13(module: ModuleID) = module.cross(CrossVersion.for3Use2_13) 
   object Compile {
     val akkaActorTyped = "com.typesafe.akka" %% "akka-actor-typed" % Versions.akka
     val akkaStream = "com.typesafe.akka" %% "akka-stream" % Versions.akka
@@ -36,11 +49,11 @@ object Dependencies {
     val akkaTypedTestkit = "com.typesafe.akka" %% "akka-actor-testkit-typed" % Versions.akka
     val akkaStreamTestkit = "com.typesafe.akka" %% "akka-stream-testkit" % Versions.akka
 
-    val slick = "com.typesafe.slick" %% "slick" % Versions.slick
+    val slick = for3Use2_13("com.typesafe.slick" %% "slick" % Versions.slick)
 
-    val alpakkaCassandra = "com.lightbend.akka" %% "akka-stream-alpakka-cassandra" % Versions.alpakka
+    val alpakkaCassandra = for3Use2_13("com.lightbend.akka" %% "akka-stream-alpakka-cassandra" % Versions.alpakka)
 
-    val alpakkaKafka = "com.typesafe.akka" %% "akka-stream-kafka" % Versions.alpakkaKafka
+    val alpakkaKafka = for3Use2_13("com.typesafe.akka" %% "akka-stream-kafka" % Versions.alpakkaKafka)
 
     // must be provided on classpath when using Apache Kafka 2.6.0+
     val jackson = "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson
@@ -48,7 +61,7 @@ object Dependencies {
     // not really used in lib code, but in example and test
     val h2Driver = "com.h2database" % "h2" % Versions.h2Driver
 
-    val collectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0"
+    val collectionCompat = for3Use2_13("org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0")
   }
 
   object Test {
@@ -59,7 +72,7 @@ object Dependencies {
     val persistenceTestkit = "com.typesafe.akka" %% "akka-persistence-testkit" % Versions.akka % "test"
 
     val scalatest = "org.scalatest" %% "scalatest" % Versions.scalaTest % allTestConfig
-    val scalatestJUnit = "org.scalatestplus" %% "junit-4-12" % (Versions.scalaTest + ".0") % allTestConfig
+    val scalatestJUnit = "org.scalatestplus" %% "junit-4-13" % (Versions.scalaTest + ".0") % allTestConfig
     val junit = "junit" % "junit" % Versions.junit % allTestConfig
 
     val h2Driver = Compile.h2Driver % allTestConfig
@@ -83,7 +96,7 @@ object Dependencies {
       "org.testcontainers" % "oracle-xe" % Versions.testContainers % allTestConfig
 
     val alpakkaKafkaTestkit =
-      "com.typesafe.akka" %% "akka-stream-kafka-testkit" % Versions.alpakkaKafka % allTestConfig
+      for3Use2_13("com.typesafe.akka" %% "akka-stream-kafka-testkit" % Versions.alpakkaKafka) % allTestConfig
   }
 
   object Examples {


### PR DESCRIPTION
Draft because on top of #622.

Also because is still work in progress. It's failing because of scala-java8-compat issue but also because the Slick code is using type projection in a way that is not allowed in Scala 3. 

I think will need to declare that when opting for Slick, users can only have it for Scala 2.13. And we exclude it from the build when compiling with Scala 3. 

I think this is fair. If someone is using Slick, they will face other issues with Scala 3 anyway. 
