### PR TITLE
fix: reduce handoff timeout for RES projections, #777

### DIFF
--- a/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/replication/ReplicationIntegrationSpec.scala
+++ b/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/replication/ReplicationIntegrationSpec.scala
@@ -73,7 +73,10 @@ object ReplicationIntegrationSpec {
         }
         akka.remote.artery.canonical.host = "127.0.0.1"
         akka.remote.artery.canonical.port = 0
-        akka.actor.testkit.typed.filter-leeway = 10s
+        akka.actor.testkit.typed {
+          filter-leeway = 10s
+          system-shutdown-default = 30s
+        }
       """)
 
   private val DCA = ReplicaId("DCA")
@@ -315,6 +318,8 @@ class ReplicationIntegrationSpec(testContainerConf: TestContainerConf)
 
   protected override def afterAll(): Unit = {
     logger.info("Shutting down all three DCs")
+    systems.foreach(_.terminate()) // speed up termination by terminating all at the once
+    // and then make sure they are completely shutdown
     systems.foreach { system =>
       ActorTestKit.shutdown(system)
     }

--- a/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/replication/ReplicationJavaDSLIntegrationSpec.scala
+++ b/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/replication/ReplicationJavaDSLIntegrationSpec.scala
@@ -80,7 +80,10 @@ object ReplicationJavaDSLIntegrationSpec {
         }
         akka.remote.artery.canonical.host = "127.0.0.1"
         akka.remote.artery.canonical.port = 0
-        akka.actor.testkit.typed.filter-leeway = 10s
+        akka.actor.testkit.typed {
+          filter-leeway = 10s
+          system-shutdown-default = 30s
+        }
       """)
 
   private val DCA = ReplicaId("DCA")
@@ -309,6 +312,8 @@ class ReplicationJavaDSLIntegrationSpec(testContainerConf: TestContainerConf)
 
   protected override def afterAll(): Unit = {
     logger.info("Shutting down all three DCs")
+    systems.foreach(_.terminate()) // speed up termination by terminating all at the once
+    // and then make sure they are completely shutdown
     systems.foreach { system =>
       ActorTestKit.shutdown(system)
     }


### PR DESCRIPTION
* using the Projection Stop message
* but then in some restart backoff situations it will take a while for the projections to terminate gracefully
* reduce handoff timeout so that rebalance is not delayed for too long

At first I suspected that RestartSource wouldn't stop by the killswitch when it was in backoff, but I verified that in an Akka unit test. Not sure what is causing the delays but this is probably good enough (for now).

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #777
