### PR TITLE
Document gRPC client lifecycle, #702

### DIFF
--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/javadsl/GrpcReadJournal.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/javadsl/GrpcReadJournal.scala
@@ -12,6 +12,7 @@ import java.util.concurrent.CompletionStage
 import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._
 
+import akka.Done
 import akka.NotUsed
 import akka.actor.ClassicActorSystemProvider
 import akka.annotation.ApiMayChange
@@ -104,4 +105,12 @@ class GrpcReadJournal(delegate: scaladsl.GrpcReadJournal)
 
   override def loadEnvelope[Event](persistenceId: String, sequenceNr: Long): CompletionStage[EventEnvelope[Event]] =
     delegate.loadEnvelope[Event](persistenceId, sequenceNr).toJava
+
+  /**
+   * Close the gRPC client. It will be automatically closed when the `ActorSystem` is terminated,
+   * so invoking this is only needed when there is a need to close the resource before that.
+   * After closing the `GrpcReadJournal` instance cannot be used again.
+   */
+  def close(): CompletionStage[Done] =
+    delegate.close().toJava
 }

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
@@ -10,6 +10,7 @@ import java.util.concurrent.TimeUnit
 import scala.collection.immutable
 import scala.concurrent.Future
 
+import akka.Done
 import akka.NotUsed
 import akka.actor.ClassicActorSystemProvider
 import akka.actor.ExtendedActorSystem
@@ -366,5 +367,13 @@ final class GrpcReadJournal private (
 
       }
   }
+
+  /**
+   * Close the gRPC client. It will be automatically closed when the `ActorSystem` is terminated,
+   * so invoking this is only needed when there is a need to close the resource before that.
+   * After closing the `GrpcReadJournal` instance cannot be used again.
+   */
+  def close(): Future[Done] =
+    client.close()
 
 }

--- a/docs/src/main/paradox/grpc.md
+++ b/docs/src/main/paradox/grpc.md
@@ -64,6 +64,16 @@ There are alternative ways of running the `ProjectionBehavior` as described in @
 
 How to implement the `EventHandler` and choose between different processing semantics is described in the @extref:[R2dbcProjection documentation](akka-persistence-r2dbc:projection.html).
 
+### gRPC client lifecycle
+
+When creating the @apidoc[GrpcReadJournal] a gRPC client is created for the target producer. The same `GrpcReadJournal` 
+instance and its gRPC client should be shared for the same target producer. The code examples above will share the instance
+between different Projection instances running in the same `ActorSystem`. The gRPC clients will automatically be 
+closed when the `ActorSystem` is terminated.
+
+If there is a need to close the gRPC client before `ActorSystem` termination the `close()` method of the @apidoc[GrpcReadJournal]
+can be called. After closing the `GrpcReadJournal` instance cannot be used again.
+
 ## Producer
 
 Akka Projections gRPC provides the gRPC service implementation that is used by the consumer side. It is created with the @apidoc[EventProducer$]:


### PR DESCRIPTION
After too much tinkering of this I came to the conclusion that we should only document it. It's anyway working in the "right" way if following our code examples.

I first tried to bind the lifecycle to the lifecycle of the Projection instance, but it's anyway not enforced to be one GrpcReadJournal instance per Projection instance.

Then I explored the possibility to reuse clients for the same `GrpcClientSettings` and thereby enforce single instance per target producer and lifecycle bound to ActorSystem. That didn't work out because GrpcClientSettings is very open ended and not possible to use as key for such registry.

References #702
