### PR TITLE
chore: Bump Jackson databind

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
     val testContainers = "1.15.3"
     val junit = "4.13.2"
     val h2Driver = "1.4.200"
-    val jackson = "2.13.4" // this should match the version of jackson used by akka-serialization-jackson
+    val jackson = "2.13.4.1" // this should match the version of jackson used by akka-serialization-jackson
   }
 
   object Compile {


### PR DESCRIPTION
Fixes https://nvd.nist.gov/vuln/detail/CVE-2022-42003 (even if we were not really affected out of the box).