### PR TITLE
fix: CassandraProjectionSpec race conditions

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -38,7 +38,8 @@ object Common extends AutoPlugin {
       },
       description := "Akka Projection.",
       excludeLintKeys += scmInfo,
-      excludeLintKeys += mimaPreviousArtifacts)
+      excludeLintKeys += mimaPreviousArtifacts,
+      excludeLintKeys += testOptions)
 
   override lazy val projectSettings = Seq(
     projectInfoVersion := (if (isSnapshot.value) "snapshot" else version.value),
@@ -65,6 +66,7 @@ object Common extends AutoPlugin {
     apiURL := Some(url(s"https://doc.akka.io/api/akka-projection/${projectInfoVersion.value}")),
     // show full stack traces and test case durations
     Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
+    IntegrationTest / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
     // -a Show stack traces and exception class name for AssertionErrors.
     // -v Log "test run started" / "test started" / "test run finished" events on log level "info" instead of "debug".
     // -q Suppress stdout for successful tests.

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -39,7 +39,8 @@ object Common extends AutoPlugin {
       description := "Akka Projection.",
       excludeLintKeys += scmInfo,
       excludeLintKeys += mimaPreviousArtifacts,
-      excludeLintKeys += testOptions)
+      excludeLintKeys += testOptions,
+      excludeLintKeys += logBuffered)
 
   override lazy val projectSettings = Seq(
     projectInfoVersion := (if (isSnapshot.value) "snapshot" else version.value),
@@ -72,6 +73,7 @@ object Common extends AutoPlugin {
     // -q Suppress stdout for successful tests.
     Test / testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v", "-q"),
     Test / logBuffered := false,
+    IntegrationTest / logBuffered := false,
     mimaPreviousArtifacts :=
       Set(
         organization.value %% moduleName.value % previousStableVersion.value


### PR DESCRIPTION
References #643

Ordering issue, the test expected that offsets writing was always completed when the next envelope is processed. Throwing in the event handler can overtake the write since it is run in a stream and errors tearing down the stream is not ordered.

A `delay(100.millis)` between the `atLeastOnceHandlerFlow` and the downstream ending in offset commit confirms the suspicion by failing the test cases exercising failure 

* Bonus: added stack traces to integration test failures.
