### PR TITLE
chore: bump scalaTest,scalatestplus and fix tests

### DIFF
--- a/akka-projection-cassandra/src/it/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
+++ b/akka-projection-cassandra/src/it/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
@@ -438,9 +438,7 @@ class CassandraProjectionSpec
           sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
         }
         offsetShouldBe(projectionId, 17L)
-        eventually {
-          repository.findById(entityId).futureValue.get.text should include("elem-17")
-        }
+        repository.findById(entityId).futureValue.get.text should include("elem-17")
 
       }
     }

--- a/akka-projection-cassandra/src/it/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
+++ b/akka-projection-cassandra/src/it/scala/akka/projection/cassandra/CassandraProjectionSpec.scala
@@ -389,13 +389,17 @@ class CassandraProjectionSpec
           sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
         }
         offsetShouldBe(projectionId, 10L)
-        repository.findById(entityId).futureValue.get.text should include("elem-15")
+        eventually {
+          repository.findById(entityId).futureValue.get.text should include("elem-15")
+        }
 
         (16 to 22).foreach { n =>
           sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
         }
         offsetShouldBe(projectionId, 20L)
-        repository.findById(entityId).futureValue.get.text should include("elem-22")
+        eventually {
+          repository.findById(entityId).futureValue.get.text should include("elem-22")
+        }
       }
     }
 
@@ -426,13 +430,17 @@ class CassandraProjectionSpec
           sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
         }
         offsetShouldBe(projectionId, 10L)
-        repository.findById(entityId).futureValue.get.text should include("elem-15")
+        eventually {
+          repository.findById(entityId).futureValue.get.text should include("elem-15")
+        }
 
         (16 to 17).foreach { n =>
           sourceProbe.get.sendNext(Envelope(entityId, n, s"elem-$n"))
         }
         offsetShouldBe(projectionId, 17L)
-        repository.findById(entityId).futureValue.get.text should include("elem-17")
+        eventually {
+          repository.findById(entityId).futureValue.get.text should include("elem-17")
+        }
 
       }
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
     val alpakka = "5.0.0"
     val alpakkaKafka = sys.props.getOrElse("build.alpakka.kafka.version", "4.0.0")
     val slick = "3.4.1"
-    val scalaTest = "3.1.1"
+    val scalaTest = "3.2.12"
     val testContainers = "1.17.6"
     val junit = "4.13.2"
     val h2Driver = "1.4.200"
@@ -77,7 +77,7 @@ object Dependencies {
     val akkaProjectionR2dbc = Compile.akkaProjectionR2dbc % allTestConfig
 
     val scalatest = "org.scalatest" %% "scalatest" % Versions.scalaTest % allTestConfig
-    val scalatestJUnit = "org.scalatestplus" %% "junit-4-12" % (Versions.scalaTest + ".0") % allTestConfig
+    val scalatestJUnit = "org.scalatestplus" %% "junit-4-13" % (Versions.scalaTest + ".0") % allTestConfig
     val junit = "junit" % "junit" % Versions.junit % allTestConfig
 
     val h2Driver = Compile.h2Driver % allTestConfig


### PR DESCRIPTION
This came up during the scala3 builds, and it seemed enough of a change to make it separate. I did not investigate why that needs changed though.