### PR TITLE
perf: More efficient batch insert of offsets, #897

### DIFF
--- a/akka-projection-r2dbc/src/main/resources/reference.conf
+++ b/akka-projection-r2dbc/src/main/resources/reference.conf
@@ -34,6 +34,9 @@ akka.projection.r2dbc {
     # Remove old entries outside the time-window from the offset store database
     # with this frequency.
     delete-interval = 1 minute
+
+    # Trying to batch insert offsets in batches of this size.
+    offset-batch-size = 20
   }
 
   # By default it shares connection-factory with akka-persistence-r2dbc (write side),

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/R2dbcProjectionSettings.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/R2dbcProjectionSettings.scala
@@ -50,7 +50,8 @@ object R2dbcProjectionSettings {
       evictInterval = config.getDuration("offset-store.evict-interval"),
       deleteInterval = config.getDuration("offset-store.delete-interval"),
       logDbCallsExceeding,
-      warnAboutFilteredEventsInFlow = config.getBoolean("warn-about-filtered-events-in-flow"))
+      warnAboutFilteredEventsInFlow = config.getBoolean("warn-about-filtered-events-in-flow"),
+      offsetBatchSize = config.getInt("offset-store.offset-batch-size"))
   }
 
   /**
@@ -72,7 +73,8 @@ final class R2dbcProjectionSettings private (
     val evictInterval: JDuration,
     val deleteInterval: JDuration,
     val logDbCallsExceeding: FiniteDuration,
-    val warnAboutFilteredEventsInFlow: Boolean) {
+    val warnAboutFilteredEventsInFlow: Boolean,
+    val offsetBatchSize: Int) {
 
   val offsetTableWithSchema: String = schema.map(_ + ".").getOrElse("") + offsetTable
   val timestampOffsetTableWithSchema: String = schema.map(_ + ".").getOrElse("") + timestampOffsetTable
@@ -123,6 +125,9 @@ final class R2dbcProjectionSettings private (
   def withWarnAboutFilteredEventsInFlow(warnAboutFilteredEventsInFlow: Boolean): R2dbcProjectionSettings =
     copy(warnAboutFilteredEventsInFlow = warnAboutFilteredEventsInFlow)
 
+  def withOffsetBatchSize(offsetBatchSize: Int): R2dbcProjectionSettings =
+    copy(offsetBatchSize = offsetBatchSize)
+
   private def copy(
       schema: Option[String] = schema,
       offsetTable: String = offsetTable,
@@ -134,7 +139,8 @@ final class R2dbcProjectionSettings private (
       evictInterval: JDuration = evictInterval,
       deleteInterval: JDuration = deleteInterval,
       logDbCallsExceeding: FiniteDuration = logDbCallsExceeding,
-      warnAboutFilteredEventsInFlow: Boolean = warnAboutFilteredEventsInFlow) =
+      warnAboutFilteredEventsInFlow: Boolean = warnAboutFilteredEventsInFlow,
+      offsetBatchSize: Int = offsetBatchSize) =
     new R2dbcProjectionSettings(
       schema,
       offsetTable,
@@ -146,8 +152,9 @@ final class R2dbcProjectionSettings private (
       evictInterval,
       deleteInterval,
       logDbCallsExceeding,
-      warnAboutFilteredEventsInFlow)
+      warnAboutFilteredEventsInFlow,
+      offsetBatchSize)
 
   override def toString =
-    s"R2dbcProjectionSettings($schema, $offsetTable, $timestampOffsetTable, $managementTable, $useConnectionFactory, $timeWindow, $keepNumberOfEntries, $evictInterval, $deleteInterval, $logDbCallsExceeding, $warnAboutFilteredEventsInFlow)"
+    s"R2dbcProjectionSettings($schema, $offsetTable, $timestampOffsetTable, $managementTable, $useConnectionFactory, $timeWindow, $keepNumberOfEntries, $evictInterval, $deleteInterval, $logDbCallsExceeding, $warnAboutFilteredEventsInFlow, $offsetBatchSize)"
 }

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
@@ -169,7 +169,7 @@ private[projection] object R2dbcProjectionImpl {
       case change: DurableStateChange[_] =>
         // in case additional types are added
         throw new IllegalArgumentException(
-          s"DurableStateChange [${change.getClass.getName}] not implemented yet. Please report bug at https://github.com/akka/akka-persistence-r2dbc/issues")
+          s"DurableStateChange [${change.getClass.getName}] not implemented yet. Please report bug at https://github.com/akka/akka-projection/issues")
       case _ => OffsetPidSeqNr(offset)
     }
   }
@@ -641,7 +641,7 @@ private[projection] class R2dbcProjectionImpl[Offset, Envelope](
       // need the envelope to be able to call offsetStore.saveOffset
       // FIXME maybe we can cleanup this mess when moving R2dbcProjection to the Akka Projections repository? This is all internal api.
       throw new IllegalStateException(
-        "Unexpected call to saveOffset. It should have called saveOffsetAndReport. Please report bug at https://github.com/akka/akka-persistence-r2dbc/issues")
+        "Unexpected call to saveOffset. It should have called saveOffsetAndReport. Please report bug at https://github.com/akka/akka-projection/issues")
     }
 
     override protected def saveOffsetAndReport(


### PR DESCRIPTION
* the r2dbc statement.add() will still result in one round trip to the db for each added statement
* using Postgres insert with many values instead
* grouped into batches of 20, and remaining executed as before

References #897
