### PR TITLE
doc: Reference docs of filters

### DIFF
--- a/akka-projection-grpc/src/main/protobuf/akka/projection/grpc/event_producer.proto
+++ b/akka-projection-grpc/src/main/protobuf/akka/projection/grpc/event_producer.proto
@@ -52,10 +52,10 @@ message ReplayReq {
 
 message FilterCriteria {
   // Exclude criteria are evaluated first.
-  // If no matching exclude the event is emitted.
-  // If an exclude is matching the include criteria are evaluated.
-  //   If no matching include the event is discarded.
-  //   If matching include the event is emitted.
+  // If no matching exclude criteria the event is emitted.
+  // If an exclude criteria is matching the include criteria are evaluated.
+  //   If no matching include criteria the event is discarded.
+  //   If matching include criteria the event is emitted.
   oneof message {
     ExcludeTags exclude_tags = 1;
     RemoveExcludeTags remove_exclude_tags = 2;

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/ConsumerFilter.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/ConsumerFilter.scala
@@ -55,10 +55,10 @@ object ConsumerFilter extends ExtensionId[ConsumerFilter] {
    * Add or remove filter criteria.
    *
    * Exclude criteria are evaluated first.
-   * If no matching exclude the event is emitted.
-   * If an exclude is matching the include criteria are evaluated.
-   * If no matching include the event is discarded.
-   * If matching include the event is emitted.
+   * If no matching exclude criteria the event is emitted.
+   * If an exclude criteria is matching the include criteria are evaluated.
+   * If no matching include criteria the event is discarded.
+   * If matching include criteria the event is emitted.
    */
   final case class UpdateFilter(streamId: String, criteria: immutable.Seq[FilterCriteria]) extends SubscriberCommand {
 

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/FilterStage.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/FilterStage.scala
@@ -84,9 +84,9 @@ import org.slf4j.LoggerFactory
 
     /**
      * Exclude criteria are evaluated first.
-     * Returns `true` if no matching exclude.
-     * If an exclude is matching the include criteria are evaluated.
-     * Returns `true` if there is a matching include, otherwise `false`.
+     * Returns `true` if no matching exclude criteria.
+     * If an exclude criteria is matching the include criteria are evaluated.
+     * Returns `true` if there is a matching include criteria, otherwise `false`.
      */
     def matches(env: EventEnvelope[_]): Boolean = {
       val pid = env.persistenceId

--- a/docs/src/main/paradox/grpc-replicated-event-sourcing-transport.md
+++ b/docs/src/main/paradox/grpc-replicated-event-sourcing-transport.md
@@ -177,6 +177,30 @@ For some scenarios it may be necessary to do a two-step deploy of format changes
 for a new serialization format so that all replicas can deserialize it, then a second deploy where the new field is actually
 populated with data.
 
+## Filters
+
+By default, events from all Replicated Event Sourced entities are replicated.
+
+The same kind of filters as described in @ref:[Akka Projection gRPC Filters](grpc.md#filters) can be used for
+Replicated Event Sourcing.
+
+The producer defined filter:
+
+Scala
+:  @@snip [ShoppingCart.scala](/samples/replicated/shopping-cart-service-scala/src/main/scala/shopping/cart/ShoppingCart.scala) { #init }
+
+Java
+:  @@snip [ShoppingCart.java](/samples/replicated/shopping-cart-service-java/src/main/java/shopping/cart/ShoppingCart.java) { #init }
+
+Consumer defined filters are updated as described in @ref:[Akka Projection gRPC Consumer defined filter](grpc.md#consumer-defined-filter)
+
+One thing to note is that `streamId` is always the same as the `entityType` when using Replicated Event Sourcing.
+
+The entity id based filter criteria must include the replica id as suffix to the entity id, with `|` separator.
+
+Replicated Event Sourcing is bidirectional replication, and therefore you would typically have to define the same
+filters on both sides. That is not handled automatically.
+
 ## Sample projects
 
 Source code and build files for complete sample projects can be found in the `akka/akka-projection` GitHub repository.

--- a/docs/src/main/paradox/grpc.md
+++ b/docs/src/main/paradox/grpc.md
@@ -229,8 +229,12 @@ To remove a filter criteria you would use the corresponding @apidoc[ConsumerFilt
 The updated filter is kept and remains after restarts of the Projection instances. If the consumer side is
 running with Akka Cluster the filter is propagated to other nodes in the cluster automatically with
 Akka Distributed Data. You only have to update at one place and it will be applied to all running Projections
-with the given `streamId`. The filters will be cleared in case of a full Cluster stop, which means that you
+with the given `streamId`.
+
+@@@ warning
+The filters will be cleared in case of a full Cluster stop, which means that you
 need to take care of populating the initial filters at startup.
+@@@
 
 See @apidoc[ConsumerFilter] for full API documentation.
 

--- a/docs/src/main/paradox/grpc.md
+++ b/docs/src/main/paradox/grpc.md
@@ -190,10 +190,10 @@ Consumer filters consists of exclude and include criteria. In short, the exclude
 may be overridden by an include criteria. More precisely, they are evaluated according to the following rules: 
 
 * Exclude criteria are evaluated first.
-* If no matching exclude the event is emitted.
-* If an exclude is matching the include criteria are evaluated.
-* If no matching include the event is discarded.
-* If matching include the event is emitted.
+* If no matching exclude criteria the event is emitted.
+* If an exclude criteria is matching the include criteria are evaluated.
+* If no matching include criteria the event is discarded.
+* If matching include criteria the event is emitted.
 
 The exclude criteria can be a combination of:
 

--- a/docs/src/main/paradox/grpc.md
+++ b/docs/src/main/paradox/grpc.md
@@ -172,7 +172,7 @@ In this example the decision is based on tags, but the filter function can use a
 on the total quantity of the shopping cart, which requires the full state of the shopping cart and is not known from
 an individual event.
 
-Note that the purpose of the `withProducerFilter` is to toggle if all events for the entity is to be emitted or not.
+Note that the purpose of the `withProducerFilter` is to toggle if all events for the entity are to be emitted or not.
 If the purpose is to filter out certain events you should instead use the `Transformation`.
 
 The producer filter is evaluated before the transformation function, i.e. the event is the original event and not

--- a/samples/grpc/shopping-analytics-service-java/src/main/java/shopping/analytics/ShoppingCartEventConsumer.java
+++ b/samples/grpc/shopping-analytics-service-java/src/main/java/shopping/analytics/ShoppingCartEventConsumer.java
@@ -138,5 +138,11 @@ class ShoppingCartEventConsumer {
         ProjectionBehavior.stopMessage());
   }
 
+  //#initProjections
+  //#update-filter
+  // FIXME
+  //#update-filter
+  //#initProjections
+
 }
 //#initProjections

--- a/samples/grpc/shopping-analytics-service-scala/README.md
+++ b/samples/grpc/shopping-analytics-service-scala/README.md
@@ -18,6 +18,6 @@
 
 3. Start `shopping-cart-service` and add item to cart
 
-4. Add at least a total quantity of 10 to the cart, smaller carts are excluded by the event filter
+4. Add at least a total quantity of 10 to the cart, smaller carts are excluded by the event filter.
 
 5. Notice the log output in the terminal of the `shopping-analytics-service`

--- a/samples/grpc/shopping-analytics-service-scala/build.sbt
+++ b/samples/grpc/shopping-analytics-service-scala/build.sbt
@@ -35,7 +35,7 @@ val AkkaHttpVersion = "10.5.0"
 val AkkaManagementVersion = "1.3.0"
 val AkkaPersistenceR2dbcVersion = "1.1.0-M7+2-e241ee57-SNAPSHOT"
 val AkkaProjectionVersion =
-  sys.props.getOrElse("akka-projection.version", "1.4.0-M3-124-96b9d6c2-SNAPSHOT") // FIXME
+  sys.props.getOrElse("akka-projection.version", "1.4.0-M3-126-b8edf16f-20230404-1623-SNAPSHOT") // FIXME
 val AkkaDiagnosticsVersion = "2.0.0"
 
 enablePlugins(AkkaGrpcPlugin)

--- a/samples/grpc/shopping-analytics-service-scala/src/main/protobuf/ShoppingCartEvents.proto
+++ b/samples/grpc/shopping-analytics-service-scala/src/main/protobuf/ShoppingCartEvents.proto
@@ -24,9 +24,3 @@ message ItemRemoved {
 message CheckedOut {
     string cartId = 1;
 }
-
-message CustomerDefined {
-    string cartId = 1;
-    string customerId = 2;
-    string category = 3;
-}

--- a/samples/grpc/shopping-analytics-service-scala/src/main/scala/shopping/analytics/Main.scala
+++ b/samples/grpc/shopping-analytics-service-scala/src/main/scala/shopping/analytics/Main.scala
@@ -27,6 +27,11 @@ object Main {
     AkkaManagement(system).start()
     ClusterBootstrap(system).start()
 
+    ShoppingCartEventConsumer.updateConsumerFilter(
+      system,
+      excludeTags = Set("small"),
+      includeTags = Set("medium", "large"))
+
     ShoppingCartEventConsumer.init(system)
   }
 

--- a/samples/grpc/shopping-cart-service-java/src/main/java/shopping/cart/PublishEvents.java
+++ b/samples/grpc/shopping-cart-service-java/src/main/java/shopping/cart/PublishEvents.java
@@ -26,12 +26,18 @@ public class PublishEvents {
             .registerMapper(ShoppingCart.ItemRemoved.class, event -> Optional.of(transformItemRemoved(event)))
             .registerMapper(ShoppingCart.CheckedOut.class, event -> Optional.of(transformCheckedOut(event)));
 
+    //#withProducerFilter
     EventProducerSource eventProducerSource = new EventProducerSource(
         "ShoppingCart",
         "cart",
         transformation,
         EventProducerSettings.apply(system)
-    );
+    )
+    //#eventProducerService
+    //#eventProducerService
+        // FIXME withProducerFilter
+    //#withProducerFilter
+    ;
 
     return EventProducer.grpcServiceHandler(system, eventProducerSource);
   }

--- a/samples/grpc/shopping-cart-service-java/src/main/java/shopping/cart/ShoppingCart.java
+++ b/samples/grpc/shopping-cart-service-java/src/main/java/shopping/cart/ShoppingCart.java
@@ -37,8 +37,8 @@ public final class ShoppingCart
         ShoppingCart.Command, ShoppingCart.Event, ShoppingCart.State> {
 
   static final String SMALL_QUANTITY_TAG = "small";
-  static final String  MEDIUM_QUANTITY_TAG = "medium";
-  static final String  LARGE_QUANTITY_TAG = "large";
+  static final String MEDIUM_QUANTITY_TAG = "medium";
+  static final String LARGE_QUANTITY_TAG = "large";
 
   //#tags
 

--- a/samples/grpc/shopping-cart-service-scala/README.md
+++ b/samples/grpc/shopping-cart-service-scala/README.md
@@ -34,7 +34,7 @@
     curl http://localhost:9101/ready
     ```
 
-6. Try it with [grpcurl](https://github.com/fullstorydev/grpcurl):
+6. Try it with [grpcurl](https://github.com/fullstorydev/grpcurl). Add at least a total quantity of 10 to the cart, smaller carts are excluded by the event filter.
 
     ```shell
     # add item to cart
@@ -49,8 +49,6 @@
     # check out cart
     grpcurl -d '{"cartId":"cart1"}' -plaintext 127.0.0.1:8101 shoppingcart.ShoppingCartService.Checkout
    
-    # set customer
-    grpcurl -d '{"cartId":"cart2", "customer": {"customerId":"customer2", "category":"gold"}}' -plaintext 127.0.0.1:8101 shoppingcart.ShoppingCartService.SetCustomer
     ```
 
     or same `grpcurl` commands to port 8102 to reach node 2.

--- a/samples/grpc/shopping-cart-service-scala/src/main/protobuf/ShoppingCartEvents.proto
+++ b/samples/grpc/shopping-cart-service-scala/src/main/protobuf/ShoppingCartEvents.proto
@@ -27,9 +27,3 @@ message ItemRemoved {
 message CheckedOut {
     string cartId = 1;
 }
-
-message CustomerDefined {
-    string cartId = 1;
-    string customerId = 2;
-    string category = 3;
-}

--- a/samples/grpc/shopping-cart-service-scala/src/main/protobuf/ShoppingCartService.proto
+++ b/samples/grpc/shopping-cart-service-scala/src/main/protobuf/ShoppingCartService.proto
@@ -12,7 +12,6 @@ service ShoppingCartService {
     rpc UpdateItem (UpdateItemRequest) returns (Cart) {}
     rpc Checkout (CheckoutRequest) returns (Cart) {}
     rpc GetCart (GetCartRequest) returns (Cart) {}
-    rpc SetCustomer (SetCustomerRequest) returns (Cart) {}
 }
 
 
@@ -36,20 +35,9 @@ message GetCartRequest {
     string cartId = 1;
 }
 
-message SetCustomerRequest {
-    string cartId = 1;
-    Customer customer = 2;
-}
-
-message Customer {
-    string customerId = 1;
-    string category = 2;
-}
-
 message Cart {
     repeated Item items = 1;
     bool checkedOut = 2;
-    Customer customer = 3;
 }
 
 message Item {

--- a/samples/grpc/shopping-cart-service-scala/src/main/scala/shopping/cart/PublishEvents.scala
+++ b/samples/grpc/shopping-cart-service-scala/src/main/scala/shopping/cart/PublishEvents.scala
@@ -28,9 +28,8 @@ object PublishEvents {
         Some(transformItemRemoved(event)))
       .registerMapper[ShoppingCart.CheckedOut, proto.CheckedOut](event =>
         Some(transformCheckedOut(event)))
-      .registerMapper[ShoppingCart.CustomerDefined, proto.CustomerDefined](event =>
-        Some(transformCustomerDefined(event)))
 
+    //#withProducerFilter
     val eventProducerSource = EventProducer
       .EventProducerSource(
         "ShoppingCart",
@@ -42,6 +41,8 @@ object PublishEvents {
         tags.contains(ShoppingCart.MediumQuantityTag) || tags.contains(
           ShoppingCart.LargeQuantityTag)
       }
+    //#eventProducerService
+    //#withProducerFilter
 
     EventProducer.grpcServiceHandler(eventProducerSource)(system)
   }
@@ -68,8 +69,5 @@ object PublishEvents {
 
   def transformCheckedOut(event: ShoppingCart.CheckedOut): proto.CheckedOut =
     proto.CheckedOut(event.cartId)
-
-  def transformCustomerDefined(event: ShoppingCart.CustomerDefined): proto.CustomerDefined =
-    proto.CustomerDefined(event.cartId, event.customerId, event.category)
 
 }

--- a/samples/grpc/shopping-cart-service-scala/src/main/scala/shopping/cart/PublishEvents.scala
+++ b/samples/grpc/shopping-cart-service-scala/src/main/scala/shopping/cart/PublishEvents.scala
@@ -36,6 +36,7 @@ object PublishEvents {
         "cart",
         transformation,
         EventProducerSettings(system))
+      //#eventProducerService
       .withProducerFilter[ShoppingCart.Event] { envelope =>
         val tags = envelope.tags
         tags.contains(ShoppingCart.MediumQuantityTag) || tags.contains(

--- a/samples/grpc/shopping-cart-service-scala/src/main/scala/shopping/cart/ShoppingCart.scala
+++ b/samples/grpc/shopping-cart-service-scala/src/main/scala/shopping/cart/ShoppingCart.scala
@@ -33,17 +33,22 @@ import akka.persistence.typed.scaladsl.RetentionCriteria
  * loaded from the database - each event will be replayed to recreate the state
  * of the entity.
  */
+//#tags
 object ShoppingCart {
+  //#tags
 
   /**
    * The current state held by the `EventSourcedBehavior`.
    */
+  //#tags
   final case class State(
       items: Map[String, Int],
       checkoutDate: Option[Instant],
       customerId: String,
       customerCategory: String)
       extends CborSerializable {
+
+    //#tags
 
     def isCheckedOut: Boolean =
       checkoutDate.isDefined
@@ -73,6 +78,7 @@ object ShoppingCart {
     def toSummary: Summary =
       Summary(items, isCheckedOut, customerId, customerCategory)
 
+    //#tags
     def totalQuantity: Int =
       items.valuesIterator.sum
 
@@ -85,6 +91,9 @@ object ShoppingCart {
     }
 
   }
+
+  //#tags
+
   object State {
     val empty: State =
       State(
@@ -186,15 +195,19 @@ object ShoppingCart {
   val EntityKey: EntityTypeKey[Command] =
     EntityTypeKey[Command]("ShoppingCart")
 
+  //#tags
   val SmallQuantityTag = "small"
   val MediumQuantityTag = "medium"
   val LargeQuantityTag = "large"
+
+  //#tags
 
   def init(system: ActorSystem[_]): Unit = {
     ClusterSharding(system).init(Entity(EntityKey)(entityContext =>
       ShoppingCart(entityContext.entityId)))
   }
 
+  //#tags
   def apply(cartId: String): Behavior[Command] = {
     EventSourcedBehavior
       .withEnforcedReplies[Command, Event, State](
@@ -210,6 +223,7 @@ object ShoppingCart {
       .onPersistFailure(
         SupervisorStrategy.restartWithBackoff(200.millis, 5.seconds, 0.1))
   }
+  //#tags
 
   private def handleCommand(
       cartId: String,
@@ -337,4 +351,6 @@ object ShoppingCart {
         state.setCustomer(customerId, category)
     }
   }
+  //#tags
 }
+//#tags

--- a/samples/grpc/shopping-cart-service-scala/src/main/scala/shopping/cart/ShoppingCartServiceImpl.scala
+++ b/samples/grpc/shopping-cart-service-scala/src/main/scala/shopping/cart/ShoppingCartServiceImpl.scala
@@ -10,8 +10,6 @@ import akka.grpc.GrpcServiceException
 import akka.util.Timeout
 import io.grpc.Status
 import org.slf4j.LoggerFactory
-import shopping.cart.proto.Cart
-import shopping.cart.proto.SetCustomerRequest
 
 // tag::moreOperations[]
 import akka.actor.typed.ActorRef
@@ -78,35 +76,12 @@ class ShoppingCartServiceImpl(system: ActorSystem[_])
     convertError(response)
   }
 
-  override def setCustomer(in: SetCustomerRequest): Future[Cart] = {
-    in.customer match {
-      case Some(c) =>
-        logger.info("setCustomer {} to cart {}", c.customerId, in.cartId)
-        val entityRef = sharding.entityRefFor(ShoppingCart.EntityKey, in.cartId)
-        val reply: Future[ShoppingCart.Summary] =
-          entityRef.askWithStatus(
-            ShoppingCart.SetCustomer(c.customerId, c.category, _))
-        val response = reply.map(cart => toProtoCart(cart))
-        convertError(response)
-      case None =>
-        Future.failed(new GrpcServiceException(
-          Status.INVALID_ARGUMENT.withDescription("customer must be defined")))
-    }
-  }
-
   private def toProtoCart(cart: ShoppingCart.Summary): proto.Cart = {
-    val customer =
-      if (cart.customerId != "")
-        Some(proto.Customer(cart.customerId, cart.customerCategory))
-      else
-        None
-
     proto.Cart(
       cart.items.iterator.map { case (itemId, quantity) =>
         proto.Item(itemId, quantity)
       }.toSeq,
-      cart.checkedOut,
-      customer)
+      cart.checkedOut)
   }
 
   private def convertError[T](response: Future[T]): Future[T] = {


### PR DESCRIPTION
* simplified the consumer side filter sample to also use tags

Not all Java snippets are updated yet. The Java samples are more difficult to update because they use the bom dependencies. We'll make a separate round with the Java samples.
