### PR TITLE
doc: Remove mentions of spanner

### DIFF
--- a/docs/src/main/paradox/cassandra.md
+++ b/docs/src/main/paradox/cassandra.md
@@ -270,9 +270,7 @@ The supported offset types of the `CassandraProjection` are:
 * `String`
 * @scala[`Int`]@java[Integer]
 * `Long`
-* Any other type that has a configured Akka Serializer is stored with base64 encoding of the serialized bytes.
-  For example the [Akka Persistence Spanner](https://doc.akka.io/docs/akka-persistence-spanner/current/) offset
-  is supported in this way. 
+* Any other type that has a configured Akka Serializer is stored with base64 encoding of the serialized bytes. 
 
 @@@ note
 

--- a/docs/src/main/paradox/jdbc.md
+++ b/docs/src/main/paradox/jdbc.md
@@ -257,8 +257,6 @@ The supported offset types of the `JdbcProjection` are:
 * `Int`
 * `Long`
 * Any other type that has a configured Akka Serializer is stored with base64 encoding of the serialized bytes.
-  For example the [Akka Persistence Spanner](https://doc.akka.io/docs/akka-persistence-spanner/current/) offset
-  is supported in this way.
 
 ## Configuration
 

--- a/docs/src/main/paradox/running.md
+++ b/docs/src/main/paradox/running.md
@@ -48,8 +48,7 @@ When using [Akka Persistence Cassandra plugin](https://doc.akka.io/docs/akka-per
 not use too many tags for each event. Each tag will result in a copy of the event in a separate table and
 that can impact write performance. Typically, you would use 1 tag per event as illustrated here. Additional
 filtering of events can be done in the Projection handler if it doesn't have to act on certain events.
-The [JDBC plugin](https://doc.akka.io/docs/akka-persistence-jdbc/current/) and
-[Spanner plugin](https://doc.akka.io/docs/akka-persistence-spanner/current/)
+The [JDBC plugin](https://doc.akka.io/docs/akka-persistence-jdbc/current/) 
 don't have this constraint.
 @@@
 

--- a/docs/src/main/paradox/slick.md
+++ b/docs/src/main/paradox/slick.md
@@ -202,8 +202,6 @@ The supported offset types of the `SlickProjection` are:
 * `Int`
 * `Long`
 * Any other type that has a configured Akka Serializer is stored with base64 encoding of the serialized bytes.
-  For example the [Akka Persistence Spanner](https://doc.akka.io/docs/akka-persistence-spanner/current/) offset
-  is supported in this way.
 
 ## Configuration
 


### PR DESCRIPTION
The plugin never reached a final release and is no longer available

References #774 
