### PR TITLE
ci: renovate GH workflows; JDK 17

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -24,13 +24,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-9
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11
 
       - name: Code style check and binary-compatibility check
         run: sbt "verifyCodeStyle; mimaReportBinaryIssues"
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -50,13 +50,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-9
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11
 
       - name: Compile all code with fatal warnings for Java 11, Scala 2.12 and Scala 2.13
         run: sbt "clean ; +IntegrationTest/compile"
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -76,13 +76,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-9
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11
 
       - name: Create all API docs for artifacts/website and all reference docs
         run: sbt "unidoc; docs/paradox"
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -102,13 +102,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-9
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11
 
       - name: Gather version
         run: |-

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -3,7 +3,7 @@ name: Dependency License Scanning
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 0' # At 00:00 on Sunday
+    - cron: '0 0 * * 6' # At 00:00 on saturdays
 
 jobs:
   fossa:
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'akka/akka-projection'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -21,10 +21,9 @@ jobs:
         uses: coursier/cache-action@v6
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v1.3.0
         with:
-          jvm:
-            adopt:11
+          jvm: temurin:1.11
 
       - name: FOSSA policy check
         run: |-

--- a/.github/workflows/integration-tests-cassandra.yml
+++ b/.github/workflows/integration-tests-cassandra.yml
@@ -15,11 +15,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { java-version: adopt@1.8,  sbt-opts: '' }
-          - { java-version: adopt@1.11, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
+          - { jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -29,16 +31,16 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Setup JDK ${{ matrix.java-version }}
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: ${{ matrix.java-version }}
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
 
-      - name: Run all integration tests with default Scala and Java ${{ matrix.java-version }}
-        run: sbt "akka-projection-cassandra/it:test" ${{ matrix.sbt-opts }}
+      - name: Set up JDK ${{ matrix.jdkVersion }}
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: ${{ matrix.jvmName }}
+
+      - name: Run all integration tests with default Scala and Java ${{ matrix.jdkVersion }}
+        run: sbt "akka-projection-cassandra/It/test" ${{ matrix.extraOpts }}
         env: # Disable Ryuk resource reaper since we always spin up fresh VMs
           TESTCONTAINERS_RYUK_DISABLED: true
 

--- a/.github/workflows/integration-tests-grpc.yml
+++ b/.github/workflows/integration-tests-grpc.yml
@@ -15,11 +15,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { java-version: adopt@1.8,  sbt-opts: '' }
-          - { java-version: adopt@1.11, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
+          - { jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -29,16 +31,16 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Setup JDK ${{ matrix.java-version }}
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: ${{ matrix.java-version }}
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
 
-      - name: Run all integration tests with default Scala and Java ${{ matrix.java-version }}
-        run: sbt "akka-projection-grpc/It/test" ${{ matrix.sbt-opts }}
+      - name: Set up JDK ${{ matrix.jdkVersion }}
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: ${{ matrix.jvmName }}
+
+      - name: Run all integration tests with default Scala and Java ${{ matrix.jdkVersion }}
+        run: sbt "akka-projection-grpc/It/test" ${{ matrix.extraOpts }}
         env: # Disable Ryuk resource reaper since we always spin up fresh VMs
           TESTCONTAINERS_RYUK_DISABLED: true
 

--- a/.github/workflows/integration-tests-jdbc.yml
+++ b/.github/workflows/integration-tests-jdbc.yml
@@ -15,11 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { java-version: adopt@1.8,  sbt-opts: '' }
-          - { java-version: adopt@1.11, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
+          - { jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -33,16 +34,16 @@ jobs:
         run: |-
           cp container-license-acceptance.txt akka-projection-jdbc/src/it/resources/container-license-acceptance.txt
 
-      - name: Setup JDK ${{ matrix.java-version }}
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: ${{ matrix.java-version }}
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5        
+        uses: coursier/cache-action@v6.4.0
 
-      - name: Run all integration tests with default Scala and Java ${{ matrix.java-version }}
-        run: sbt "akka-projection-jdbc/it:test" ${{ matrix.sbt-opts }}
+      - name: Set up JDK ${{ matrix.jdkVersion }}
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: ${{ matrix.jvmName }}
+
+      - name: Run all integration tests with default Scala and Java ${{ matrix.jdkVersion }}
+        run: sbt "akka-projection-jdbc/It/test" ${{ matrix.extraOpts }}
         env: # Disable Ryuk resource reaper since we always spin up fresh VMs
           TESTCONTAINERS_RYUK_DISABLED: true
 

--- a/.github/workflows/integration-tests-kafka.yml
+++ b/.github/workflows/integration-tests-kafka.yml
@@ -15,11 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { java-version: adopt@1.8,  sbt-opts: '' }
-          - { java-version: adopt@1.11, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
+          - { jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -29,16 +30,16 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Setup JDK ${{ matrix.java-version }}
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: ${{ matrix.java-version }}
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
 
-      - name: Run all integration tests with default Scala and Java ${{ matrix.java-version }}
-        run: sbt "akka-projection-kafka/it:test" ${{ matrix.sbt-opts }}
+      - name: Set up JDK ${{ matrix.jdkVersion }}
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: ${{ matrix.jvmName }}
+
+      - name: Run all integration tests with default Scala and Java ${{ matrix.jdkVersion }}
+        run: sbt "akka-projection-kafka/It/test" ${{ matrix.extraOpts }}
         env: # Disable Ryuk resource reaper since we always spin up fresh VMs
           TESTCONTAINERS_RYUK_DISABLED: true
 

--- a/.github/workflows/integration-tests-slick.yml
+++ b/.github/workflows/integration-tests-slick.yml
@@ -15,11 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { java-version: adopt@1.8,  sbt-opts: '' }
-          - { java-version: adopt@1.11, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
+          - { jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -33,16 +34,16 @@ jobs:
         run: |-
           cp container-license-acceptance.txt akka-projection-slick/src/it/resources/container-license-acceptance.txt
 
-      - name: Setup JDK ${{ matrix.java-version }}
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: ${{ matrix.java-version }}
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
 
-      - name: Run all integration tests with default Scala and Java ${{ matrix.java-version }}
-        run: sbt "akka-projection-slick/it:test" ${{ matrix.sbt-opts }}
+      - name: Set up JDK ${{ matrix.jdkVersion }}
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: ${{ matrix.jvmName }}
+
+      - name: Run all integration tests with default Scala and Java ${{ matrix.jdkVersion }}
+        run: sbt "akka-projection-slick/It/test" ${{ matrix.extraOpts }}
         env: # Disable Ryuk resource reaper since we always spin up fresh VMs
           TESTCONTAINERS_RYUK_DISABLED: true
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged
-      - uses: release-drafter/release-drafter@v5
+      # https://github.com/release-drafter/release-drafter/releases
+      # v5.21.1
+      - uses: release-drafter/release-drafter@6df64e4ba4842c203c604c1f45246c5863410adb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -28,13 +28,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Setup Scala with JDK 8
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.8.0-275
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 8
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: adopt:1.8.0-275
 
       - name: Publish artifacts for all Scala versions
         env:
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -64,13 +64,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Setup Scala with JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-9
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:1.11.0
 
       - name: Publish API and reference documentation
         env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,11 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { java-version: adopt@1.8,  sbt-opts: '' }
-          - { java-version: adopt@1.11, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
+          - { jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -29,16 +30,16 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Setup JDK ${{ matrix.java-version }}
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: ${{ matrix.java-version }}
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
 
-      - name: Run tests with default Scala and Java ${{ matrix.java-version }}
-        run: sbt "test" ${{ matrix.sbt-opts }}
+      - name: Set up JDK ${{ matrix.jdkVersion }}
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: ${{ matrix.jvmName }}
+
+      - name: Run tests with default Scala and Java ${{ matrix.jdkVersion }}
+        run: sbt "test" ${{ matrix.extraOpts }}
 
       - name: Print logs on failure
         if: ${{ failure() }}


### PR DESCRIPTION
- Current versions of GH actions.
- Use coursier setup-action
- Add JDK17 to the matrices.

Notice: release runs on JDK 8

Aligns with
- https://github.com/akka/akka/pull/31730
- https://github.com/akka/akka/pull/31734