### PR TITLE
bump(tests): logback 1.3.6 (was 1.2.11) and lock minor version

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -11,6 +11,8 @@ updates.ignore = [
   { groupId = "com.typesafe.slick" }
   
   {groupId = "com.fasterxml.jackson.core" }
+  # Logback 1.4 requires JDK11
+  { groupId = "ch.qos.logback", artifactId = "logback-classic", version = "1.3." }
 ]
 
 updatePullRequests = false

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -90,7 +90,7 @@ object Dependencies {
     val msSQLServerDriver = "com.microsoft.sqlserver" % "mssql-jdbc" % "7.4.1.jre8" % allTestConfig
     val oracleDriver = "com.oracle.ojdbc" % "ojdbc8" % "19.3.0.0" % allTestConfig
 
-    val logback = "ch.qos.logback" % "logback-classic" % "1.2.11" % allTestConfig
+    val logback = "ch.qos.logback" % "logback-classic" % "1.3.6" % allTestConfig
 
     val cassandraContainer =
       "org.testcontainers" % "cassandra" % Versions.testContainers % allTestConfig

--- a/samples/grpc/shopping-analytics-service-java/pom.xml
+++ b/samples/grpc/shopping-analytics-service-java/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.11</version>
+            <version>1.3.6</version>
         </dependency>
 
         <dependency>

--- a/samples/grpc/shopping-analytics-service-scala/build.sbt
+++ b/samples/grpc/shopping-analytics-service-scala/build.sbt
@@ -2,8 +2,7 @@ name := "shopping-analytics-service"
 
 organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
-licenses := Seq(
-  ("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
+licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
 scalaVersion := "2.13.10"
 
@@ -60,7 +59,7 @@ libraryDependencies ++= Seq(
   "com.lightbend.akka" %% "akka-diagnostics" % AkkaDiagnosticsVersion,
   // Common dependencies for logging and testing
   "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-  "ch.qos.logback" % "logback-classic" % "1.2.11",
+  "ch.qos.logback" % "logback-classic" % "1.3.6",
   "org.scalatest" %% "scalatest" % "3.1.2" % Test,
   // 2. Using gRPC and/or protobuf
   "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion,

--- a/samples/grpc/shopping-cart-service-java/pom.xml
+++ b/samples/grpc/shopping-cart-service-java/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.11</version>
+            <version>1.3.6</version>
         </dependency>
 
         <dependency>

--- a/samples/grpc/shopping-cart-service-scala/build.sbt
+++ b/samples/grpc/shopping-cart-service-scala/build.sbt
@@ -2,8 +2,7 @@ name := "shopping-cart-service"
 
 organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
-licenses := Seq(
-  ("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
+licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
 scalaVersion := "2.13.10"
 
@@ -60,7 +59,7 @@ libraryDependencies ++= Seq(
   "com.lightbend.akka" %% "akka-diagnostics" % AkkaDiagnosticsVersion,
   // Common dependencies for logging and testing
   "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-  "ch.qos.logback" % "logback-classic" % "1.2.11",
+  "ch.qos.logback" % "logback-classic" % "1.3.6",
   "org.scalatest" %% "scalatest" % "3.1.2" % Test,
   // 2. Using gRPC and/or protobuf
   "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion,

--- a/samples/replicated/shopping-cart-service-java/pom.xml
+++ b/samples/replicated/shopping-cart-service-java/pom.xml
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.11</version>
+            <version>1.3.6</version>
         </dependency>
 
         <dependency>

--- a/samples/replicated/shopping-cart-service-scala/build.sbt
+++ b/samples/replicated/shopping-cart-service-scala/build.sbt
@@ -2,13 +2,13 @@ name := "shopping-cart-service"
 
 organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
-licenses := Seq(
-  ("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
+licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
 scalaVersion := "2.13.10"
 
 Compile / scalacOptions ++= Seq(
-  "-release", "11",
+  "-release",
+  "11",
   "-deprecation",
   "-feature",
   "-unchecked",
@@ -60,7 +60,7 @@ libraryDependencies ++= Seq(
   "com.lightbend.akka" %% "akka-diagnostics" % AkkaDiagnosticsVersion,
   // Common dependencies for logging and testing
   "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-  "ch.qos.logback" % "logback-classic" % "1.2.11",
+  "ch.qos.logback" % "logback-classic" % "1.3.6",
   "org.scalatest" %% "scalatest" % "3.1.2" % Test,
   // 2. Using gRPC and/or protobuf
   "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion,


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References
- #811
