### PR TITLE
fix: Store all grouped offsets for R2DBC, #906

### DIFF
--- a/akka-projection-core/src/main/scala/akka/projection/internal/InternalProjectionState.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/InternalProjectionState.scala
@@ -226,7 +226,10 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
     }
   }
 
-  private def exactlyOnceProcessing(
+  /**
+   * ExactlyOnce or async store of offset by the handler adapter.
+   */
+  private def offsetStoredByHandlerProcessing(
       source: Source[ProjectionContextImpl[Offset, Envelope], NotUsed],
       recoveryStrategy: HandlerRecoveryStrategy): Source[Done, NotUsed] = {
 
@@ -434,7 +437,10 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
     val composedSource: Source[Done, NotUsed] =
       offsetStrategy match {
         case ExactlyOnce(recoveryStrategyOpt) =>
-          exactlyOnceProcessing(source, recoveryStrategyOpt.getOrElse(settings.recoveryStrategy))
+          offsetStoredByHandlerProcessing(source, recoveryStrategyOpt.getOrElse(settings.recoveryStrategy))
+
+        case OffsetStoredByHandler(recoveryStrategyOpt) =>
+          offsetStoredByHandlerProcessing(source, recoveryStrategyOpt.getOrElse(settings.recoveryStrategy))
 
         case AtLeastOnce(afterEnvelopesOpt, orAfterDurationOpt, recoveryStrategyOpt) =>
           atLeastOnceProcessing(

--- a/akka-projection-core/src/main/scala/akka/projection/internal/OffsetStrategy.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/OffsetStrategy.scala
@@ -50,6 +50,13 @@ private[projection] final case class AtLeastOnce(
  * INTERNAL API
  */
 @InternalApi
+private[projection] final case class OffsetStoredByHandler(recoveryStrategy: Option[HandlerRecoveryStrategy] = None)
+    extends OffsetStrategy
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[projection] sealed trait HandlerStrategy {
   def recreateHandlerOnNextAccess(): Unit
 

--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcProjectionImpl.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcProjectionImpl.scala
@@ -29,6 +29,7 @@ import akka.projection.internal.HandlerStrategy
 import akka.projection.internal.InternalProjection
 import akka.projection.internal.InternalProjectionState
 import akka.projection.internal.ManagementState
+import akka.projection.internal.OffsetStoredByHandler
 import akka.projection.internal.OffsetStrategy
 import akka.projection.internal.ProjectionSettings
 import akka.projection.internal.SettingsImpl
@@ -198,7 +199,7 @@ private[projection] class JdbcProjectionImpl[Offset, Envelope, S <: JdbcSession]
       .copy(afterEnvelopes = Some(afterEnvelopes), orAfterDuration = Some(afterDuration)))
 
   /**
-   * Settings for GroupedSlickProjection
+   * Settings for GroupedJdbcProjection
    */
   override def withGroup(
       groupAfterEnvelopes: Int,
@@ -210,8 +211,9 @@ private[projection] class JdbcProjectionImpl[Offset, Envelope, S <: JdbcSession]
   override def withRecoveryStrategy(
       recoveryStrategy: HandlerRecoveryStrategy): JdbcProjectionImpl[Offset, Envelope, S] = {
     val newStrategy = offsetStrategy match {
-      case s: ExactlyOnce => s.copy(recoveryStrategy = Some(recoveryStrategy))
-      case s: AtLeastOnce => s.copy(recoveryStrategy = Some(recoveryStrategy))
+      case s: ExactlyOnce           => s.copy(recoveryStrategy = Some(recoveryStrategy))
+      case s: AtLeastOnce           => s.copy(recoveryStrategy = Some(recoveryStrategy))
+      case s: OffsetStoredByHandler => s.copy(recoveryStrategy = Some(recoveryStrategy))
       //NOTE: AtMostOnce has its own withRecoveryStrategy variant
       // this method is not available for AtMostOnceProjection
       case s: AtMostOnce => s

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/scaladsl/R2dbcProjection.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/scaladsl/R2dbcProjection.scala
@@ -5,7 +5,6 @@
 package akka.projection.r2dbc.scaladsl
 
 import scala.collection.immutable
-import scala.concurrent.duration.Duration
 
 import akka.Done
 import akka.actor.typed.ActorSystem
@@ -20,6 +19,7 @@ import akka.projection.internal.ExactlyOnce
 import akka.projection.internal.FlowHandlerStrategy
 import akka.projection.internal.GroupedHandlerStrategy
 import akka.projection.internal.NoopStatusObserver
+import akka.projection.internal.OffsetStoredByHandler
 import akka.projection.internal.SingleHandlerStrategy
 import akka.projection.r2dbc.R2dbcProjectionSettings
 import akka.projection.r2dbc.internal.R2dbcProjectionImpl
@@ -262,7 +262,7 @@ object R2dbcProjection {
       settingsOpt = None,
       sourceProvider,
       restartBackoffOpt = None,
-      offsetStrategy = AtLeastOnce(afterEnvelopes = Some(1), orAfterDuration = Some(Duration.Zero)),
+      offsetStrategy = OffsetStoredByHandler(),
       handlerStrategy = GroupedHandlerStrategy(adaptedHandler),
       NoopStatusObserver,
       offsetStore)

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
@@ -28,6 +28,7 @@ import akka.projection.internal.HandlerStrategy
 import akka.projection.internal.InternalProjection
 import akka.projection.internal.InternalProjectionState
 import akka.projection.internal.ManagementState
+import akka.projection.internal.OffsetStoredByHandler
 import akka.projection.internal.OffsetStrategy
 import akka.projection.internal.ProjectionSettings
 import akka.projection.internal.SettingsImpl
@@ -128,8 +129,9 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
       recoveryStrategy: HandlerRecoveryStrategy): SlickProjectionImpl[Offset, Envelope, P] = {
     val newStrategy =
       offsetStrategy match {
-        case s: ExactlyOnce => s.copy(recoveryStrategy = Some(recoveryStrategy))
-        case s: AtLeastOnce => s.copy(recoveryStrategy = Some(recoveryStrategy))
+        case s: ExactlyOnce           => s.copy(recoveryStrategy = Some(recoveryStrategy))
+        case s: AtLeastOnce           => s.copy(recoveryStrategy = Some(recoveryStrategy))
+        case s: OffsetStoredByHandler => s.copy(recoveryStrategy = Some(recoveryStrategy))
         //NOTE: AtMostOnce has its own withRecoveryStrategy variant
         // this method is not available for AtMostOnceProjection
         case s: AtMostOnce => s


### PR DESCRIPTION
* Issue for R2dbcProjection.groupedWithinAsync, which only stored the last offset of the group
* Symptom was Rejected envelope from backtracking after restarting
* Store all offset of the group
* Easiest to not use the AtLeastOnce offsetStrategy for this and instead store the offset in the handler adapter, which is very similar to grouped ExactlyOnce
* This might be a slight change in semantics in the way that start processing of next group will not begin until offsets for previous group has been stored. I think that is totally fine, and it was only 1 group in flight previously.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #906
