### PR TITLE
chore: exclude tooling from dependency graph submission

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -30,4 +30,4 @@ jobs:
         uses: scalacenter/sbt-dependency-submission@573f2f9ac18dd26794bd0c5b26b71e880467b608
         with:
           modules-ignore: examples_2.13 examples_2.12
-          configs-ignore: test It
+          configs-ignore: test It scala-tool scala-doc-tool


### PR DESCRIPTION
Apparently even Scala tool dependencies are submitted.

See 
- https://github.com/scalacenter/sbt-dependency-submission/issues/49#issuecomment-1373614001

References 
- #792 
- #802 