### PR TITLE
feat: Topic filters for Projections over gRPC

### DIFF
--- a/akka-distributed-cluster-docs/src/main/paradox/guide/2-service-to-service.md
+++ b/akka-distributed-cluster-docs/src/main/paradox/guide/2-service-to-service.md
@@ -122,7 +122,9 @@ In this example the decision is based on tags, but the filter function can use a
 on the total quantity of the shopping cart, which requires the full state of the shopping cart and is not known from
 an individual event.
 
-Note that the purpose of the `withProducerFilter` is to toggle if all events for the entity are to be emitted or not.
+@extref[Topic filters](akka-projection:grpc.html#topics) can be defined in similar way, using `withTopicProducerFilter`.
+
+Note that the purpose of `withProducerFilter` and `withTopicProducerFilter` is to toggle if all events for the entity are to be emitted or not.
 If the purpose is to filter out certain events you should instead use the `Transformation`.
 
 The producer filter is evaluated before the transformation function, i.e. the event is the original event and not

--- a/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/producer/TopicProducerFilterEndToEndSpec.scala
+++ b/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/producer/TopicProducerFilterEndToEndSpec.scala
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2009-2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.grpc.producer
+
+import akka.Done
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Behavior
+import akka.grpc.GrpcClientSettings
+import akka.grpc.scaladsl.ServiceHandler
+import akka.http.scaladsl.Http
+import akka.persistence.query.typed.EventEnvelope
+import akka.persistence.typed.PersistenceId
+import akka.persistence.typed.scaladsl.Effect
+import akka.persistence.typed.scaladsl.EventSourcedBehavior
+import akka.projection.ProjectionBehavior
+import akka.projection.ProjectionContext
+import akka.projection.ProjectionId
+import akka.projection.eventsourced.scaladsl.EventSourcedProvider
+import akka.projection.grpc.TestContainerConf
+import akka.projection.grpc.TestData
+import akka.projection.grpc.TestDbLifecycle
+import akka.projection.grpc.consumer.GrpcQuerySettings
+import akka.projection.grpc.consumer.scaladsl.GrpcReadJournal
+import akka.projection.grpc.producer.scaladsl.EventProducer
+import akka.projection.grpc.producer.scaladsl.EventProducer.EventProducerSource
+import akka.projection.grpc.producer.scaladsl.EventProducer.Transformation
+import akka.projection.r2dbc.scaladsl.R2dbcProjection
+import akka.stream.scaladsl.FlowWithContext
+import akka.testkit.SocketUtil
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.DurationInt
+
+object TopicProducerFilterEndToEndSpec {
+
+  val config: Config = ConfigFactory
+    .parseString(s"""
+    akka.actor.allow-java-serialization = on
+    akka.http.server.preview.enable-http2 = on
+    akka.persistence.r2dbc.journal.publish-events = false
+    akka.persistence.r2dbc {
+      query {
+        refresh-interval = 500 millis
+        # reducing this to have quicker test, triggers backtracking earlier
+        backtracking.behind-current-time = 3 seconds
+      }
+    }
+    akka.projection.grpc {
+      producer {
+        query-plugin-id = "akka.persistence.r2dbc.query"
+      }
+    }
+    akka.actor.testkit.typed.filter-leeway = 10s
+    """)
+
+  private case class Processed(envelope: EventEnvelope[String])
+
+  private val entityType = "TopicProducerFilterTestEntity"
+  object TestEntity {
+    case class Command(text: String, replyTo: ActorRef[Done])
+    def apply(id: String): Behavior[Command] =
+      EventSourcedBehavior[Command, String, Set[String]](
+        PersistenceId(entityType, id),
+        Set.empty[String], {
+          case (_, Command(text, replyTo)) =>
+            Effect.persist(text).thenRun(_ => replyTo ! Done)
+        },
+        (state, event) => state + event)
+        .withTaggerForState((state, _) =>
+          if (state.exists(_.contains("replicate-it"))) Set("t:a/b/c") else Set("t:d/e/f"))
+  }
+
+}
+
+class TopicProducerFilterEndToEndSpec(testContainerConf: TestContainerConf)
+    extends ScalaTestWithActorTestKit(TopicProducerFilterEndToEndSpec.config.withFallback(testContainerConf.config))
+    with AnyWordSpecLike
+    with TestDbLifecycle
+    with TestData
+    with BeforeAndAfterAll
+    with LogCapturing {
+
+  def this() = this(new TestContainerConf)
+
+  import TopicProducerFilterEndToEndSpec._
+
+  override def typedSystem: ActorSystem[_] = testKit.system
+  private implicit val ec: ExecutionContext = typedSystem.executionContext
+
+  private val grpcPort: Int = SocketUtil.temporaryServerAddress("127.0.0.1").getPort
+
+  private val streamId = "topic-producer-filter-e2e-test"
+  private val projectionId = ProjectionId("topic-producer-filter-e2e-projection", "0-1023")
+  private def grpcJournalSource() =
+    EventSourcedProvider.eventsBySlices[String](
+      system,
+      GrpcReadJournal(
+        GrpcQuerySettings(streamId),
+        GrpcClientSettings
+          .connectToServiceAt("127.0.0.1", grpcPort)
+          .withTls(false),
+        protobufDescriptors = Nil),
+      streamId,
+      // just the one consumer for now
+      0,
+      1023)
+
+  private val projectionProbe = createTestProbe[Processed]()
+
+  private def spawnProjection(): ActorRef[ProjectionBehavior.Command] =
+    spawn(
+      ProjectionBehavior(
+        R2dbcProjection.atLeastOnceFlow(
+          projectionId,
+          settings = None,
+          sourceProvider = grpcJournalSource(),
+          handler = FlowWithContext[EventEnvelope[String], ProjectionContext].map { envelope =>
+            projectionProbe.ref ! Processed(envelope)
+            Done
+          })))
+
+  "A projection with topic producer a filter" must {
+
+    "Start an event producer service" in {
+      val eps = EventProducerSource(entityType, streamId, Transformation.identity, EventProducerSettings(system))
+        .withTopicProducerFilter("a/+/c")
+      val handler = EventProducer.grpcServiceHandler(eps)
+
+      val bound =
+        Http(system)
+          .newServerAt("127.0.0.1", grpcPort)
+          .bind(ServiceHandler.concatOrNotFound(handler))
+          .map(_.addToCoordinatedShutdown(3.seconds))
+
+      bound.futureValue
+    }
+
+    "Start a consumer" in {
+      spawnProjection()
+    }
+
+    "Filter events according to topic producer filter" in {
+      val ackProbe = createTestProbe[Done]()
+      val entity1 = testKit.spawn(TestEntity("one"))
+      entity1.tell(TestEntity.Command("a", ackProbe.ref))
+      ackProbe.receiveMessage()
+      entity1.tell(TestEntity.Command("b", ackProbe.ref))
+      ackProbe.receiveMessage()
+
+      projectionProbe.expectNoMessage()
+
+      entity1.tell(TestEntity.Command("c-replicate-it", ackProbe.ref))
+      ackProbe.receiveMessage()
+
+      val replicatedEvents = projectionProbe.receiveMessages(3, 5.seconds) // behind-current-time + some more time
+      replicatedEvents.map(_.envelope.event) shouldBe Seq("a", "b", "c-replicate-it")
+      replicatedEvents.last.envelope.tags shouldBe Set("t:a/b/c")
+    }
+
+  }
+
+}

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/ConsumerFilterSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/ConsumerFilterSpec.scala
@@ -36,6 +36,18 @@ class ConsumerFilterSpec extends AnyWordSpecLike with Matchers {
       mergeFilter(filter3, filter1 ++ filter2) shouldBe filter1
     }
 
+    "merge and remove include of topics" in {
+      val filter1 = Vector(IncludeTopics(Set("a", "b")))
+      mergeFilter(Nil, filter1) shouldBe filter1
+      mergeFilter(filter1, Nil) shouldBe filter1
+      val filter2 = Vector(IncludeTopics(Set("a", "c")))
+      mergeFilter(filter1, filter2) shouldBe Vector(IncludeTopics(Set("a", "b", "c")))
+      mergeFilter(filter2, filter1) shouldBe Vector(IncludeTopics(Set("a", "b", "c")))
+      val filter3 = Vector(RemoveIncludeTopics(Set("a", "c")))
+      mergeFilter(filter1 ++ filter2, filter3) shouldBe Vector(IncludeTopics(Set("b")))
+      mergeFilter(filter3, filter1 ++ filter2) shouldBe Vector(IncludeTopics(Set("b")))
+    }
+
     "merge and reduce filter" in {
       val filter1 =
         Vector(
@@ -95,6 +107,15 @@ class ConsumerFilterSpec extends AnyWordSpecLike with Matchers {
 
       val filter2 = Vector(IncludeTags(Set("a", "c")))
       createDiff(filter1, filter2) shouldBe Vector(IncludeTags(Set("c")), RemoveIncludeTags(Set("b")))
+    }
+
+    "create diff for IncludeTopics" in {
+      val filter1 = Vector(IncludeTopics(Set("a", "b")))
+      createDiff(Nil, filter1) shouldBe filter1
+      createDiff(filter1, Nil) shouldBe Vector(RemoveIncludeTopics(Set("a", "b")))
+
+      val filter2 = Vector(IncludeTopics(Set("a", "c")))
+      createDiff(filter1, filter2) shouldBe Vector(IncludeTopics(Set("c")), RemoveIncludeTopics(Set("b")))
     }
 
     "create diff for ExcludeRegexEntityIds" in {

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/ConsumerSerializerSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/ConsumerSerializerSpec.scala
@@ -27,6 +27,7 @@ class ConsumerSerializerSpec extends ScalaTestWithActorTestKit with AnyWordSpecL
     Vector(
       ConsumerFilter.ExcludeTags(Set("t1", "t2")),
       ConsumerFilter.IncludeTags(Set("t3", "t4")),
+      ConsumerFilter.IncludeTopics(Set("a/+/b", "c/#")),
       ConsumerFilter.ExcludeRegexEntityIds(Set("all.*")),
       ConsumerFilter.IncludeRegexEntityIds(Set(".*akka.*")),
       ConsumerFilter.ExcludeEntityIds(Set("a", "b", "c")),

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/FilterStageSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/FilterStageSpec.scala
@@ -129,6 +129,7 @@ class FilterStageSpec extends ScalaTestWithActorTestKit("""
             initFilter,
             testCurrentEventsByPersistenceIdQuery(allEnvelopes),
             producerFilter = initProducerFilter,
+            topicTagPrefix = producerSettings.topicTagPrefix,
             replayParallelism = producerSettings.replayParallelism))
         .join(Flow.fromSinkAndSource(Sink.ignore, envSource))
     private val streamIn: Source[StreamIn, TestPublisher.Probe[StreamIn]] = TestSource()

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/TopicMatcherSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/TopicMatcherSpec.scala
@@ -4,10 +4,27 @@
 
 package akka.projection.grpc.internal
 
+import java.time.Instant
+
+import akka.persistence.query.TimestampOffset
+import akka.persistence.query.typed.EventEnvelope
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class TopicMatcherSpec extends AnyWordSpecLike with Matchers {
+
+  def createEnvelope(tags: Set[String]): EventEnvelope[String] =
+    EventEnvelope(
+      TimestampOffset(Instant.now, Map("test|pid" -> 1L)),
+      "test|pid",
+      1L,
+      "evt",
+      System.currentTimeMillis(),
+      "test",
+      0,
+      filtered = false,
+      source = "",
+      tags)
 
   "TopicMatcher" should {
     "match all wildcard" in {
@@ -66,6 +83,16 @@ class TopicMatcherSpec extends AnyWordSpecLike with Matchers {
       matcher.matches("myhome/groundfloor/kitchen/brightness") shouldBe true
       matcher.matches("myhome/firstfloor/kitchen/temperature") shouldBe false
       matcher.matches("otherhome/groundfloor/kitchen/brightness") shouldBe true
+    }
+
+    "match topic with wildcard in the topic" in {
+      val matcher = TopicMatcher("myhome/groundfloor/+/temperature")
+      // not recommended to use wildcard symbols in the topic names, but we can't prevent it
+      // and they are like any other characters in the topic names
+      matcher.matches("myhome/groundfloor/+/temperature") shouldBe true
+      matcher.matches("myhome/groundfloor/living+/temperature") shouldBe true
+      matcher.matches("+/groundfloor/+/temperature") shouldBe false
+      matcher.matches("myhome/groundfloor/#") shouldBe false
     }
 
     "not allow empty expression" in {
@@ -131,6 +158,21 @@ class TopicMatcherSpec extends AnyWordSpecLike with Matchers {
       val matcher = TopicMatcher("myhome/#")
       matcher.matches("myhome/groundfloor/") shouldBe true
       matcher.matches("myhome/groundfloor//") shouldBe true
+    }
+
+    "match on topic tag in EventEnvelope" in {
+      val matcher = TopicMatcher("myhome/groundfloor/+/temperature")
+      matcher.matches(createEnvelope(tags = Set("t:myhome/groundfloor/livingroom/temperature")), "t:") shouldBe true
+      matcher.matches(createEnvelope(tags = Set("t:myhome/groundfloor/kitchen/brightness")), "t:") shouldBe false
+      matcher.matches(createEnvelope(tags = Set("other")), "t:") shouldBe false
+      matcher.matches(createEnvelope(tags = Set.empty), "t:") shouldBe false
+    }
+
+    "match all even if topic tag is not defined EventEnvelope" in {
+      val matcher = TopicMatcher("#")
+      matcher.matches(createEnvelope(tags = Set("t:myhome/groundfloor/livingroom/temperature")), "t:") shouldBe true
+      matcher.matches(createEnvelope(tags = Set("other")), "t:") shouldBe true
+      matcher.matches(createEnvelope(tags = Set.empty), "t:") shouldBe true
     }
   }
 }

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/TopicMatcherSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/TopicMatcherSpec.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.projection.grpc.internal
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class TopicMatcherSpec extends AnyWordSpecLike with Matchers {
+
+  "TopicMatcher" should {
+    "match all wildcard" in {
+      val matcher = TopicMatcher("#")
+      matcher.matches("myhome/groundfloor/livingroom/temperature") shouldBe true
+    }
+
+    "match exact" in {
+      val matcher = TopicMatcher("myhome/groundfloor")
+      matcher.matches("myhome/groundfloor") shouldBe true
+      matcher.matches("otherhome/groundfloor") shouldBe false
+      matcher.matches("myhome/groundfloor/kitchen") shouldBe false
+      matcher.matches("Myhome/groundfloor") shouldBe false
+    }
+
+    "match single level wildcard" in {
+      val matcher = TopicMatcher("myhome/groundfloor/+/temperature")
+      matcher.matches("myhome/groundfloor/livingroom/temperature") shouldBe true
+      matcher.matches("myhome/groundfloor/kitchen/brightness") shouldBe false
+      matcher.matches("myhome/firstfloor/kitchen/temperature") shouldBe false
+      matcher.matches("myhome/groundfloor/kitchen/fridge/temperature") shouldBe false
+      matcher.matches("myhome/groundfloor") shouldBe false
+      matcher.matches("myhome/groundfloor/livingroom/temperature/") shouldBe true
+    }
+
+    "match with only one single level wildcard" in {
+      val matcher = TopicMatcher("+")
+      matcher.matches("myhome") shouldBe true
+      matcher.matches("myhome/groundfloor") shouldBe false
+      matcher.matches("/myhome") shouldBe false
+      matcher.matches("myhome/") shouldBe true
+    }
+
+    "match with several single level wildcards" in {
+      val matcher = TopicMatcher("+/groundfloor/+/temperature")
+      matcher.matches("myhome/groundfloor/livingroom/temperature") shouldBe true
+      matcher.matches("myhome/groundfloor/kitchen/brightness") shouldBe false
+
+      matcher.matches("otherhome/groundfloor/livingroom/temperature") shouldBe true
+      matcher.matches("otherhome/groundfloor/kitchen/brightness") shouldBe false
+    }
+
+    "match multi level wildcard" in {
+      val matcher = TopicMatcher("myhome/groundfloor/#")
+      matcher.matches("myhome/groundfloor/livingroom/temperature") shouldBe true
+      matcher.matches("myhome/groundfloor/kitchen/brightness") shouldBe true
+      matcher.matches("myhome/firstfloor/kitchen/temperature") shouldBe false
+
+      matcher.matches("myhome/groundfloor/") shouldBe false
+      matcher.matches("myhome/groundfloor//") shouldBe false
+    }
+
+    "match with single and multi level wildcards" in {
+      val matcher = TopicMatcher("+/groundfloor/#")
+      matcher.matches("myhome/groundfloor/livingroom/temperature") shouldBe true
+      matcher.matches("myhome/groundfloor/kitchen/brightness") shouldBe true
+      matcher.matches("myhome/firstfloor/kitchen/temperature") shouldBe false
+      matcher.matches("otherhome/groundfloor/kitchen/brightness") shouldBe true
+    }
+
+    "not allow empty expression" in {
+      intercept[IllegalArgumentException] {
+        TopicMatcher.checkValid("")
+      }
+    }
+
+    "not allow multi level wildcard in other place than at the end" in {
+      intercept[IllegalArgumentException] {
+        TopicMatcher.checkValid("myhome/#/")
+      }
+      intercept[IllegalArgumentException] {
+        TopicMatcher.checkValid("myhome/#/temperature")
+      }
+
+      TopicMatcher.checkValid("#")
+      TopicMatcher.checkValid("/#")
+    }
+
+    "only allow multi level wildcard for a full token" in {
+      intercept[IllegalArgumentException] {
+        TopicMatcher.checkValid("myhome/groundfloor/temp#")
+      }
+    }
+
+    "only allow single level wildcard for a full token" in {
+      intercept[IllegalArgumentException] {
+        TopicMatcher.checkValid("myhome/g+floor/temperature")
+      }
+      intercept[IllegalArgumentException] {
+        TopicMatcher.checkValid("myhome/ground+/temperature")
+      }
+      intercept[IllegalArgumentException] {
+        TopicMatcher.checkValid("myhome/+floor/temperature")
+      }
+      intercept[IllegalArgumentException] {
+        TopicMatcher.checkValid("myhome/groundfloor/temp+")
+      }
+      intercept[IllegalArgumentException] {
+        TopicMatcher.checkValid("a+")
+      }
+      intercept[IllegalArgumentException] {
+        TopicMatcher.checkValid("a+/")
+      }
+
+      TopicMatcher.checkValid("/+")
+      TopicMatcher.checkValid("+/")
+      TopicMatcher.checkValid("/+/")
+    }
+
+    "strip trailing separator chars" in {
+      import TopicMatcher.Separator
+      TopicMatcher.stripEnd("a/b/", Separator) shouldBe "a/b"
+      TopicMatcher.stripEnd("a/b//", Separator) shouldBe "a/b"
+      TopicMatcher.stripEnd("a/b///", Separator) shouldBe "a/b"
+      TopicMatcher.stripEnd("a/", Separator) shouldBe "a"
+
+      TopicMatcher.stripEnd("a/b", Separator) shouldBe "a/b"
+      TopicMatcher.stripEnd("a", Separator) shouldBe "a"
+      TopicMatcher.stripEnd("", Separator) shouldBe ""
+
+      val matcher = TopicMatcher("myhome/#")
+      matcher.matches("myhome/groundfloor/") shouldBe true
+      matcher.matches("myhome/groundfloor//") shouldBe true
+    }
+  }
+}

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/TopicMatcherSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/TopicMatcherSpec.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.projection.grpc.internal
 
 import org.scalatest.matchers.should.Matchers

--- a/akka-projection-grpc/src/main/mima-filters/1.4.2.backwards.excludes/topic-filter.excludes
+++ b/akka-projection-grpc/src/main/mima-filters/1.4.2.backwards.excludes/topic-filter.excludes
@@ -1,0 +1,12 @@
+# internal changes
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.grpc.internal.DdataConsumerFilterStore#State.copy")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.projection.grpc.internal.DdataConsumerFilterStore#State.copy$default$6")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.grpc.internal.DdataConsumerFilterStore#State.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.grpc.internal.DdataConsumerFilterStore#State.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.grpc.internal.FilterStage#Filter.copy")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.projection.grpc.internal.FilterStage#Filter.copy$default$4")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.projection.grpc.internal.FilterStage#Filter.copy$default$5")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.projection.grpc.internal.FilterStage#Filter.copy$default$6")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.grpc.internal.FilterStage#Filter.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.grpc.internal.FilterStage#Filter.empty")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.grpc.internal.FilterStage#Filter.apply")

--- a/akka-projection-grpc/src/main/protobuf/akka/projection/grpc/consumer.proto
+++ b/akka-projection-grpc/src/main/protobuf/akka/projection/grpc/consumer.proto
@@ -19,6 +19,8 @@ message ConsumerFilterStoreState {
   // ORSet serialized with Akka's ReplicatedDataSerializer
   bytes exclude_entity_ids = 5;
   SeqNrMap include_entity_offsets = 6;
+  // ORSet serialized with Akka's ReplicatedDataSerializer
+  bytes include_topics = 7;
 }
 
 message SeqNrMap {

--- a/akka-projection-grpc/src/main/protobuf/akka/projection/grpc/event_producer.proto
+++ b/akka-projection-grpc/src/main/protobuf/akka/projection/grpc/event_producer.proto
@@ -96,6 +96,8 @@ message FilterCriteria {
     RemoveExcludeEntityIds remove_exclude_entity_ids = 10;
     IncludeEntityIds include_entity_ids = 11;
     RemoveIncludeEntityIds remove_include_entity_ids = 12;
+    IncludeTopics include_topics = 13;
+    RemoveIncludeTopics remove_include_topics = 14;
   }
 }
 
@@ -173,6 +175,18 @@ message IncludeRegexEntityIds {
 // Remove a previously added `IncludeRegexEntityIds`.
 message RemoveIncludeRegexEntityIds {
   repeated string matching = 1;
+}
+
+// Include events with any of the given matching topics. A matching include overrides
+// a matching exclude.
+message IncludeTopics {
+  // topic match expression according to MQTT specification, including wildcards
+  repeated string expression = 1;
+}
+
+// Remove a previously added `IncludeTopics`.
+message RemoveIncludeTopics {
+  repeated string expression = 1;
 }
 
 message Offset {

--- a/akka-projection-grpc/src/main/resources/reference.conf
+++ b/akka-projection-grpc/src/main/resources/reference.conf
@@ -35,6 +35,8 @@ akka.projection.grpc {
 
     filter {
       replay-parallelism = 3
+      # Topic of an event is defined by an event tag with this prefix
+      topic-tag-prefix = "t:"
     }
 
   }

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/ConsumerFilter.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/ConsumerFilter.scala
@@ -133,8 +133,10 @@ object ConsumerFilter extends ExtensionId[ConsumerFilter] {
   }
 
   /**
-   * Include events with any of the given matching topics. A matching include overrides
-   * a matching exclude.
+   * Include events with any of the given matching topics. A matching include overrides a matching exclude.
+   *
+   * Topic match expression according to MQTT specification, including wildcards.
+   * The topic of an event is defined by a tag with certain prefix, see `topic-tag-prefix` configuration.
    */
   final case class IncludeTopics(expressions: Set[String]) extends FilterCriteria {
 

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/ConsumerFilter.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/ConsumerFilter.scala
@@ -20,6 +20,7 @@ import akka.annotation.ApiMayChange
 import akka.annotation.InternalApi
 import akka.persistence.typed.ReplicaId
 import akka.projection.grpc.internal.ConsumerFilterRegistry
+import akka.projection.grpc.internal.TopicMatcher
 import akka.util.JavaDurationConverters._
 import akka.util.ccompat.JavaConverters._
 import com.typesafe.config.Config
@@ -140,6 +141,8 @@ object ConsumerFilter extends ExtensionId[ConsumerFilter] {
     /** Java API */
     def this(expressions: JSet[String]) =
       this(expressions.asScala.toSet)
+
+    expressions.foreach(TopicMatcher.checkValid)
   }
 
   /**

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
@@ -52,6 +52,7 @@ import akka.projection.grpc.internal.proto.FilterReq
 import akka.projection.grpc.internal.proto.FilteredEvent
 import akka.projection.grpc.internal.proto.IncludeEntityIds
 import akka.projection.grpc.internal.proto.IncludeRegexEntityIds
+import akka.projection.grpc.internal.proto.IncludeTopics
 import akka.projection.grpc.internal.proto.IncludeTags
 import akka.projection.grpc.internal.proto.InitReq
 import akka.projection.grpc.internal.proto.LoadEventRequest
@@ -63,6 +64,7 @@ import akka.projection.grpc.internal.proto.RemoveExcludeTags
 import akka.projection.grpc.internal.proto.RemoveIncludeEntityIds
 import akka.projection.grpc.internal.proto.RemoveIncludeRegexEntityIds
 import akka.projection.grpc.internal.proto.RemoveIncludeTags
+import akka.projection.grpc.internal.proto.RemoveIncludeTopics
 import akka.projection.grpc.internal.proto.ReplayReq
 import akka.projection.grpc.internal.proto.StreamIn
 import akka.projection.grpc.internal.proto.StreamOut
@@ -390,6 +392,10 @@ final class GrpcReadJournal private (
         FilterCriteria(FilterCriteria.Message.IncludeTags(IncludeTags(tags.toVector)))
       case ConsumerFilter.RemoveIncludeTags(tags) =>
         FilterCriteria(FilterCriteria.Message.RemoveIncludeTags(RemoveIncludeTags(tags.toVector)))
+      case ConsumerFilter.IncludeTopics(expressions) =>
+        FilterCriteria(FilterCriteria.Message.IncludeTopics(IncludeTopics(expressions.toVector)))
+      case ConsumerFilter.RemoveIncludeTopics(expressions) =>
+        FilterCriteria(FilterCriteria.Message.RemoveIncludeTopics(RemoveIncludeTopics(expressions.toVector)))
       case ConsumerFilter.IncludeEntityIds(entityOffsets) =>
         FilterCriteria(FilterCriteria.Message.IncludeEntityIds(IncludeEntityIds(entityOffsets.map {
           case ConsumerFilter.EntityIdOffset(entityId, seqNr) => EntityIdOffset(entityId, seqNr)

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/ConsumerSerializer.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/ConsumerSerializer.scala
@@ -79,6 +79,7 @@ import scalapb.GeneratedMessage
   private def stateToProto(state: DdataConsumerFilterStore.State): proto.ConsumerFilterStoreState = {
     val excludeTagsBytes = orsetToBytes(state.excludeTags)
     val includeTagsBytes = orsetToBytes(state.includeTags)
+    val includeTopicsBytes = orsetToBytes(state.includeTopics)
     val excludeRegexEntityIdsBytes = orsetToBytes(state.excludeRegexEntityIds)
     val includeRegexEntityIdsBytes = orsetToBytes(state.includeRegexEntityIds)
     val excludeEntityIdsBytes = orsetToBytes(state.excludeEntityIds)
@@ -90,7 +91,8 @@ import scalapb.GeneratedMessage
       excludeRegexEntityIdsBytes,
       includeRegexEntityIdsBytes,
       excludeEntityIdsBytes,
-      seqNrMap)
+      seqNrMap,
+      includeTopicsBytes)
   }
 
   private def seqNrMapToProto(seqNrMap: DdataConsumerFilterStore.SeqNrMap): proto.SeqNrMap = {
@@ -106,6 +108,7 @@ import scalapb.GeneratedMessage
     val protoState = proto.ConsumerFilterStoreState.parseFrom(bytes)
     val excludeTags = orsetFromBinary(protoState.excludeTags.toByteArray)
     val includeTags = orsetFromBinary(protoState.includeTags.toByteArray)
+    val includeTopics = orsetFromBinary(protoState.includeTopics.toByteArray)
     val excludeRegexEntityIds = orsetFromBinary(protoState.excludeRegexEntityIds.toByteArray)
     val includeRegexEntityIds = orsetFromBinary(protoState.includeRegexEntityIds.toByteArray)
     val excludeEntityIds = orsetFromBinary(protoState.excludeEntityIds.toByteArray)
@@ -116,6 +119,7 @@ import scalapb.GeneratedMessage
     DdataConsumerFilterStore.State(
       excludeTags,
       includeTags,
+      includeTopics,
       excludeRegexEntityIds,
       includeRegexEntityIds,
       excludeEntityIds,

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/EventProducerServiceImpl.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/EventProducerServiceImpl.scala
@@ -181,6 +181,7 @@ import akka.persistence.query.typed.scaladsl.EventsBySliceStartingFromSnapshotsQ
               init.filter,
               currentEventsByPersistenceIdQueriesPerStreamId(init.streamId),
               producerFilter = producerSource.producerFilter,
+              topicTagPrefix = producerSource.settings.topicTagPrefix,
               replayParallelism = producerSource.settings.replayParallelism))
           .join(Flow.fromSinkAndSource(Sink.ignore, events))
 

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/FilterStage.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/FilterStage.scala
@@ -122,18 +122,8 @@ import org.slf4j.LoggerFactory
       def matchesIncludeRegexEntityIds: Boolean =
         matchesRegexEntityIds(includeRegexEntityIds.values)
 
-      def matchesTopics: Boolean = {
-        if (env.tags.isEmpty)
-          false
-        else {
-          env.tags.iterator.exists { tag =>
-            if (tag.startsWith(topicTagPrefix))
-              topicMatchers.exists(_.matches(tag.substring(topicTagPrefix.length)))
-            else
-              false
-          }
-        }
-      }
+      def matchesTopics: Boolean =
+        topicMatchers.exists(_.matches(env, topicTagPrefix))
 
       if (env.tags.intersect(excludeTags).nonEmpty ||
           excludePersistenceIds.contains(pid) ||

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/TopicMatcher.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/TopicMatcher.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.projection.grpc.internal
 
 import scala.annotation.tailrec

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/TopicMatcher.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/TopicMatcher.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.projection.grpc.internal
+
+import scala.annotation.tailrec
+
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object TopicMatcher {
+  val Separator = '/'
+  val SingleLevelWildcard = '+'
+  val SingleLevelWildcardStr = "+"
+  val MultiLevelWildcard = '#'
+  val MultiLevelWildcardStr = "#"
+
+  def checkValid(expression: String): Unit = {
+    if (expression.isEmpty)
+      throw new IllegalArgumentException("Empty topic expression is not allowed")
+
+    // single level
+    val i = expression.indexOf(SingleLevelWildcard)
+    if (i > 0) {
+      if (expression.length >= 2 && expression.charAt(i - 1) != Separator)
+        throw new IllegalArgumentException(
+          s"Single level wildcard $SingleLevelWildcard must be a full token, expression [$expression]")
+      if (i <= expression.length - 2 && expression.charAt(i + 1) != Separator)
+        throw new IllegalArgumentException(
+          s"Single level wildcard $SingleLevelWildcard must be a full token, expression [$expression]")
+    }
+
+    // multi level
+    val j = expression.indexOf(MultiLevelWildcard)
+    if (j > 0) {
+      if (j != expression.length - 1)
+        throw new IllegalArgumentException(
+          s"Multi level wildcard $MultiLevelWildcard must be at the end, expression [$expression]")
+      if (expression.length >= 2 && expression.charAt(j - 1) != Separator)
+        throw new IllegalArgumentException(
+          s"Multi level wildcard $MultiLevelWildcard must be a full token, expression [$expression]")
+    }
+
+  }
+
+  def apply(expression: String): TopicMatcher = {
+    checkValid(expression)
+
+    if (expression.length == 1 && expression.charAt(0) == MultiLevelWildcard)
+      AllTopicMatcher
+    else if (expression.indexOf(SingleLevelWildcard) >= 0 || expression.indexOf(MultiLevelWildcard) >= 0)
+      new WildcardMatcher(expression)
+    else
+      new ExactTopicMatcher(expression)
+
+  }
+
+  def stripEnd(str: String, stripChar: Character): String = {
+    @tailrec def loop(i: Int): Int = {
+      if (i < 0 || str.charAt(i) != stripChar)
+        i
+      else
+        loop(i - 1)
+    }
+    val i = loop(str.length - 1)
+
+    if (i == str.length - 1 || i < 0)
+      str
+    else
+      str.substring(0, i + 1)
+  }
+}
+
+/** INTERNAL API */
+@InternalApi private[akka] sealed trait TopicMatcher {
+  def matches(topic: String): Boolean
+}
+
+/** INTERNAL API */
+@InternalApi object AllTopicMatcher extends TopicMatcher {
+  override def matches(topic: String): Boolean =
+    true
+}
+
+/** INTERNAL API */
+@InternalApi final class ExactTopicMatcher(expression: String) extends TopicMatcher {
+  override def matches(topic: String): Boolean =
+    expression == topic
+}
+
+/** INTERNAL API */
+@InternalApi final class WildcardMatcher(expression: String) extends TopicMatcher {
+  import TopicMatcher._
+  private val expressionTokens = expression.split(Separator)
+
+  override def matches(topic: String): Boolean = {
+    // inspiration from https://github.com/hivemq/hivemq-community-edition/blob/master/src/main/java/com/hivemq/mqtt/topic/TokenizedTopicMatcher.java
+    val strippedTopic = stripEnd(topic, Separator)
+    val topicTokens = strippedTopic.split(Separator)
+    val smallest = math.min(topicTokens.length, expressionTokens.length)
+
+    @tailrec def loop(i: Int): Boolean = {
+      if (i == smallest)
+        // it's a match if the length is equal or the expression token with the number x+1
+        // (where x is the topic length) is a wildcard
+        expressionTokens.length == topicTokens.length ||
+        (topicTokens.length - strippedTopic.length == 1 && expressionTokens(expressionTokens.length - 1) == MultiLevelWildcardStr)
+      else if (expressionTokens(i) == topicTokens(i))
+        loop(i + 1)
+      else if (expressionTokens(i) == MultiLevelWildcardStr)
+        true
+      else if (expressionTokens(i) == SingleLevelWildcardStr)
+        // matches topic level wildcard, so we can continue
+        loop(i + 1)
+      else
+        // does not match a wildcard and is not equal to the topic token
+        false
+    }
+
+    loop(0)
+  }
+
+}

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/TopicMatcher.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/TopicMatcher.scala
@@ -7,6 +7,7 @@ package akka.projection.grpc.internal
 import scala.annotation.tailrec
 
 import akka.annotation.InternalApi
+import akka.persistence.query.typed.EventEnvelope
 
 /**
  * INTERNAL API
@@ -77,6 +78,19 @@ import akka.annotation.InternalApi
 /** INTERNAL API */
 @InternalApi private[akka] sealed trait TopicMatcher {
   def matches(topic: String): Boolean
+
+  def matches(env: EventEnvelope[_], topicTagPrefix: String): Boolean = {
+    if (env.tags.isEmpty)
+      false
+    else {
+      env.tags.iterator.exists { tag =>
+        if (tag.startsWith(topicTagPrefix))
+          matches(tag.substring(topicTagPrefix.length))
+        else
+          false
+      }
+    }
+  }
 }
 
 /** INTERNAL API */

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/TopicMatcher.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/TopicMatcher.scala
@@ -97,6 +97,9 @@ import akka.persistence.query.typed.EventEnvelope
 @InternalApi object AllTopicMatcher extends TopicMatcher {
   override def matches(topic: String): Boolean =
     true
+
+  override def matches(env: EventEnvelope[_], topicTagPrefix: String): Boolean =
+    true // also true if no topic tags in EventEnvelope
 }
 
 /** INTERNAL API */

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/producer/EventProducerSettings.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/producer/EventProducerSettings.scala
@@ -20,7 +20,8 @@ object EventProducerSettings {
     new EventProducerSettings(
       queryPluginId = config.getString("query-plugin-id"),
       transformationParallelism = config.getInt("transformation-parallelism"),
-      replayParallelism = config.getInt("filter.replay-parallelism"))
+      replayParallelism = config.getInt("filter.replay-parallelism"),
+      topicTagPrefix = config.getString("filter.topic-tag-prefix"))
   }
 
   /** Java API */
@@ -36,7 +37,8 @@ object EventProducerSettings {
 final class EventProducerSettings private (
     val queryPluginId: String,
     val transformationParallelism: Int,
-    val replayParallelism: Int) {
+    val replayParallelism: Int,
+    val topicTagPrefix: String) {
   require(transformationParallelism >= 1, "Configuration property [transformation-parallelism] must be >= 1.")
   require(replayParallelism >= 1, "Configuration property [replay-parallelism] must be >= 1.")
 

--- a/docs/src/main/paradox/grpc.md
+++ b/docs/src/main/paradox/grpc.md
@@ -145,6 +145,14 @@ events are still transferred to the consumer, to ensure sequence number validati
 Filters can be used when a consumer is only interested in a subset of the entities. The filters can be defined
 on both the producer side and on the consumer side, and they can be changed at runtime.
 
+@@@ note
+
+The purpose of filters is to toggle if all events for the entity are to be emitted or not.
+If the purpose is to filter out certain events you should instead use the
+@ref:[transformation function of the producer](#producer).
+
+@@@
+
 ### Tags
 
 Tags are typically used for the filters, so first an example of how to tag events in the entity. Here, the tag is


### PR DESCRIPTION
* same syntax and semantics of wildcard filters as MQTT
  - single level wildcard '+'
  - multi level wildcard at the end '#'
* topic for entity is defined by and ordinary event tag with a 't:' prefix
  - prefix is configurable
* follows same pattern as other filters
  - rather mechanical addition similar to IncludeTags

TODO:
- [x] reference docs