### PR TITLE
feat: Store consumer filter

### DIFF
--- a/akka-projection-grpc-tests/src/it/resources/logback-test.xml
+++ b/akka-projection-grpc-tests/src/it/resources/logback-test.xml
@@ -20,6 +20,7 @@
 
     <!-- Silence some other stuff -->
     <logger name="akka.actor.typed.pubsub" level="INFO" />
+    <logger name="akka.http" level="INFO" />
     <logger name="akka.cluster.typed.internal.receptionist" level="INFO" />
     <logger name="io.grpc.netty.shaded.io.grpc.netty" level="INFO" />
     <logger name="io.r2dbc.postgresql" level="INFO" />

--- a/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/IntegrationSpec.scala
+++ b/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/IntegrationSpec.scala
@@ -355,14 +355,14 @@ class IntegrationSpec(testContainerConf: TestContainerConf)
       processedB.envelope.event shouldBe "B"
 
       val consumerFilter = ConsumerFilter(system).ref
-      consumerFilter ! ConsumerFilter.FilterCommand(streamId, List(ConsumerFilter.ExcludeEntityIds(Set(pid.entityId))))
+      consumerFilter ! ConsumerFilter.UpdateFilter(streamId, List(ConsumerFilter.ExcludeEntityIds(Set(pid.entityId))))
       // FIXME hack sleep to let it propagate to producer side
       Thread.sleep(3000)
 
       entity ! TestEntity.Persist("c")
       processedProbe.expectNoMessage(1.second)
 
-      consumerFilter ! ConsumerFilter.FilterCommand(
+      consumerFilter ! ConsumerFilter.UpdateFilter(
         streamId,
         List(ConsumerFilter.IncludeEntityIds(Set(ConsumerFilter.EntityIdOffset(pid.entityId, 0L)))))
       // FIXME hack sleep
@@ -383,7 +383,7 @@ class IntegrationSpec(testContainerConf: TestContainerConf)
       processedD.envelope.event shouldBe "D"
 
       // remove filter
-      consumerFilter ! ConsumerFilter.FilterCommand(
+      consumerFilter ! ConsumerFilter.UpdateFilter(
         streamId,
         List(ConsumerFilter.RemoveIncludeEntityIds(Set(pid.entityId))))
       // FIXME hack sleep to let it propagate to producer side
@@ -418,7 +418,7 @@ class IntegrationSpec(testContainerConf: TestContainerConf)
       processedB.envelope.event shouldBe "B"
 
       val consumerFilter = ConsumerFilter(system).ref
-      consumerFilter ! ConsumerFilter.ReplayCommand(streamId, Set(ConsumerFilter.EntityIdOffset(pid.entityId, 2L)))
+      consumerFilter ! ConsumerFilter.Replay(streamId, Set(ConsumerFilter.EntityIdOffset(pid.entityId, 2L)))
       // FIXME hack sleep to let it propagate to producer side
       Thread.sleep(3000)
 

--- a/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/IntegrationSpec.scala
+++ b/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/IntegrationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022-2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.grpc
@@ -55,6 +55,7 @@ object IntegrationSpec {
 
   val config: Config = ConfigFactory
     .parseString(s"""
+    akka.loglevel = DEBUG
     akka.http.server.preview.enable-http2 = on
     akka.persistence.r2dbc {
       query {

--- a/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/TestData.scala
+++ b/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/TestData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022-2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.grpc

--- a/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/consumer/scaladsl/EventTimestampQuerySpec.scala
+++ b/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/consumer/scaladsl/EventTimestampQuerySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022-2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.grpc.consumer.scaladsl

--- a/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/consumer/scaladsl/LoadEventQuerySpec.scala
+++ b/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/consumer/scaladsl/LoadEventQuerySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022-2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.grpc.consumer.scaladsl

--- a/akka-projection-grpc-tests/src/test/java/akka/projection/grpc/consumer/javadsl/ConsumerCompileTest.java
+++ b/akka-projection-grpc-tests/src/test/java/akka/projection/grpc/consumer/javadsl/ConsumerCompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022-2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.grpc.consumer.javadsl;

--- a/akka-projection-grpc-tests/src/test/java/akka/projection/grpc/producer/javadsl/ProducerCompileTest.java
+++ b/akka-projection-grpc-tests/src/test/java/akka/projection/grpc/producer/javadsl/ProducerCompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022-2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.grpc.producer.javadsl;

--- a/akka-projection-grpc-tests/src/test/java/akka/projection/grpc/replication/javdsl/ReplicationCompileTest.java
+++ b/akka-projection-grpc-tests/src/test/java/akka/projection/grpc/replication/javdsl/ReplicationCompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022-2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.grpc.replication.javdsl;

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/ConsumerFilterSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/ConsumerFilterSpec.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2009-2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.grpc
+
+import akka.projection.grpc.consumer.ConsumerFilter
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class ConsumerFilterSpec extends AnyWordSpecLike with Matchers {
+  import ConsumerFilter._
+
+  "ConsumerFilter" should {
+    "merge and remove include" in {
+      val filter1 = Vector(ExcludeEntityIds(Set("a")))
+      mergeFilter(Nil, filter1) shouldBe filter1
+      mergeFilter(filter1, Nil) shouldBe filter1
+      val filter2 = Vector(IncludeEntityIds(Set(EntityIdOffset("a", 1))))
+      mergeFilter(filter1, filter2) shouldBe filter1 ++ filter2
+      mergeFilter(filter2, filter1) shouldBe filter1 ++ filter2
+      val filter3 = Vector(RemoveIncludeEntityIds(Set("a")))
+      mergeFilter(filter1 ++ filter2, filter3) shouldBe filter1
+      mergeFilter(filter3, filter1 ++ filter2) shouldBe filter1
+    }
+
+    "merge and reduce filter" in {
+      val filter1 =
+        Vector(
+          ExcludeEntityIds(Set("a", "b", "c")),
+          IncludeEntityIds(Set(EntityIdOffset("b", 1), EntityIdOffset("c", 2))))
+
+      val filter2 =
+        Vector(ExcludeEntityIds(Set("d")), RemoveIncludeEntityIds(Set("a", "b")), RemoveExcludeEntityIds(Set("c")))
+
+      val expectedFilter =
+        Vector(ExcludeEntityIds(Set("a", "b", "d")), IncludeEntityIds(Set(EntityIdOffset("c", 2))))
+
+      mergeFilter(filter1, filter2) shouldBe expectedFilter
+      mergeFilter(filter2, filter1) shouldBe expectedFilter
+    }
+
+    "merge and use highest seqNr" in {
+      val filter1 =
+        Vector(IncludeEntityIds(Set(EntityIdOffset("b", 1), EntityIdOffset("b", 2), EntityIdOffset("c", 2))))
+      val expectedFilter1 = Vector(IncludeEntityIds(Set(EntityIdOffset("b", 2), EntityIdOffset("c", 2))))
+      mergeFilter(Nil, filter1) shouldBe expectedFilter1
+      mergeFilter(filter1, Nil) shouldBe expectedFilter1
+
+      val filter2 =
+        Vector(IncludeEntityIds(Set(EntityIdOffset("b", 3), EntityIdOffset("c", 1))))
+      val expectedFilter2 = Vector(IncludeEntityIds(Set(EntityIdOffset("b", 3), EntityIdOffset("c", 2))))
+      mergeFilter(filter1, filter2) shouldBe expectedFilter2
+    }
+
+    "create diff for ExcludeRegexEntityIds" in {
+      val filter1 = Vector(ExcludeRegexEntityIds(Set("a.*", "b.*")))
+      createDiff(Nil, filter1) shouldBe filter1
+      createDiff(filter1, Nil) shouldBe Vector(RemoveExcludeRegexEntityIds(Set("a.*", "b.*")))
+
+      val filter2 = Vector(ExcludeRegexEntityIds(Set("a.*", "c.*")))
+      createDiff(filter1, filter2) shouldBe Vector(
+        ExcludeRegexEntityIds(Set("c.*")),
+        RemoveExcludeRegexEntityIds(Set("b.*")))
+    }
+
+    "create diff for ExcludeEntityIds" in {
+      val filter1 = Vector(ExcludeEntityIds(Set("a", "b")))
+      createDiff(Nil, filter1) shouldBe filter1
+      createDiff(filter1, Nil) shouldBe Vector(RemoveExcludeEntityIds(Set("a", "b")))
+
+      val filter2 = Vector(ExcludeEntityIds(Set("a", "c")))
+      createDiff(filter1, filter2) shouldBe Vector(ExcludeEntityIds(Set("c")), RemoveExcludeEntityIds(Set("b")))
+    }
+
+    "create diff for IncludeEntityIds" in {
+      val filter1 = Vector(IncludeEntityIds(Set(EntityIdOffset("a", 1), EntityIdOffset("b", 1))))
+      createDiff(Nil, filter1) shouldBe filter1
+      createDiff(filter1, Nil) shouldBe Vector(RemoveIncludeEntityIds(Set("a", "b")))
+
+      val filter2 = Vector(IncludeEntityIds(Set(EntityIdOffset("a", 1), EntityIdOffset("c", 1))))
+      createDiff(filter1, filter2) shouldBe Vector(
+        IncludeEntityIds(Set(EntityIdOffset("c", 1))),
+        RemoveIncludeEntityIds(Set("b")))
+    }
+
+    "create diff for IncludeEntityIds and use highest seqNr" in {
+      val filter1 =
+        Vector(IncludeEntityIds(Set(EntityIdOffset("a", 1), EntityIdOffset("b", 2), EntityIdOffset("c", 3))))
+      val filter2 =
+        Vector(IncludeEntityIds(Set(EntityIdOffset("a", 1), EntityIdOffset("b", 3), EntityIdOffset("c", 1))))
+      createDiff(filter1, filter2) shouldBe Vector(IncludeEntityIds(Set(EntityIdOffset("b", 3))))
+    }
+  }
+
+}

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/ConsumerFilterRegistrySpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/ConsumerFilterRegistrySpec.scala
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.grpc.internal
+
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.projection.grpc.consumer.ConsumerFilter
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class ConsumerFilterRegistrySpec
+    extends ScalaTestWithActorTestKit
+    with AnyWordSpecLike
+    with Matchers
+    with TestData
+    with LogCapturing {
+
+  private var streamIdCounter = 0
+  def nextStreamId(): String = {
+    streamIdCounter += 1
+    s"stream$streamIdCounter"
+  }
+
+  "ConsumerFilterRegistry" must {
+    "get filter" in {
+      val streamId = nextStreamId()
+      val registry = spawn(ConsumerFilterRegistry())
+
+      val currentProbe = createTestProbe[ConsumerFilter.CurrentFilter]()
+      registry ! ConsumerFilter.GetFilter(streamId, currentProbe.ref)
+      currentProbe.expectMessage(ConsumerFilter.CurrentFilter(streamId, Nil))
+
+      val filter1 = Vector(ConsumerFilter.ExcludeEntityIds(Set("a", "c")))
+      registry ! ConsumerFilter.UpdateFilter(streamId, filter1)
+      registry ! ConsumerFilter.GetFilter(streamId, currentProbe.ref)
+      currentProbe.expectMessage(ConsumerFilter.CurrentFilter(streamId, filter1))
+
+      val filter2 =
+        Vector(
+          ConsumerFilter.ExcludeEntityIds(Set("a", "b")),
+          ConsumerFilter.IncludeEntityIds(Set(ConsumerFilter.EntityIdOffset("b", 1))),
+          ConsumerFilter.RemoveExcludeEntityIds(Set("c")))
+
+      registry ! ConsumerFilter.UpdateFilter(streamId, filter2)
+      registry ! ConsumerFilter.GetFilter(streamId, currentProbe.ref)
+      currentProbe.expectMessage(
+        ConsumerFilter.CurrentFilter(
+          streamId,
+          Vector(
+            ConsumerFilter.ExcludeEntityIds(Set("a", "b")),
+            ConsumerFilter.IncludeEntityIds(Set(ConsumerFilter.EntityIdOffset("b", 1))))))
+
+    }
+
+    "update filter and notify subscriber" in {
+      val streamId = nextStreamId()
+      val registry = spawn(ConsumerFilterRegistry())
+
+      val subscriberProbe = createTestProbe[ConsumerFilter.SubscriberCommand]()
+      registry ! ConsumerFilter.Subscribe(streamId, Nil, subscriberProbe.ref)
+
+      val filter =
+        Vector(
+          ConsumerFilter.ExcludeEntityIds(Set("a", "b", "c")),
+          ConsumerFilter.IncludeEntityIds(Set(ConsumerFilter.EntityIdOffset("b", 1))))
+      registry ! ConsumerFilter.UpdateFilter(streamId, filter)
+
+      subscriberProbe.expectMessage(ConsumerFilter.UpdateFilter(streamId, filter))
+    }
+
+    "notify subscriber with diff" in {
+      val streamId = nextStreamId()
+      val registry = spawn(ConsumerFilterRegistry())
+
+      val subscriberProbe1 = createTestProbe[ConsumerFilter.SubscriberCommand]()
+      registry ! ConsumerFilter.Subscribe(streamId, Nil, subscriberProbe1.ref)
+
+      val filter1 = Vector(ConsumerFilter.ExcludeEntityIds(Set("a", "c")))
+      registry ! ConsumerFilter.UpdateFilter(streamId, filter1)
+      subscriberProbe1.expectMessage(ConsumerFilter.UpdateFilter(streamId, filter1))
+
+      val filter2 =
+        Vector(
+          ConsumerFilter.ExcludeEntityIds(Set("a", "b")),
+          ConsumerFilter.IncludeEntityIds(Set(ConsumerFilter.EntityIdOffset("b", 1))),
+          ConsumerFilter.RemoveExcludeEntityIds(Set("c")))
+      registry ! ConsumerFilter.UpdateFilter(streamId, filter2)
+
+      // subscriber1 receives the diff
+      subscriberProbe1.expectMessage(
+        ConsumerFilter.UpdateFilter(
+          streamId,
+          Vector(
+            ConsumerFilter.ExcludeEntityIds(Set("b")),
+            ConsumerFilter.RemoveExcludeEntityIds(Set("c")),
+            ConsumerFilter.IncludeEntityIds(Set(ConsumerFilter.EntityIdOffset("b", 1))))))
+
+      // subscriber2 starts from filter2
+      val subscriberProbe2 = createTestProbe[ConsumerFilter.SubscriberCommand]()
+      registry ! ConsumerFilter.Subscribe(streamId, filter2, subscriberProbe2.ref)
+      subscriberProbe2.expectNoMessage()
+
+      val filter3 = Vector(ConsumerFilter.ExcludeEntityIds(Set("d")))
+      registry ! ConsumerFilter.UpdateFilter(streamId, filter3)
+      // diff is sent to both subscribers
+      subscriberProbe1.expectMessage(ConsumerFilter.UpdateFilter(streamId, filter3))
+      subscriberProbe2.expectMessage(ConsumerFilter.UpdateFilter(streamId, filter3))
+    }
+
+    "start diff from init filter" in {
+      val streamId = nextStreamId()
+      val registry = spawn(ConsumerFilterRegistry())
+
+      val initFilter = Vector(ConsumerFilter.ExcludeEntityIds(Set("a", "c")))
+      registry ! ConsumerFilter.UpdateFilter(streamId, initFilter)
+
+      // before registering the subscriber it would retrieve the init filter
+      val currentProbe = createTestProbe[ConsumerFilter.CurrentFilter]()
+      registry ! ConsumerFilter.GetFilter(streamId, currentProbe.ref)
+      currentProbe.expectMessage(ConsumerFilter.CurrentFilter(streamId, initFilter))
+
+      // that init filter is then included in the Subscribe, to be used as starting point for evaluating
+      // the diff for that subscriber
+      val subscriberProbe = createTestProbe[ConsumerFilter.SubscriberCommand]()
+      registry ! ConsumerFilter.Subscribe(streamId, initFilter, subscriberProbe.ref)
+
+      val filter2 =
+        Vector(
+          ConsumerFilter.ExcludeEntityIds(Set("a", "b")),
+          ConsumerFilter.IncludeEntityIds(Set(ConsumerFilter.EntityIdOffset("b", 1))),
+          ConsumerFilter.RemoveExcludeEntityIds(Set("c")))
+      registry ! ConsumerFilter.UpdateFilter(streamId, filter2)
+
+      // diff between filter2 and initFilter
+      subscriberProbe.expectMessage(
+        ConsumerFilter.UpdateFilter(
+          streamId,
+          Vector(
+            ConsumerFilter.ExcludeEntityIds(Set("b")),
+            ConsumerFilter.RemoveExcludeEntityIds(Set("c")),
+            ConsumerFilter.IncludeEntityIds(Set(ConsumerFilter.EntityIdOffset("b", 1))))))
+    }
+
+    "notify new subscriber of diff from concurrent update" in {
+      val streamId = nextStreamId()
+      val registry = spawn(ConsumerFilterRegistry())
+
+      val initFilter = Vector(ConsumerFilter.ExcludeEntityIds(Set("a", "c")))
+      registry ! ConsumerFilter.UpdateFilter(streamId, initFilter)
+
+      // before registering the subscriber it would retrieve the init filter
+      val currentProbe = createTestProbe[ConsumerFilter.CurrentFilter]()
+      registry ! ConsumerFilter.GetFilter(streamId, currentProbe.ref)
+      currentProbe.expectMessage(ConsumerFilter.CurrentFilter(streamId, initFilter))
+
+      // but it could be updated before it registers
+      val filter2 =
+        Vector(
+          ConsumerFilter.ExcludeEntityIds(Set("a", "b")),
+          ConsumerFilter.IncludeEntityIds(Set(ConsumerFilter.EntityIdOffset("b", 1))),
+          ConsumerFilter.RemoveExcludeEntityIds(Set("c")))
+      registry ! ConsumerFilter.UpdateFilter(streamId, filter2)
+
+      // let the update complete before registering the subscriber, but it will work otherwise as well
+      Thread.sleep(1000)
+
+      val subscriberProbe = createTestProbe[ConsumerFilter.SubscriberCommand]()
+      registry ! ConsumerFilter.Subscribe(streamId, initFilter, subscriberProbe.ref)
+
+      // diff between filter2 and initFilter
+      subscriberProbe.expectMessage(
+        ConsumerFilter.UpdateFilter(
+          streamId,
+          Vector(
+            ConsumerFilter.ExcludeEntityIds(Set("b")),
+            ConsumerFilter.RemoveExcludeEntityIds(Set("c")),
+            ConsumerFilter.IncludeEntityIds(Set(ConsumerFilter.EntityIdOffset("b", 1))))))
+    }
+  }
+
+}

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/ConsumerFilterStoreSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/ConsumerFilterStoreSpec.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.projection.grpc.internal
 
 import akka.actor.testkit.typed.scaladsl.LogCapturing
@@ -46,8 +47,7 @@ abstract class ConsumerFilterStoreSpec(implName: String)
       val filter =
         Vector(
           ConsumerFilter.ExcludeEntityIds(Set("a", "b", "c")),
-          ConsumerFilter.IncludeEntityIds(
-            Set(ConsumerFilter.EntityIdOffset("b", 1), ConsumerFilter.EntityIdOffset("b", 2))))
+          ConsumerFilter.IncludeEntityIds(Set(ConsumerFilter.EntityIdOffset("b", 1))))
       store1 ! ConsumerFilterStore.UpdateFilter(filter)
       notifyProbe.expectMessage(ConsumerFilterRegistry.FilterUpdated(streamId, filter))
       testKit.stop(store1)
@@ -67,29 +67,4 @@ class LocalConsumerFilterStoreSpec extends ConsumerFilterStoreSpec("LocalConsume
       new LocalConsumerFilterStore(context, streamId, notifyProbe.ref).behavior()
     })
   }
-
-  "additionally, LocalConsumerFilterStore" must {
-    "reduce filter" in {
-      val filter1 =
-        Vector(
-          ConsumerFilter.ExcludeEntityIds(Set("a", "b", "c")),
-          ConsumerFilter.IncludeEntityIds(
-            Set(ConsumerFilter.EntityIdOffset("b", 1), ConsumerFilter.EntityIdOffset("c", 2))))
-
-      val filter2 =
-        Vector(
-          ConsumerFilter.ExcludeEntityIds(Set("d")),
-          ConsumerFilter.RemoveIncludeEntityIds(Set("a", "b")),
-          ConsumerFilter.RemoveExcludeEntityIds(Set("c")))
-
-      val expectedFilter =
-        Vector(
-          ConsumerFilter.ExcludeEntityIds(Set("a", "b")),
-          ConsumerFilter.IncludeEntityIds(Set(ConsumerFilter.EntityIdOffset("c", 2))),
-          ConsumerFilter.ExcludeEntityIds(Set("d")))
-
-      LocalConsumerFilterStore.reduceFilter(filter1, filter2) shouldBe expectedFilter
-    }
-  }
-
 }

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/ConsumerFilterStoreSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/ConsumerFilterStoreSpec.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.projection.grpc.internal
+
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorRef
+import akka.actor.typed.scaladsl.Behaviors
+import akka.projection.grpc.consumer.ConsumerFilter
+import akka.projection.grpc.consumer.ConsumerFilter.CurrentFilter
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+abstract class ConsumerFilterStoreSpec(implName: String)
+    extends ScalaTestWithActorTestKit
+    with AnyWordSpecLike
+    with Matchers
+    with TestData
+    with LogCapturing {
+
+  val notifyProbe = createTestProbe[ConsumerFilterRegistry.FilterUpdated]()
+
+  private var streamIdCounter = 0
+  def nextStreamId(): String = {
+    streamIdCounter += 1
+    s"stream$streamIdCounter"
+  }
+
+  def spawnStore(streamId: String): ActorRef[ConsumerFilterStore.Command]
+
+  implName must {
+    "get empty filter" in {
+      val replyProbe = createTestProbe[ConsumerFilter.CurrentFilter]()
+      val streamId = nextStreamId()
+      val store = spawnStore(streamId)
+      store ! ConsumerFilterStore.GetFilter(replyProbe.ref)
+      replyProbe.expectMessage(CurrentFilter(streamId, Nil))
+      testKit.stop(store)
+    }
+
+    "update filter and keep filter state when spawning new store" in {
+      val replyProbe = createTestProbe[ConsumerFilter.CurrentFilter]()
+      val streamId = nextStreamId()
+      val store1 = spawnStore(streamId)
+      val filter =
+        Vector(
+          ConsumerFilter.ExcludeEntityIds(Set("a", "b", "c")),
+          ConsumerFilter.IncludeEntityIds(
+            Set(ConsumerFilter.EntityIdOffset("b", 1), ConsumerFilter.EntityIdOffset("b", 2))))
+      store1 ! ConsumerFilterStore.UpdateFilter(filter)
+      notifyProbe.expectMessage(ConsumerFilterRegistry.FilterUpdated(streamId, filter))
+      testKit.stop(store1)
+
+      val store2 = spawnStore(streamId)
+      store2 ! ConsumerFilterStore.GetFilter(replyProbe.ref)
+      replyProbe.expectMessage(CurrentFilter(streamId, filter))
+      testKit.stop(store2)
+    }
+  }
+
+}
+
+class LocalConsumerFilterStoreSpec extends ConsumerFilterStoreSpec("LocalConsumerFilterStore") {
+  override def spawnStore(streamId: String): ActorRef[ConsumerFilterStore.Command] = {
+    spawn(Behaviors.setup[ConsumerFilterStore.Command] { context =>
+      new LocalConsumerFilterStore(context, streamId, notifyProbe.ref).behavior()
+    })
+  }
+
+  "additionally, LocalConsumerFilterStore" must {
+    "reduce filter" in {
+      val filter1 =
+        Vector(
+          ConsumerFilter.ExcludeEntityIds(Set("a", "b", "c")),
+          ConsumerFilter.IncludeEntityIds(
+            Set(ConsumerFilter.EntityIdOffset("b", 1), ConsumerFilter.EntityIdOffset("c", 2))))
+
+      val filter2 =
+        Vector(
+          ConsumerFilter.ExcludeEntityIds(Set("d")),
+          ConsumerFilter.RemoveIncludeEntityIds(Set("a", "b")),
+          ConsumerFilter.RemoveExcludeEntityIds(Set("c")))
+
+      val expectedFilter =
+        Vector(
+          ConsumerFilter.ExcludeEntityIds(Set("a", "b")),
+          ConsumerFilter.IncludeEntityIds(Set(ConsumerFilter.EntityIdOffset("c", 2))),
+          ConsumerFilter.ExcludeEntityIds(Set("d")))
+
+      LocalConsumerFilterStore.reduceFilter(filter1, filter2) shouldBe expectedFilter
+    }
+  }
+
+}

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/EventProducerServiceSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/EventProducerServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022-2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.grpc.internal

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/FilterStageSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/FilterStageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022-2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.grpc.internal

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/ProtoAnySerializationSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/ProtoAnySerializationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022-2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.grpc.internal

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/TestData.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/TestData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022-2023 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.projection.grpc.internal

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/ConsumerFilter.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/ConsumerFilter.scala
@@ -7,7 +7,9 @@ package akka.projection.grpc.consumer
 import java.util.{ List => JList }
 import java.util.{ Set => JSet }
 
+import scala.annotation.tailrec
 import scala.collection.immutable
+import scala.collection.immutable.Set
 
 import akka.util.ccompat.JavaConverters._
 import akka.actor.typed.ActorRef
@@ -17,6 +19,8 @@ import akka.actor.typed.ExtensionId
 import akka.actor.typed.Props
 import akka.annotation.InternalApi
 import akka.projection.grpc.internal.ConsumerFilterRegistry
+
+// FIXME add ApiMayChange in all places
 
 /**
  * Extension to dynamically control the filters for the `GrpcReadJournal`.
@@ -139,6 +143,136 @@ object ConsumerFilter extends ExtensionId[ConsumerFilter] {
   final case class EntityIdOffset(entityId: String, seqNr: Long)
 
   override def createExtension(system: ActorSystem[_]): ConsumerFilter = new ConsumerFilter(system)
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] def mergeFilter(
+      currentFilter: immutable.Seq[FilterCriteria],
+      update: immutable.Seq[FilterCriteria]): immutable.Seq[FilterCriteria] = {
+
+    val both = currentFilter ++ update
+
+    val removeExcludeRegexEntityIds =
+      both.flatMap {
+        case rem: RemoveExcludeRegexEntityIds => rem.matching
+        case _                                => Set.empty
+      }.toSet
+    val excludeRegexEntityIds2 = excludeRegexEntityIds(both).diff(removeExcludeRegexEntityIds)
+
+    val removeExcludeEntityIds =
+      both.flatMap {
+        case rem: RemoveExcludeEntityIds => rem.entityIds
+        case _                           => Set.empty
+      }.toSet
+    val excludeEntityIds2 = excludeEntityIds(both).diff(removeExcludeEntityIds)
+
+    val removeIncludeEntityIds =
+      both.flatMap {
+        case rem: RemoveIncludeEntityIds => rem.entityIds
+        case _                           => Set.empty
+      }.toSet
+    val includeEntityOffsets2 = includeEntityOffsets(both).filterNot(x => removeIncludeEntityIds.contains(x.entityId))
+    val includeEntityOffsets3 = deduplicateEntityOffsets(includeEntityOffsets2.iterator, Map.empty)
+
+    Vector(
+      if (excludeRegexEntityIds2.isEmpty) None else Some(ExcludeRegexEntityIds(excludeRegexEntityIds2)),
+      if (excludeEntityIds2.isEmpty) None else Some(ExcludeEntityIds(excludeEntityIds2)),
+      if (includeEntityOffsets3.isEmpty) None else Some(IncludeEntityIds(includeEntityOffsets3))).flatten
+  }
+
+  // remove duplicates, use highest seqNr
+  @tailrec private def deduplicateEntityOffsets(
+      entityOffsets: Iterator[EntityIdOffset],
+      result: Map[String, EntityIdOffset]): Set[EntityIdOffset] = {
+    if (entityOffsets.hasNext) {
+      val offset = entityOffsets.next()
+      result.get(offset.entityId) match {
+        case None =>
+          deduplicateEntityOffsets(entityOffsets, result.updated(offset.entityId, offset))
+        case Some(o) =>
+          if (offset.seqNr > o.seqNr)
+            deduplicateEntityOffsets(entityOffsets, result.updated(offset.entityId, offset))
+          else
+            deduplicateEntityOffsets(entityOffsets, result)
+      }
+    } else {
+      result.values.toSet
+    }
+  }
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] def createDiff(
+      a: immutable.Seq[FilterCriteria],
+      b: immutable.Seq[FilterCriteria]): immutable.Seq[FilterCriteria] = {
+
+    val excludeRegexEntityIdsA = excludeRegexEntityIds(a)
+    val excludeRegexEntityIdsB = excludeRegexEntityIds(b)
+    val excludeRegexEntityIdsDiffAB = excludeRegexEntityIdsA.diff(excludeRegexEntityIdsB)
+    val excludeRegexEntityIdsDiffBA = excludeRegexEntityIdsB.diff(excludeRegexEntityIdsA)
+    val excludeRegexEntityIdCriteria =
+      if (excludeRegexEntityIdsDiffBA.isEmpty) None else Some(ExcludeRegexEntityIds(excludeRegexEntityIdsDiffBA))
+    val removeExcludeRegexEntityIdCriteria =
+      if (excludeRegexEntityIdsDiffAB.isEmpty) None else Some(RemoveExcludeRegexEntityIds(excludeRegexEntityIdsDiffAB))
+
+    val excludeEntityIdsA = excludeEntityIds(a)
+    val excludeEntityIdsB = excludeEntityIds(b)
+    val excludeEntityIdsDiffAB = excludeEntityIdsA.diff(excludeEntityIdsB)
+    val excludeEntityIdsDiffBA = excludeEntityIdsB.diff(excludeEntityIdsA)
+    val excludeEntityIdCriteria =
+      if (excludeEntityIdsDiffBA.isEmpty) None else Some(ExcludeEntityIds(excludeEntityIdsDiffBA))
+    val removeExcludeEntityIdCriteria =
+      if (excludeEntityIdsDiffAB.isEmpty) None else Some(RemoveExcludeEntityIds(excludeEntityIdsDiffAB))
+
+    val includeEntityOffsetsA = includeEntityOffsets(a).map(x => x.entityId -> x).toMap
+    val includeEntityOffsetsB = includeEntityOffsets(b).map(x => x.entityId -> x).toMap
+    val includeEntityOffsetsDiffAB = includeEntityOffsetsA.filter {
+      case (entityId, _) => !includeEntityOffsetsB.contains(entityId)
+    }
+    val includeEntityOffsetsDiffBA = includeEntityOffsetsB.filter {
+      case (entityId, offsetB) =>
+        includeEntityOffsetsA.get(entityId) match {
+          case None          => true
+          case Some(offsetA) => offsetB.seqNr > offsetA.seqNr
+        }
+    }
+    val includeEntityIdCriteria =
+      if (includeEntityOffsetsDiffBA.isEmpty) None else Some(IncludeEntityIds(includeEntityOffsetsDiffBA.values.toSet))
+    val removeIncludeEntityIdCriteria =
+      if (includeEntityOffsetsDiffAB.isEmpty) None else Some(RemoveIncludeEntityIds(includeEntityOffsetsDiffAB.keySet))
+
+    Vector(
+      excludeRegexEntityIdCriteria,
+      removeExcludeRegexEntityIdCriteria,
+      excludeEntityIdCriteria,
+      removeExcludeEntityIdCriteria,
+      includeEntityIdCriteria,
+      removeIncludeEntityIdCriteria).flatten
+
+  }
+
+  private def includeEntityOffsets(filter: Seq[FilterCriteria]): Set[EntityIdOffset] = {
+    filter.flatMap {
+      case inc: IncludeEntityIds => inc.entityOffsets
+      case _                     => Set.empty
+    }.toSet
+  }
+
+  private def excludeEntityIds(filter: Seq[FilterCriteria]): Set[String] = {
+    filter.flatMap {
+      case exl: ExcludeEntityIds => exl.entityIds
+      case _                     => Set.empty
+    }.toSet
+  }
+
+  private def excludeRegexEntityIds(filter: Seq[FilterCriteria]): Set[String] = {
+    filter.flatMap {
+      case rxp: ExcludeRegexEntityIds => rxp.matching
+      case _                          => Set.empty
+    }.toSet
+  }
 
 }
 

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/ConsumerFilter.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/ConsumerFilter.scala
@@ -33,8 +33,15 @@ object ConsumerFilter extends ExtensionId[ConsumerFilter] {
 
   /**
    * INTERNAL API
+   *
+   * Before registering the subscriber it would retrieve the current filter with `GetFilter`.
+   * That init filter is then included in the `Subscribe.initCriteria`, to be used as starting point for evaluating
+   * the diff for that subscriber.
    */
-  @InternalApi private[akka] final case class Subscribe(streamId: String, subscriber: ActorRef[SubscriberCommand])
+  @InternalApi private[akka] final case class Subscribe(
+      streamId: String,
+      initCriteria: immutable.Seq[FilterCriteria],
+      subscriber: ActorRef[SubscriberCommand])
       extends Command
 
   /**

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/ConsumerFilterStore.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/ConsumerFilterStore.scala
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.grpc.internal
+
+import java.util.ConcurrentModificationException
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.collection.immutable
+
+import akka.actor.ExtendedActorSystem
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Behavior
+import akka.actor.typed.Extension
+import akka.actor.typed.ExtensionId
+import akka.actor.typed.SupervisorStrategy
+import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.scaladsl.Behaviors
+import akka.annotation.InternalApi
+import akka.projection.grpc.consumer.ConsumerFilter
+import akka.projection.grpc.consumer.ConsumerFilter.FilterCriteria
+import akka.projection.grpc.internal.LocalConsumerFilterStore.reduceFilter
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object ConsumerFilterStore {
+  sealed trait Command
+
+  final case class UpdateFilter(criteria: immutable.Seq[FilterCriteria]) extends Command
+
+  final case class GetFilter(replyTo: ActorRef[ConsumerFilter.CurrentFilter]) extends Command
+
+  private def useDistributedData(system: ActorSystem[_]): Boolean = {
+    system.classicSystem
+      .asInstanceOf[ExtendedActorSystem]
+      .provider
+      .getClass
+      .getName == "akka.cluster.ClusterActorRefProvider" &&
+    system.dynamicAccess.getClassFor("akka.cluster.ddata.typed.scaladsl.DistributedData").isSuccess
+  }
+
+  def apply(
+      system: ActorSystem[_],
+      streamId: String,
+      notifyUpdatesTo: ActorRef[ConsumerFilterRegistry.FilterUpdated]): Behavior[Command] = {
+    // ddata dependency is optional
+    if (useDistributedData(system)) {
+      Behaviors
+        .supervise[Command] {
+          Behaviors.setup { context =>
+            // FIXME DdataConsumerFilterStore have to be created with dynamicAccess?
+            new LocalConsumerFilterStore(context, streamId, notifyUpdatesTo).behavior()
+          }
+        }
+        .onFailure(SupervisorStrategy.restart)
+    } else {
+      Behaviors
+        .supervise[Command] {
+          Behaviors.setup { context =>
+            new LocalConsumerFilterStore(context, streamId, notifyUpdatesTo).behavior()
+          }
+        }
+        .onFailure(SupervisorStrategy.restart)
+    }
+  }
+
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object LocalConsumerFilterStore {
+  private object StoreExt extends ExtensionId[StoreExt] {
+    override def createExtension(system: ActorSystem[_]): StoreExt = new StoreExt
+  }
+
+  private class StoreExt extends Extension {
+    val filtersByStreamId = new ConcurrentHashMap[String, immutable.Seq[FilterCriteria]]
+  }
+
+  def reduceFilter(
+      filterCriteria: immutable.Seq[FilterCriteria],
+      update: immutable.Seq[FilterCriteria]): immutable.Seq[FilterCriteria] = {
+    update.foldLeft(filterCriteria) {
+      case (acc, ConsumerFilter.RemoveIncludeEntityIds(entityIds)) =>
+        acc.flatMap {
+          case inc: ConsumerFilter.IncludeEntityIds =>
+            val newEntityOffsets = inc.entityOffsets.filterNot(x => entityIds.contains(x.entityId))
+            if (newEntityOffsets.isEmpty) None
+            else Some(ConsumerFilter.IncludeEntityIds(newEntityOffsets))
+          case other => Some(other)
+        }
+
+      case (acc, ConsumerFilter.RemoveExcludeEntityIds(entityIds)) =>
+        acc.flatMap {
+          case excl: ConsumerFilter.ExcludeEntityIds =>
+            val newEntityIds = excl.entityIds.diff(entityIds)
+            if (newEntityIds.isEmpty) None
+            else Some(ConsumerFilter.ExcludeEntityIds(newEntityIds))
+          case other => Some(other)
+        }
+
+      case (acc, ConsumerFilter.RemoveExcludeRegexEntityIds(matching)) =>
+        acc.flatMap {
+          case excl: ConsumerFilter.RemoveExcludeRegexEntityIds =>
+            val newMatching = excl.matching.diff(matching)
+            if (newMatching.isEmpty) None
+            else Some(ConsumerFilter.ExcludeEntityIds(newMatching))
+          case other => Some(other)
+        }
+
+      case (acc, other) =>
+        acc :+ other
+    }
+  }
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] class LocalConsumerFilterStore(
+    context: ActorContext[ConsumerFilterStore.Command],
+    streamId: String,
+    notifyUpdatesTo: ActorRef[ConsumerFilterRegistry.FilterUpdated]) {
+  import ConsumerFilterStore._
+
+  // The state must survive the actor lifecycle so keeping the state in an Extension. Single writer per streamId.
+  private val storeExt = LocalConsumerFilterStore.StoreExt(context.system)
+
+  def getState(): immutable.Seq[FilterCriteria] = {
+    storeExt.filtersByStreamId.computeIfAbsent(streamId, _ => Vector.empty[FilterCriteria])
+  }
+
+  def setState(old: immutable.Seq[FilterCriteria], filterCriteria: immutable.Seq[FilterCriteria]): Unit = {
+    if (!storeExt.filtersByStreamId.replace(streamId, old, filterCriteria))
+      throw new ConcurrentModificationException(s"Unexpected concurrent update of streamId [$streamId]")
+  }
+
+  def behavior(): Behavior[Command] = {
+    Behaviors.receiveMessage {
+      case UpdateFilter(updatedCriteria) =>
+        val oldFilterCriteria = getState()
+        val newFilterCriteria = reduceFilter(oldFilterCriteria, updatedCriteria)
+        setState(oldFilterCriteria, newFilterCriteria)
+
+        notifyUpdatesTo ! ConsumerFilterRegistry.FilterUpdated(streamId, newFilterCriteria)
+
+        Behaviors.same
+
+      case GetFilter(replyTo) =>
+        replyTo ! ConsumerFilter.CurrentFilter(streamId, getState())
+        Behaviors.same
+    }
+  }
+}
+
+/**
+ * INTERNAL API
+ */
+// FIXME
+//@InternalApi private[akka] class DdataConsumerFilterStore(
+//    context: ActorContext[ConsumerFilterStore.Command],
+//    streamId: String,
+//    notifyUpdatesTo: ActorRef[ConsumerFilterRegistry.FilterUpdated]) {
+//  import ConsumerFilterStore._
+//
+//  // FIXME
+//
+//  def behavior(): Behavior[Command] = ???
+//}

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/FilterStage.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/FilterStage.scala
@@ -215,6 +215,8 @@ import akka.stream.stage.StageLogging
                 acc
             }
         }
+        // FIXME might be too much logging if it includes many ids
+        log.debug("Stream [{}]: updated filter to [{}}]", logPrefix, filter)
       }
 
       private def handledByThisStream(pid: PersistenceId): Boolean = {


### PR DESCRIPTION
* When a filter is added via the ConsumerFilter extension it should be propagated to other streams with the same streamId, also other nodes in the (consumer side) cluster, and FilterReq submitted to each stream. The filter state must also be “stored” so that it can be retrieved when a new stream is started.
* This adds local alternative, when cluster isn't used on the consumer side.
* ddata implemenation will come in separate PR.
