### PR TITLE
feat: cassandra cross build for Scala 3

### DIFF
--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
@@ -178,7 +178,7 @@ import akka.stream.scaladsl.Source
         settings) {
 
     override implicit def executionContext: ExecutionContext = system.executionContext
-    override val logger: LoggingAdapter = Logging(system.classicSystem, this.getClass)
+    override val logger: LoggingAdapter = Logging(system.classicSystem, classOf[CassandraInternalProjectionState])
 
     private val offsetStore = new CassandraOffsetStore(system)
 
@@ -193,7 +193,10 @@ import akka.stream.scaladsl.Source
       offsetStore.saveOffset(projectionId, offset)
 
     private[projection] def newRunningInstance(): RunningProjection = {
-      new CassandraRunningProjection(RunningProjection.withBackoff(() => mappedSource(), settings), offsetStore, this)
+      new CassandraRunningProjection(
+        RunningProjection.withBackoff(() => this.mappedSource(), settings),
+        offsetStore,
+        this)
     }
 
   }

--- a/build.sbt
+++ b/build.sbt
@@ -74,6 +74,7 @@ lazy val cassandra =
     // however, without it the generated pom.xml doesn't get this test dependencies
     .dependsOn(coreTest % "test->test;it->test")
     .dependsOn(testkit % "test->compile;it->compile")
+    .settings(Scala3.settings)
 
 // provides source providers for akka-persistence-query
 lazy val eventsourced =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
     val akkaPersistenceCassandra = "1.1.0"
     val akkaPersistenceJdbc = "5.2.0"
     val akkaPersistenceR2dbc = "1.2.0-M1"
-    val alpakka = "5.0.0"
+    val alpakka = "6.0.1"
     val alpakkaKafka = sys.props.getOrElse("build.alpakka.kafka.version", "4.0.2")
     val slick = "3.4.1"
     val scalaTest = "3.2.16"


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
Bumps Alpakka to 6.0.1 and adds Scala3 support to cassandra