### PR TITLE
feat: consumer filter with tags

### DIFF
--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/ConsumerFilterStoreSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/ConsumerFilterStoreSpec.scala
@@ -67,6 +67,7 @@ abstract class ConsumerFilterStoreSpec(implName: String, config: Config)
       val store = spawnStore(streamId)
       val filter1 =
         Vector(
+          ConsumerFilter.ExcludeTags(Set("t1", "t2")),
           ConsumerFilter.ExcludeEntityIds(Set("a", "b", "c")),
           ConsumerFilter.IncludeEntityIds(Set(ConsumerFilter.EntityIdOffset("b", 1))))
       store ! ConsumerFilterStore.UpdateFilter(filter1)
@@ -74,11 +75,13 @@ abstract class ConsumerFilterStoreSpec(implName: String, config: Config)
 
       val filter2 =
         Vector(
+          ConsumerFilter.RemoveExcludeTags(Set("t2")),
           ConsumerFilter.ExcludeEntityIds(Set("d")),
           ConsumerFilter.RemoveExcludeEntityIds(Set("c")),
           ConsumerFilter.RemoveIncludeEntityIds(Set("b")))
       store ! ConsumerFilterStore.UpdateFilter(filter2)
-      val expectedFilter = Vector(ConsumerFilter.ExcludeEntityIds(Set("a", "b", "d")))
+      val expectedFilter =
+        Vector(ConsumerFilter.ExcludeTags(Set("t1")), ConsumerFilter.ExcludeEntityIds(Set("a", "b", "d")))
       notifyProbe.expectMessage(ConsumerFilterRegistry.FilterUpdated(streamId, expectedFilter))
 
       store ! ConsumerFilterStore.GetFilter(replyProbe.ref)

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/ConsumerSerializerSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/ConsumerSerializerSpec.scala
@@ -25,12 +25,16 @@ class ConsumerSerializerSpec extends ScalaTestWithActorTestKit with AnyWordSpecL
 
   private val filter1 =
     Vector(
+      ConsumerFilter.ExcludeTags(Set("t1", "t2")),
+      ConsumerFilter.IncludeTags(Set("t3", "t4")),
       ConsumerFilter.ExcludeRegexEntityIds(Set("all.*")),
       ConsumerFilter.ExcludeEntityIds(Set("a", "b", "c")),
       ConsumerFilter.IncludeEntityIds(Set(ConsumerFilter.EntityIdOffset("b", 1))))
 
   private val filter2 =
     Vector(
+      ConsumerFilter.RemoveExcludeTags(Set("t2")),
+      ConsumerFilter.RemoveIncludeTags(Set("t4")),
       ConsumerFilter.ExcludeEntityIds(Set("d")),
       ConsumerFilter.RemoveExcludeEntityIds(Set("c")),
       ConsumerFilter.RemoveIncludeEntityIds(Set("b")),

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/FilterSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/FilterSpec.scala
@@ -4,40 +4,70 @@
 
 package akka.projection.grpc.internal
 
+import java.time.Instant
+
+import akka.persistence.query.TimestampOffset
+import akka.persistence.query.typed.EventEnvelope
+import akka.persistence.typed.PersistenceId
 import akka.projection.grpc.internal.FilterStage.Filter
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class FilterSpec extends AnyWordSpecLike with Matchers {
+
+  private def createEnvelope(pid: String, tags: Set[String] = Set.empty): EventEnvelope[Any] = {
+    val slice = math.abs(pid.hashCode % 1024)
+    val seqNr = 1
+    val now = Instant.now()
+    EventEnvelope(
+      TimestampOffset(Instant.now, Map(pid -> seqNr)),
+      pid,
+      seqNr,
+      "evt",
+      now.toEpochMilli,
+      PersistenceId.extractEntityType(pid),
+      slice,
+      filtered = false,
+      source = "",
+      tags = tags)
+  }
+
   "Filter" should {
     "include with empty filter" in {
-      Filter.empty.matches("pid-1") shouldBe true
+      Filter.empty.matches(createEnvelope("pid")) shouldBe true
     }
 
     "honor include after exclude" in {
       val filter =
-        Filter.empty.addIncludePersistenceIds(Set("pid-1", "pid-3")).addExcludePersistenceIds(Set("pid-3", "pid-2"))
-      filter.matches("pid-1") shouldBe true
-      filter.matches("pid-2") shouldBe false
-      filter.matches("pid-3") shouldBe true
+        Filter.empty
+          .addIncludePersistenceIds(Set("pid-1", "pid-3"))
+          .addExcludePersistenceIds(Set("pid-3", "pid-2"))
+          .addIncludeTags(Set("a"))
+          .addExcludeTags(Set("a", "b"))
+      filter.matches(createEnvelope("pid-1")) shouldBe true
+      filter.matches(createEnvelope("pid-2")) shouldBe false
+      filter.matches(createEnvelope("pid-3")) shouldBe true
+      filter.matches(createEnvelope("pid-4", tags = Set("b"))) shouldBe false
+      filter.matches(createEnvelope("pid-5", tags = Set("a"))) shouldBe true
+      filter.matches(createEnvelope("pid-6", tags = Set("a", "b"))) shouldBe true
     }
 
     "exclude with regexp" in {
       val filter =
         Filter.empty.addIncludePersistenceIds(Set("Entity|a-1", "Entity|a-2")).addExcludeRegexEntityIds(List("a-.*"))
-      filter.matches("Entity|a-1") shouldBe true
-      filter.matches("Entity|a-2") shouldBe true
-      filter.matches("Entity|a-3") shouldBe false
-      filter.matches("Entity|b-1") shouldBe true
+      filter.matches(createEnvelope("Entity|a-1")) shouldBe true
+      filter.matches(createEnvelope("Entity|a-2")) shouldBe true
+      filter.matches(createEnvelope("Entity|a-3")) shouldBe false
+      filter.matches(createEnvelope("Entity|b-1")) shouldBe true
     }
 
     "remove criteria" in {
       val filter =
         Filter.empty.addIncludePersistenceIds(Set("pid-1", "pid-3")).addExcludePersistenceIds(Set("pid-3", "pid-2"))
-      filter.matches("pid-1") shouldBe true
-      filter.matches("pid-3") shouldBe true
+      filter.matches(createEnvelope("pid-1")) shouldBe true
+      filter.matches(createEnvelope("pid-3")) shouldBe true
       val filter2 = filter.removeIncludePersistenceIds(Set("pid-3"))
-      filter2.matches("pid-3") shouldBe false
+      filter2.matches(createEnvelope("pid-3")) shouldBe false
     }
   }
 

--- a/akka-projection-grpc/src/main/protobuf/akka/projection/grpc/consumer.proto
+++ b/akka-projection-grpc/src/main/protobuf/akka/projection/grpc/consumer.proto
@@ -9,10 +9,14 @@ option optimize_for = SPEED;
 
 message ConsumerFilterStoreState {
   // ORSet serialized with Akka's ReplicatedDataSerializer
-  bytes exclude_regex_entity_ids = 1;
+  bytes exclude_tags = 1;
   // ORSet serialized with Akka's ReplicatedDataSerializer
-  bytes exclude_entity_ids = 2;
-  SeqNrMap include_entity_offsets = 3;
+  bytes include_tags = 2;
+  // ORSet serialized with Akka's ReplicatedDataSerializer
+  bytes exclude_regex_entity_ids = 3;
+  // ORSet serialized with Akka's ReplicatedDataSerializer
+  bytes exclude_entity_ids = 4;
+  SeqNrMap include_entity_offsets = 5;
 }
 
 message SeqNrMap {

--- a/akka-projection-grpc/src/main/protobuf/akka/projection/grpc/event_producer.proto
+++ b/akka-projection-grpc/src/main/protobuf/akka/projection/grpc/event_producer.proto
@@ -57,13 +57,33 @@ message FilterCriteria {
   //   If no matching include the event is discarded.
   //   If matching include the event is emitted.
   oneof message {
-    ExcludeRegexEntityIds exclude_matching_entity_ids = 1;
-    RemoveExcludeRegexEntityIds remove_exclude_matching_entity_ids = 2;
-    ExcludeEntityIds exclude_entity_ids = 3;
-    RemoveExcludeEntityIds remove_exclude_entity_ids = 4;
-    IncludeEntityIds include_entity_ids = 5;
-    RemoveIncludeEntityIds remove_include_entity_ids = 6;
+    ExcludeTags exclude_tags = 1;
+    RemoveExcludeTags remove_exclude_tags = 2;
+    IncludeTags include_tags = 3;
+    RemoveIncludeTags remove_include_tags = 4;
+    ExcludeRegexEntityIds exclude_matching_entity_ids = 5;
+    RemoveExcludeRegexEntityIds remove_exclude_matching_entity_ids = 6;
+    ExcludeEntityIds exclude_entity_ids = 7;
+    RemoveExcludeEntityIds remove_exclude_entity_ids = 8;
+    IncludeEntityIds include_entity_ids = 9;
+    RemoveIncludeEntityIds remove_include_entity_ids = 10;
   }
+}
+
+message ExcludeTags {
+  repeated string tags = 1;
+}
+
+message RemoveExcludeTags {
+  repeated string tags = 1;
+}
+
+message IncludeTags {
+  repeated string tags = 1;
+}
+
+message RemoveIncludeTags {
+  repeated string tags = 1;
 }
 
 message IncludeEntityIds {

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
@@ -6,9 +6,11 @@ package akka.projection.grpc.consumer.scaladsl
 
 import java.time.Instant
 import java.util.concurrent.TimeUnit
+
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+
 import akka.Done
 import akka.NotUsed
 import akka.actor.ClassicActorSystemProvider
@@ -44,17 +46,21 @@ import akka.projection.grpc.internal.proto.EventProducerServiceClient
 import akka.projection.grpc.internal.proto.EventTimestampRequest
 import akka.projection.grpc.internal.proto.ExcludeEntityIds
 import akka.projection.grpc.internal.proto.ExcludeRegexEntityIds
+import akka.projection.grpc.internal.proto.ExcludeTags
 import akka.projection.grpc.internal.proto.FilterCriteria
 import akka.projection.grpc.internal.proto.FilterReq
 import akka.projection.grpc.internal.proto.FilteredEvent
 import akka.projection.grpc.internal.proto.IncludeEntityIds
+import akka.projection.grpc.internal.proto.IncludeTags
 import akka.projection.grpc.internal.proto.InitReq
 import akka.projection.grpc.internal.proto.LoadEventRequest
 import akka.projection.grpc.internal.proto.LoadEventResponse
 import akka.projection.grpc.internal.proto.PersistenceIdSeqNr
 import akka.projection.grpc.internal.proto.RemoveExcludeEntityIds
 import akka.projection.grpc.internal.proto.RemoveExcludeRegexEntityIds
+import akka.projection.grpc.internal.proto.RemoveExcludeTags
 import akka.projection.grpc.internal.proto.RemoveIncludeEntityIds
+import akka.projection.grpc.internal.proto.RemoveIncludeTags
 import akka.projection.grpc.internal.proto.ReplayReq
 import akka.projection.grpc.internal.proto.StreamIn
 import akka.projection.grpc.internal.proto.StreamOut
@@ -376,6 +382,14 @@ final class GrpcReadJournal private (
 
   private def toProtoFilterCriteria(criteria: immutable.Seq[ConsumerFilter.FilterCriteria]): Seq[FilterCriteria] = {
     criteria.map {
+      case ConsumerFilter.ExcludeTags(tags) =>
+        FilterCriteria(FilterCriteria.Message.ExcludeTags(ExcludeTags(tags.toVector)))
+      case ConsumerFilter.RemoveExcludeTags(tags) =>
+        FilterCriteria(FilterCriteria.Message.RemoveExcludeTags(RemoveExcludeTags(tags.toVector)))
+      case ConsumerFilter.IncludeTags(tags) =>
+        FilterCriteria(FilterCriteria.Message.IncludeTags(IncludeTags(tags.toVector)))
+      case ConsumerFilter.RemoveIncludeTags(tags) =>
+        FilterCriteria(FilterCriteria.Message.RemoveIncludeTags(RemoveIncludeTags(tags.toVector)))
       case ConsumerFilter.IncludeEntityIds(entityOffsets) =>
         FilterCriteria(FilterCriteria.Message.IncludeEntityIds(IncludeEntityIds(entityOffsets.map {
           case ConsumerFilter.EntityIdOffset(entityId, seqNr) => EntityIdOffset(entityId, seqNr)

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/ConsumerSerializer.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/ConsumerSerializer.scala
@@ -77,12 +77,18 @@ import scalapb.GeneratedMessage
   }
 
   private def stateToProto(state: DdataConsumerFilterStore.State): proto.ConsumerFilterStoreState = {
-
+    val excludeTagsBytes = orsetToBytes(state.excludeTags)
+    val includeTagsBytes = orsetToBytes(state.includeTags)
     val excludeRegexEntityIdsBytes = orsetToBytes(state.excludeRegexEntityIds)
     val excludeEntityIdsBytes = orsetToBytes(state.excludeEntityIds)
     val seqNrMap = Some(seqNrMapToProto(state.includeEntityOffsets))
 
-    proto.ConsumerFilterStoreState(excludeRegexEntityIdsBytes, excludeEntityIdsBytes, seqNrMap)
+    proto.ConsumerFilterStoreState(
+      excludeTagsBytes,
+      includeTagsBytes,
+      excludeRegexEntityIdsBytes,
+      excludeEntityIdsBytes,
+      seqNrMap)
   }
 
   private def seqNrMapToProto(seqNrMap: DdataConsumerFilterStore.SeqNrMap): proto.SeqNrMap = {
@@ -96,13 +102,20 @@ import scalapb.GeneratedMessage
 
   private def stateFromBinary(bytes: Array[Byte]): DdataConsumerFilterStore.State = {
     val protoState = proto.ConsumerFilterStoreState.parseFrom(bytes)
+    val excludeTags = orsetFromBinary(protoState.excludeTags.toByteArray)
+    val includeTags = orsetFromBinary(protoState.includeTags.toByteArray)
     val excludeRegexEntityIds = orsetFromBinary(protoState.excludeRegexEntityIds.toByteArray)
     val excludeEntityIds = orsetFromBinary(protoState.excludeEntityIds.toByteArray)
     val includeEntityOffsets = protoState.includeEntityOffsets match {
       case Some(protoSeqNrMap) => seqNrMapFromProto(protoSeqNrMap)
       case None                => DdataConsumerFilterStore.SeqNrMap.empty
     }
-    DdataConsumerFilterStore.State(excludeRegexEntityIds, excludeEntityIds, includeEntityOffsets)
+    DdataConsumerFilterStore.State(
+      excludeTags,
+      includeTags,
+      excludeRegexEntityIds,
+      excludeEntityIds,
+      includeEntityOffsets)
   }
 
   private def seqNrMapFromProto(protoSeqNrMap: proto.SeqNrMap): DdataConsumerFilterStore.SeqNrMap = {


### PR DESCRIPTION
* following the same pattern as the other consumer filters
  * exclude tags
  * remove exclude tags
  * include tags
  * remove include tags
* when a new entity is "activated" via a tag that will trigger a replay because the offset store doesn't accept unknown/unexpected sequence number (same mechanism as we have for the producer filters) 
