### PR TITLE
Store offset for failed skipped envelope

### DIFF
--- a/akka-projection-core/src/main/mima-filters/1.2.3.backwards.excludes/skip-offset.excludes
+++ b/akka-projection-core/src/main/mima-filters/1.2.3.backwards.excludes/skip-offset.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.internal.HandlerRecoveryImpl.applyRecovery")

--- a/akka-projection-core/src/main/scala/akka/projection/internal/HandlerRecoveryImpl.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/HandlerRecoveryImpl.scala
@@ -29,6 +29,7 @@ import akka.projection.StatusObserver
 @InternalApi private[projection] object HandlerRecoveryImpl {
 
   private val futDone = Future.successful(Done)
+  private val defaultOnSkip = () => futDone
 
   def apply[Offset, Envelope](
       projectionId: ProjectionId,
@@ -54,8 +55,8 @@ import akka.projection.StatusObserver
       firstOffset: Offset, // used for logging
       lastOffset: Offset, // used for logging
       abort: Future[Done], // retries can be aborted by failing this Future
-      futureCallback: () => Future[Done])(implicit system: ActorSystem[_]): Future[Done] = {
-    import HandlerRecoveryImpl.futDone
+      futureCallback: () => Future[Done],
+      onSkip: () => Future[Done] = HandlerRecoveryImpl.defaultOnSkip)(implicit system: ActorSystem[_]): Future[Done] = {
     import HandlerRecoveryStrategy.Internal._
 
     implicit val scheduler: Scheduler = system.classicSystem.scheduler
@@ -127,7 +128,7 @@ import akka.projection.StatusObserver
               projectionId.id,
               offsetLogParameter,
               err)
-            futDone
+            onSkip()
 
           case RetryAndFail(retries, delay) =>
             logger.warning(
@@ -174,7 +175,7 @@ import akka.projection.StatusObserver
                 retries + 1,
                 exception)
             }
-            retried.recoverWith { case _ => futDone }
+            retried.recoverWith { case _ => onSkip() }
         }
     }
   }

--- a/akka-projection-core/src/main/scala/akka/projection/internal/InternalProjectionState.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/InternalProjectionState.scala
@@ -255,7 +255,8 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
             done
           }
         }
-        handlerRecovery.applyRecovery(first.envelope, firstOffset, lastOffset, abort.future, measured)
+        val onSkip = () => saveOffsetsAndReport(projectionId, partitioned)
+        handlerRecovery.applyRecovery(first.envelope, firstOffset, lastOffset, abort.future, measured, onSkip)
       }
 
       sourceProvider match {
@@ -312,7 +313,15 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
                 done
               }
             }
-            handlerRecovery.applyRecovery(context.envelope, context.offset, context.offset, abort.future, measured)
+
+            val onSkip = () => saveOffsetAndReport(projectionId, context, 1)
+            handlerRecovery.applyRecovery(
+              context.envelope,
+              context.offset,
+              context.offset,
+              abort.future,
+              measured,
+              onSkip)
 
           }
 

--- a/akka-projection-jdbc/src/it/scala/akka/projection/jdbc/JdbcProjectionSpec.scala
+++ b/akka-projection-jdbc/src/it/scala/akka/projection/jdbc/JdbcProjectionSpec.scala
@@ -340,6 +340,28 @@ class JdbcProjectionSpec
       offsetShouldBe(6L)
     }
 
+    "store offset for failing events when using RecoveryStrategy.skip" in {
+      implicit val entityId = UUID.randomUUID().toString
+      implicit val projectionId = genRandomProjectionId()
+
+      val bogusEventHandler = new ConcatHandler(_ == 6)
+
+      val projectionFailing =
+        JdbcProjection
+          .exactlyOnce(
+            projectionId,
+            sourceProvider = sourceProvider(entityId),
+            jdbcSessionFactory,
+            handler = () => bogusEventHandler)
+          .withRecoveryStrategy(HandlerRecoveryStrategy.skip)
+
+      offsetShouldBeEmpty()
+      projectionTestKit.run(projectionFailing) {
+        projectedValueShouldBe("e1|e2|e3|e4|e5")
+      }
+      offsetShouldBe(6L)
+    }
+
     "skip failing events after retrying when using RecoveryStrategy.retryAndSkip" in {
       implicit val entityId = UUID.randomUUID().toString
       implicit val projectionId = genRandomProjectionId()
@@ -378,8 +400,10 @@ class JdbcProjectionSpec
       progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 1, "e1")))
       progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 2, "e2")))
       progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 3, "e3")))
-      // Offset 4 is not stored so it is not reported.
+      // Offset 4 is stored even though it failed and was skipped
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 4, "e4")))
       progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 5, "e5")))
+      progressProbe.expectMessage(TestStatusObserver.OffsetProgress(Envelope(entityId, 6, "e6")))
 
       offsetShouldBe(6L)
     }


### PR DESCRIPTION
* need this to be able to fix one of the pending tests in akka-persistence-r2dbc
* makes more sense to try to store the offset when an envelope is skipped

