### PR TITLE
fix: Allow passing protobuf descriptors to producer push consumer

### DIFF
--- a/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/producer/ProducerPushSample.scala
+++ b/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/producer/ProducerPushSample.scala
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future
 
-// FIXME pull out to real sample for docs etc
+// FIXME drop once sample projects are done
 object ProducerPushSampleCommon {
   val streamId = "fruit_stream_id"
   val entityTypeKey = EntityTypeKey[TestEntity.Command]("Fruit")
@@ -175,7 +175,10 @@ object ProducerPushSampleConsumer {
       system.ignoreRef)
 
     // consumer runs gRPC server accepting pushed events from producers
-    val destination = EventProducerPushDestination(streamId)
+    val destination = EventProducerPushDestination(
+      streamId,
+      // note: we use akka serialization for the payloads here, so no proto descriptors
+      Nil)
     val bound = Http(system)
       .newServerAt("127.0.0.1", grpcPort)
       .bind(EventProducerPushDestination.grpcServiceHandler(destination))

--- a/akka-projection-grpc-tests/src/test/java/akka/projection/grpc/consumer/javadsl/EventProducerPushDestinationCompileTest.java
+++ b/akka-projection-grpc-tests/src/test/java/akka/projection/grpc/consumer/javadsl/EventProducerPushDestinationCompileTest.java
@@ -21,6 +21,7 @@ import akka.projection.grpc.consumer.ConsumerFilter;
 import akka.projection.javadsl.Handler;
 import akka.projection.javadsl.SourceProvider;
 import akka.projection.r2dbc.javadsl.R2dbcProjection;
+import com.google.protobuf.Descriptors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +32,9 @@ import java.util.concurrent.CompletionStage;
 public class EventProducerPushDestinationCompileTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(EventProducerPushDestinationCompileTest.class);
+
+  // just an empty dummy list for documentation
+  private static List<Descriptors.FileDescriptor> protoDescriptors = Collections.emptyList();
 
   public static void initConsumer(ActorSystem<SpawnProtocol.Command> system) {
 
@@ -65,7 +69,7 @@ public class EventProducerPushDestinationCompileTest {
 
     // this is the API, consumer runs gRPC server accepting pushed events from producers
     // #consumerSetup
-    EventProducerPushDestination destination = EventProducerPushDestination.create("stream-id", system);
+    EventProducerPushDestination destination = EventProducerPushDestination.create("stream-id", protoDescriptors, system);
     CompletionStage<ServerBinding> bound = Http.get(system)
         .newServerAt("127.0.0.1", 8080)
         .bind(EventProducerPushDestination.grpcServiceHandler(destination, system));
@@ -77,7 +81,7 @@ public class EventProducerPushDestinationCompileTest {
   public static void withFilters(ActorSystem<?> system) {
     // #consumerFilters
     EventProducerPushDestination destination =
-        EventProducerPushDestination.create("stream-id", system)
+        EventProducerPushDestination.create("stream-id", protoDescriptors, system)
             .withConsumerFilters(
                 Arrays.asList(new ConsumerFilter.IncludeTopics(Collections.singleton("myhome/groundfloor/+/temperature")))
             );
@@ -87,7 +91,7 @@ public class EventProducerPushDestinationCompileTest {
   public static void withTransformations(ActorSystem<?> system) {
     // #consumerTransformation
     EventProducerPushDestination destination =
-      EventProducerPushDestination.create("stream-id", system)
+      EventProducerPushDestination.create("stream-id", protoDescriptors, system)
         .withTransformationForOrigin((String originId, Metadata metadata) ->
             Transformation.empty()
               .registerPersistenceIdMapper(envelope -> envelope.persistenceId().replace("originalPrefix", "newPrefix"))

--- a/akka-projection-grpc/src/main/mima-filters/1.5.0-M2.backwards.excludes/event-producer-push-protobuf.excludes
+++ b/akka-projection-grpc/src/main/mima-filters/1.5.0-M2.backwards.excludes/event-producer-push-protobuf.excludes
@@ -1,3 +1,7 @@
 # constructors are internal api
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.grpc.consumer.javadsl.EventProducerPushDestination.this")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.grpc.consumer.scaladsl.EventProducerPushDestination.this")
+
+# new/chagned API require, protobuf descriptors
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.grpc.consumer.javadsl.EventProducerPushDestination.create")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.grpc.consumer.scaladsl.EventProducerPushDestination.apply")

--- a/akka-projection-grpc/src/main/mima-filters/1.5.0-M2.backwards.excludes/event-producer-push-protobuf.excludes
+++ b/akka-projection-grpc/src/main/mima-filters/1.5.0-M2.backwards.excludes/event-producer-push-protobuf.excludes
@@ -1,0 +1,3 @@
+# constructors are internal api
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.grpc.consumer.javadsl.EventProducerPushDestination.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.grpc.consumer.scaladsl.EventProducerPushDestination.this")

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/javadsl/EventProducerPushDestination.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/javadsl/EventProducerPushDestination.scala
@@ -78,7 +78,7 @@ object EventProducerPushDestination {
 }
 
 @ApiMayChange
-final class EventProducerPushDestination private[akka] (
+final class EventProducerPushDestination private (
     val journalPluginId: Optional[String],
     val acceptedStreamId: String,
     val transformationForOrigin: BiFunction[String, Metadata, Transformation],

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/javadsl/EventProducerPushDestination.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/javadsl/EventProducerPushDestination.scala
@@ -44,14 +44,23 @@ import scala.compat.java8.OptionConverters.RichOptionalGeneric
 @ApiMayChange
 object EventProducerPushDestination {
 
-  def create(acceptedStreamId: String, system: ActorSystem[_]): EventProducerPushDestination =
+  /**
+   * @param acceptedStreamId The stream id that the producers must use for this destination
+   * @param protobufDescriptors When using protobuf as event wire format, rather than direct Akka Serialization,
+   *                            all message descriptors needs to be listed up front when creating the destination.
+   *                            If not using protobuf encoded events, use an empty list.
+   */
+  def create(
+      acceptedStreamId: String,
+      protobufDescriptors: JList[Descriptors.FileDescriptor],
+      system: ActorSystem[_]): EventProducerPushDestination =
     new EventProducerPushDestination(
       Optional.empty(),
       acceptedStreamId,
       (_, _) => Transformation.empty,
       Optional.empty(),
       Collections.emptyList(),
-      Collections.emptyList(),
+      protobufDescriptors,
       EventProducerPushDestinationSettings.create(system))
 
   def grpcServiceHandler(
@@ -110,13 +119,6 @@ final class EventProducerPushDestination private (
   def withTransformationForOrigin(
       transformationForOrigin: BiFunction[String, Metadata, Transformation]): EventProducerPushDestination =
     copy(transformationForOrigin = transformationForOrigin)
-
-  /**
-   * When using protobuf encoded events, rather than direct Akka Serialization of events sent over the wire from the
-   * producer, all message descriptors needs to be listed up front when creating the destination.
-   */
-  def withProtobufDescriptors(protobufDescriptors: JList[Descriptors.FileDescriptor]): EventProducerPushDestination =
-    copy(protobufDescriptors = protobufDescriptors)
 
   /**
    * Filter incoming streams, at producer side, with these filters

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/EventProducerPushDestination.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/EventProducerPushDestination.scala
@@ -39,15 +39,19 @@ object EventProducerPushDestination {
 
   /**
    * @param acceptedStreamId Only accept this stream ids, deny others
+   * @param protobufDescriptors When using protobuf as event wire format, rather than direct Akka Serialization,
+   *                            all message descriptors needs to be listed up front when creating the destination.
+   *                            If not using protobuf encoded events, use an empty list.
    */
-  def apply(acceptedStreamId: String)(implicit system: ActorSystem[_]): EventProducerPushDestination =
+  def apply(acceptedStreamId: String, protobufDescriptors: immutable.Seq[Descriptors.FileDescriptor])(
+      implicit system: ActorSystem[_]): EventProducerPushDestination =
     new EventProducerPushDestination(
       None,
       acceptedStreamId,
       (_, _) => Transformation.empty,
       None,
       immutable.Seq.empty,
-      immutable.Seq.empty,
+      protobufDescriptors,
       EventProducerPushDestinationSettings(system))
 
   @ApiMayChange
@@ -193,14 +197,6 @@ final class EventProducerPushDestination private[akka] (
 
   def withSettings(settings: EventProducerPushDestinationSettings): EventProducerPushDestination =
     copy(settings = settings)
-
-  /**
-   * When using protobuf encoded events, rather than direct Akka Serialization of events sent over the wire from the
-   * producer, all message descriptors needs to be listed up front when creating the destination.
-   */
-  def withProtobufDescriptors(
-      protobufDescriptors: immutable.Seq[Descriptors.FileDescriptor]): EventProducerPushDestination =
-    copy(protobufDescriptors = protobufDescriptors)
 
   /**
    * @param transformation A transformation to use for all events.

--- a/docs/src/main/paradox/grpc-producer-push.md
+++ b/docs/src/main/paradox/grpc-producer-push.md
@@ -120,3 +120,17 @@ of configured consumer filters. The filters are defined using `withProducerFilte
 It is possible to define additional connection metadata that is passed to the consumer on connection when constructing the
 @apidoc[EventProducerPush]. This can be used for authenticating a producer in the consumer interceptor, or providing 
 additional details to use when transforming events in the consumer.
+
+### Serialization
+
+By default, the producer will use Akka Serialization to serialize each event for pushing to the consumer, this is convenient
+but can tightly couple the producer and consumer so that they must be upgraded lock step, even though they are two separate
+systems. To avoid problems and keeping the lifecycles of the producer and consumer systems separate it is better to use
+an explicit protobuf message protocol for the events pushed.
+
+This can be done in isolation for the producer push by transforming each type of outgoing messages with the `EventProducer.Transformation`
+passed to the `EventProducerSource` on construction.
+
+On the consuming side the protobuf messages can be turned from wire protocol protobuf messages back to some application domain
+specific representation before storing in the journal with the `EventProducerPushDestination.Transformation` for the `EventProducerPushDestination`
+on construction using `withTransformation` or `withTransformationForOrigin`.

--- a/docs/src/main/paradox/grpc-producer-push.md
+++ b/docs/src/main/paradox/grpc-producer-push.md
@@ -41,7 +41,7 @@ Setting up the consumer starts with creating an @apidoc[EventProducerPushDestina
 The stream id is a public identifier of entity types between producers and consumers, a producer pushing events for unknown
 stream ids will be denied.
 
-The destination is then used as a parameter to @apidoc[EventProducerPushDestination]{grpcServiceHandler} to get a gRPC service 
+The destination is then used as a parameter to @apidoc[EventProducerPushDestination]{ scala="#grpcServiceHandler" java="#grpcServiceHandler" } to get a gRPC service 
 handler that can be bound as an Akka HTTP/gRPC endpoint:
 
 Scala
@@ -51,12 +51,16 @@ Java
 :  @@snip [ShoppingCartEventConsumer.java](/akka-projection-grpc-tests/src/test/java/akka/projection/grpc/consumer/javadsl/EventProducerPushDestinationCompileTest.java) { #consumerSetup }
 
 
+The Protobuf descriptor parameter needs to contain descriptors for all Protobuf messages that the producer will publish,
+unless not using Protobuf as wire format, in that case an empty list can be passed to the `EventProducerPushDestination`.
+For more details about using Protobuf as wire format see @ref[Serialization](#serialization).
+
 ### Filtering
 
 The consumer can define filters for what events it wants the producers to send. Filtered events will still have an entry
 in the consumer journal but without any payload sent from the producer or stored in the consumer.
 
-Filters are set for the destination using @apidoc[withConsumerFilters](EventProducerPushDestination){ scala="withConsumerFilters" java ="withConsumerFilters" }
+Filters are set for the destination using @apidoc[withConsumerFilters](EventProducerPushDestination){ scala="#withConsumerFilters(filters:immutable.Seq)" java="#withConsumerFilters(java.util.List)" }
 
 Scala
 :  @@snip [ShoppingCartEventConsumer.scala](/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/producer/EventProducerPushSpec.scala) { #consumerFilters }
@@ -71,8 +75,8 @@ This may be implemented as a future improvement.
 
 ### Transformation
 
-The events and some of their metadata can be transformed before being stored in the consumer, @apidoc[withTransformation](EventProducerPushDestination){ scala="withTransformation" java="withTransformation" }
-defines a single transformation to use for all producers, while @apidoc[EventProducerPushDestination]{withTransformationForOrigin} 
+The events and some of their metadata can be transformed before being stored in the consumer, @apidoc[withTransformation](EventProducerPushDestination){ scala="#withTransformation(transformation:Transformation)" java="#withTransformation(Transformation)" }
+defines a single transformation to use for all producers, while @apidoc[EventProducerPushDestination]{ scala="#withTransformationForOrigin" java="#withTransformationForOrigin" } 
 is invoked with an origin id for the producer and additional metadata specified when setting up the producer and can provide
 transformations based on those.
 
@@ -88,7 +92,7 @@ Java
 
 ### Intercepting connections
 
-Connections from producers can be intercepted by adding an interceptor via @apidoc[EventProducerPushDestination] `withInterceptor`.
+Connections from producers can be intercepted by adding an interceptor via @apidoc[withInterceptor](EventProducerPushDestination){ scala="#withInterceptor" java="#withInterceptor" }.
 This can be used together with the additional producer metadata to add authentication, as an alternative to or in addition to mTLS.
 
 ## Producer set up
@@ -123,14 +127,23 @@ additional details to use when transforming events in the consumer.
 
 ### Serialization
 
-By default, the producer will use Akka Serialization to serialize each event for pushing to the consumer, this is convenient
-but can tightly couple the producer and consumer so that they must be upgraded lock step, even though they are two separate
-systems. To avoid problems and keeping the lifecycles of the producer and consumer systems separate it is better to use
-an explicit protobuf message protocol for the events pushed.
+If just passed the internal event instances of an application the producer will use Akka Serialization to serialize each 
+event for pushing them the consumer, this is convenient but tightly couples the producer and consumer so that they must 
+be upgraded in lock step, even though they are two separate systems. 
 
-This can be done in isolation for the producer push by transforming each type of outgoing messages with the `EventProducer.Transformation`
+To avoid problems and keeping the lifecycles of the producer and consumer systems separate it is better to use an explicit
+protobuf message protocol for the events pushed. With Protobuf it is possible evolve of protocol messages without breaking
+compatibility (the ability for the consumer to read the messages produced with older and newer versions of the producer).
+Note that even with Protobuf it will still require care to not change the published events in incompatible ways.
+
+You will likely not want to define the original Event Sourced Entity events as protobuf messages but rather as
+regular @java[Java]@scala[Scala] classes, like you'd normally do, but, you can still use protobuf messages as a wire format.
+
+In the producer this is done by transforming each type of event to an outgoing protobuf messages with the `EventProducer.Transformation`
 passed to the `EventProducerSource` on construction.
 
-On the consuming side the protobuf messages can be turned from wire protocol protobuf messages back to some application domain
-specific representation before storing in the journal with the `EventProducerPushDestination.Transformation` for the `EventProducerPushDestination`
+On the consuming side it might be ok to store and use the protobuf messages as they are, but it is also possible to transform
+them from the wire protocol protobuf messages back to some application domain specific representation before storing in the 
+journal by defining a `EventProducerPushDestination.Transformation` and specifying for the `EventProducerPushDestination`
 on construction using `withTransformation` or `withTransformationForOrigin`.
+

--- a/samples/grpc/local-drone-control-scala/project/build.properties
+++ b/samples/grpc/local-drone-control-scala/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.2

--- a/samples/grpc/restaurant-drone-deliveries-service-scala/project/build.properties
+++ b/samples/grpc/restaurant-drone-deliveries-service-scala/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.2


### PR DESCRIPTION
Before this the producer push spec was relying on Akka serialisation format for the payloads, but to use protobuf messages (which I think is what we should recommend for decoupling) as wire protocol we need to be able to pass along protobuf descriptors for the messages.

Added minimal docs, not sure, but perhaps we need something more fleshed out?