### PR TITLE
fix: Backtracking and filtering in gRPC Projections

### DIFF
--- a/akka-projection-grpc/src/it/scala/akka/projection/grpc/consumer/scaladsl/LoadEventQuerySpec.scala
+++ b/akka-projection-grpc/src/it/scala/akka/projection/grpc/consumer/scaladsl/LoadEventQuerySpec.scala
@@ -122,8 +122,9 @@ class LoadEventQuerySpec(testContainerConf: TestContainerConf)
       val env = grpcReadJournal
         .loadEnvelope[String](pid.id, sequenceNr = 1L)
         .futureValue
-      env.eventOption.isEmpty shouldBe true
+      env.filtered shouldBe true
       env.eventMetadata shouldBe Some(NotUsed)
+      env.eventOption.isEmpty shouldBe true
     }
 
     "handle missing event as NOT_FOUND" in new TestFixture {

--- a/akka-projection-grpc/src/main/protobuf/akka/projection/grpc/event_producer.proto
+++ b/akka-projection-grpc/src/main/protobuf/akka/projection/grpc/event_producer.proto
@@ -60,7 +60,10 @@ message Event {
   int64 seq_nr = 2;
   int32 slice = 3;
   Offset offset = 4;
+  // Actual payload and metadata serialization is deferred to Akka serialization,
+  // the serializer id and manifest are encoded into a custom type_url schema
   google.protobuf.Any payload = 5;
+  string source = 6;
 }
 
 // Events that are filtered out are represented by this
@@ -70,6 +73,7 @@ message FilteredEvent {
   int64 seq_nr = 2;
   int32 slice = 3;
   Offset offset = 4;
+  string source = 5;
 }
 
 message EventTimestampRequest {

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/EnvelopeSource.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/EnvelopeSource.scala
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2009-2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.projection.grpc.internal
+
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] object EnvelopeSource {
+  val Backtracking = "BT"
+}

--- a/akka-projection-grpc/src/test/scala/akka/projection/grpc/producer/scaladsl/TransformationSpec.scala
+++ b/akka-projection-grpc/src/test/scala/akka/projection/grpc/producer/scaladsl/TransformationSpec.scala
@@ -23,7 +23,9 @@ class TransformationSpec extends AnyWordSpec with Matchers with ScalaFutures {
       timestamp = System.currentTimeMillis(),
       entityType = "banana",
       slice = 5,
-      eventMetadata = meta).asInstanceOf[EventEnvelope[Any]]
+      eventMetadata = meta,
+      filtered = false,
+      source = "").asInstanceOf[EventEnvelope[Any]]
 
   "The gRPC event Transformation" should {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,10 +16,12 @@ object Dependencies {
   val AkkaPersistenceR2dbcVersionInDocs = Versions.akkaPersistenceR2dbc
 
   object Versions {
-    val akka = sys.props.getOrElse("build.akka.version", "2.7.0")
+    // FIXME non-milestone
+    val akka = sys.props.getOrElse("build.akka.version", "2.8.0-M4")
     val akkaPersistenceCassandra = "1.1.0"
     val akkaPersistenceJdbc = "5.2.0"
-    val akkaPersistenceR2dbc = "1.0.1"
+    // FIXME non-milestone
+    val akkaPersistenceR2dbc = "1.1.0-M4"
     val alpakka = "5.0.0"
     val alpakkaKafka = sys.props.getOrElse("build.alpakka.kafka.version", "4.0.0")
     val slick = "3.4.1"


### PR DESCRIPTION
Needed changes along with the new envelope fields in Akka (https://github.com/akka/akka/pull/31817) and in the R2DBC persistence plugin (https://github.com/akka/akka-persistence-r2dbc/pull/348).
