### PR TITLE
One more TestSink

### DIFF
--- a/akka-projection-grpc/src/test/scala/akka/projection/grpc/internal/EventProducerServiceSpec.scala
+++ b/akka-projection-grpc/src/test/scala/akka/projection/grpc/internal/EventProducerServiceSpec.scala
@@ -113,7 +113,7 @@ class EventProducerServiceSpec
     val probePromise = Promise[TestSubscriber.Probe[StreamOut]]()
     eventProducerService
       .eventsBySlices(streamIn)
-      .toMat(TestSink[StreamOut])(Keep.right)
+      .toMat(TestSink[StreamOut]())(Keep.right)
       .mapMaterializedValue { probe =>
         probePromise.trySuccess(probe)
         NotUsed


### PR DESCRIPTION
Compilation error in `main` due to concurrent PR merges.