### PR TITLE
bump: Akka 23.02 milestones; sbt bumps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -125,7 +125,7 @@ lazy val examples = project
   .settings(publish / skip := true, scalacOptions += "-feature", javacOptions += "-parameters")
 
 lazy val docs = project
-  .enablePlugins(AkkaParadoxPlugin, ParadoxSitePlugin, PreprocessPlugin, PublishRsyncPlugin)
+  .enablePlugins(AkkaParadoxPlugin, ParadoxSitePlugin, SitePreviewPlugin, PreprocessPlugin, PublishRsyncPlugin)
   .disablePlugins(MimaPlugin)
   .dependsOn(core, testkit)
   .settings(
@@ -135,6 +135,10 @@ lazy val docs = project
     previewPath := (Paradox / siteSubdirName).value,
     Preprocess / siteSubdirName := s"api/akka-projection/${projectInfoVersion.value}",
     Preprocess / sourceDirectory := (LocalRootProject / ScalaUnidoc / unidoc / target).value,
+    Preprocess / preprocessRules := Seq(
+        ( // package duplication errors
+          (s"https://doc\\.akka\\.io/api/akka-grpc/${akka.grpc.gen.BuildInfo.version}/akka/grpc/akka/grpc").r,
+          _ => s"https://doc\\.akka\\.io/api/akka-grpc/${akka.grpc.gen.BuildInfo.version}/akka/grpc/")),
     Paradox / siteSubdirName := s"docs/akka-projection/${projectInfoVersion.value}",
     Compile / paradoxProperties ++= Map(
         "project.url" -> "https://doc.akka.io/docs/akka-projection/current/",
@@ -167,7 +171,7 @@ lazy val docs = project
         "javadoc.akka.projection.base_url" -> "", // no Javadoc is published
         // Misc
         "extref.samples.base_url" -> "https://developer.lightbend.com/start/?group=akka&amp;project=%s",
-        "extref.platform-guide.base_url" -> "https://developer.lightbend.com/docs/akka-platform-guide/%s"),
+        "extref.platform-guide.base_url" -> "https://developer.lightbend.com/docs/akka-guide/%s"),
     paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
     paradoxRoots := List("index.html", "getting-started/event-generator-app.html"),
     ApidocPlugin.autoImport.apidocRootPackage := "akka",

--- a/docs/src/main/paradox/getting-started/index.md
+++ b/docs/src/main/paradox/getting-started/index.md
@@ -22,4 +22,4 @@ The example used in this guide is based on a more complete application that is p
 
 This video on YouTube gives a short introduction to Akka Projections for processing a stream of events or records from a source to a projected model or external system.
 
-[![Akka Projections introduction](../assets/intro-video.png)](http://www.youtube.com/watch?v=0toyKxomdwo "Watch video on YouTube")
+[![Akka Projections introduction](../assets/intro-video.png)](https://www.youtube.com/watch?v=0toyKxomdwo "Watch video on YouTube")

--- a/docs/src/main/paradox/grpc.md
+++ b/docs/src/main/paradox/grpc.md
@@ -159,7 +159,7 @@ The consumer can pass metadata, such as auth headers, in each request to the pro
 
 Authentication and authorization for the producer can be done by implementing a @apidoc[EventProducerInterceptor] and pass
 it to the `grpcServiceHandler` method during producer bootstrap. The interceptor is invoked with the stream id and 
-gRPC request metadata for each incoming request and can return a suitable error through @apidoc[GrpcServiceException]
+gRPC request metadata for each incoming request and can return a suitable error through @apidoc[akka.grpc.GrpcServiceException]
 
 ## Performance considerations
 

--- a/docs/src/main/paradox/slick.md
+++ b/docs/src/main/paradox/slick.md
@@ -1,7 +1,7 @@
 # Offset in a relational DB with Slick
 
 The @apidoc[SlickProjection$] has support for storing the offset in a relational database using
-[Slick](http://scala-slick.org) (JDBC). This is only an option for Scala and for Java the
+[Slick](https://scala-slick.org) (JDBC). This is only an option for Scala and for Java the
 @ref:[offset can be stored in relational DB with JDBC](jdbc.md). The JDBC module can also be
 used with Scala.
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,10 +9,10 @@ object Dependencies {
   val Scala212 = "2.12.17"
   val ScalaVersions = Seq(Scala213, Scala212)
 
-  val AkkaVersionInDocs = "2.7"
+  val AkkaVersionInDocs = "2.8"
   val AlpakkaVersionInDocs = "5.0"
-  val AlpakkaKafkaVersionInDocs = "3.1"
-  val AkkaGrpcVersionInDocs = "2.2"
+  val AlpakkaKafkaVersionInDocs = "4.0"
+  val AkkaGrpcVersionInDocs = "2.3"
   val AkkaPersistenceR2dbcVersionInDocs = Versions.akkaPersistenceR2dbc
 
   object Versions {
@@ -29,7 +29,7 @@ object Dependencies {
     val testContainers = "1.15.3"
     val junit = "4.13.2"
     val h2Driver = "1.4.200"
-    val jackson = "2.13.4.2" // this should match the version of jackson used by akka-serialization-jackson
+    val jacksonDatabind = "2.13.4.2" // this should match the version of jackson used by akka-serialization-jackson
   }
 
   object Compile {
@@ -56,7 +56,7 @@ object Dependencies {
     val alpakkaKafka = "com.typesafe.akka" %% "akka-stream-kafka" % Versions.alpakkaKafka
 
     // must be provided on classpath when using Apache Kafka 2.6.0+
-    val jackson = "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson
+    val jackson = "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jacksonDatabind
 
     // not really used in lib code, but in example and test
     val h2Driver = "com.h2database" % "h2" % Versions.h2Driver

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.8.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,16 +2,17 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.9.0")
 
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")
 
 // remember to bump in samples/grpc/ projects as well if changing
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.2.1")
+// FIXME non-milestone
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.3.0-M2")
 
 // Documentation
-addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.45")
+addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.46")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "0.2.2")
 addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.2")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")
+addSbtPlugin("com.github.sbt" % "sbt-site-paradox" % "1.5.0-RC2")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.1")

--- a/samples/grpc/shopping-analytics-service-java/pom.xml
+++ b/samples/grpc/shopping-analytics-service-java/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <akka-grpc-maven-plugin.version>2.2.1</akka-grpc-maven-plugin.version>
+        <akka-grpc-maven-plugin.version>2.3.0-M2</akka-grpc-maven-plugin.version>
         <scala.binary.version>2.13</scala.binary.version>
         <!-- needs to be defined to allow for overriding through mvn exec:exec -DAPP_CONFIG=local1.conf -->
         <APP_CONFIG>application.conf</APP_CONFIG>

--- a/samples/grpc/shopping-analytics-service-scala/project/build.properties
+++ b/samples/grpc/shopping-analytics-service-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.8.2

--- a/samples/grpc/shopping-analytics-service-scala/project/plugins.sbt
+++ b/samples/grpc/shopping-analytics-service-scala/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.2.1")
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.3.0-M2")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")

--- a/samples/grpc/shopping-analytics-service-scala/project/plugins.sbt
+++ b/samples/grpc/shopping-analytics-service-scala/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.3.0-M2")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.13")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")

--- a/samples/grpc/shopping-cart-service-java/pom.xml
+++ b/samples/grpc/shopping-cart-service-java/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <akka-grpc-maven-plugin.version>2.2.1</akka-grpc-maven-plugin.version>
+        <akka-grpc-maven-plugin.version>2.3.0-M2</akka-grpc-maven-plugin.version>
         <scala.binary.version>2.13</scala.binary.version>
         <!-- needs to be defined to allow for overriding through mvn exec:exec -DAPP_CONFIG=local1.conf -->
         <APP_CONFIG>application.conf</APP_CONFIG>

--- a/samples/grpc/shopping-cart-service-scala/project/build.properties
+++ b/samples/grpc/shopping-cart-service-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.8.2

--- a/samples/grpc/shopping-cart-service-scala/project/plugins.sbt
+++ b/samples/grpc/shopping-cart-service-scala/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.2.1")
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.3.0-M2")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")

--- a/samples/grpc/shopping-cart-service-scala/project/plugins.sbt
+++ b/samples/grpc/shopping-cart-service-scala/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.3.0-M2")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.13")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")

--- a/samples/replicated/shopping-cart-service-java/pom.xml
+++ b/samples/replicated/shopping-cart-service-java/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <akka-grpc-maven-plugin.version>2.2.1</akka-grpc-maven-plugin.version>
+        <akka-grpc-maven-plugin.version>2.3.0-M2</akka-grpc-maven-plugin.version>
         <scala.binary.version>2.13</scala.binary.version>
         <!-- needs to be defined to allow for overriding through mvn exec:exec -DAPP_CONFIG=local1.conf -->
         <APP_CONFIG>application.conf</APP_CONFIG>

--- a/samples/replicated/shopping-cart-service-scala/project/build.properties
+++ b/samples/replicated/shopping-cart-service-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.8.2

--- a/samples/replicated/shopping-cart-service-scala/project/plugins.sbt
+++ b/samples/replicated/shopping-cart-service-scala/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.2.1")
+addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.3.0-M2")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.13")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")

--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -1,0 +1,32 @@
+// config for https://github.com/ennru/site-link-validator/
+site-link-validator {
+  root-dir = "./docs/target/site/"
+  # relative to `root-dir`
+  start-file = "docs/akka-projection/snapshot/index.html"
+
+  # Resolves URLs with the given prefix as local files instead
+  link-mappings = [
+    {
+      prefix = "https://doc.akka.io/docs/akka-projection/snapshot/"
+      replace = "/docs/akka-projection/snapshot/"
+    }
+    {
+      prefix = "https://doc.akka.io/api/akka-projection/snapshot/"
+      replace = "/api/akka-projection/snapshot/"
+    }
+  ]
+
+  ignore-missing-local-files-regex = ""
+
+  ignore-prefixes = [
+    # Fails after a number of requests with "403 Forbidden"
+    "https://javadoc.io/static/"
+    # GitHub will block with "429 Too Many Requests"
+    "https://github.com/"
+    # MVN repository forbids access after a few requests
+    "https://mvnrepository.com/artifact/"
+  ]
+
+  non-https-whitelist = [
+  ]
+}


### PR DESCRIPTION
Makes the Scala XML 2.1 jump in sbt.

References
- https://github.com/sbt/sbt/releases/tag/v1.8.2
- https://github.com/akka/akka/releases/tag/v2.8.0-M4
- https://github.com/akka/akka-grpc/releases/tag/v2.3.0-M2
- https://github.com/sbt/sbt-site/releases/tag/v1.5.0-RC2

Alpakka milestone pending.
The link checker is much happier than before.

I'm not sure we need all of this now.