### PR TITLE
perf: Avoid event serialization in producer push destination

### DIFF
--- a/akka-projection-grpc-tests/src/test/java/akka/projection/grpc/consumer/javadsl/EventProducerPushDestinationCompileTest.java
+++ b/akka-projection-grpc-tests/src/test/java/akka/projection/grpc/consumer/javadsl/EventProducerPushDestinationCompileTest.java
@@ -83,7 +83,7 @@ public class EventProducerPushDestinationCompileTest {
     EventProducerPushDestination destination =
         EventProducerPushDestination.create("stream-id", protoDescriptors, system)
             .withConsumerFilters(
-                Arrays.asList(new ConsumerFilter.IncludeTopics(Collections.singleton("myhome/groundfloor/+/temperature")))
+                Collections.singletonList(new ConsumerFilter.IncludeTopics(Collections.singleton("myhome/groundfloor/+/temperature")))
             );
       // #consumerFilters
   }
@@ -94,7 +94,8 @@ public class EventProducerPushDestinationCompileTest {
       EventProducerPushDestination.create("stream-id", protoDescriptors, system)
         .withTransformationForOrigin((String originId, Metadata metadata) ->
             Transformation.empty()
-              .registerPersistenceIdMapper(envelope -> envelope.persistenceId().replace("originalPrefix", "newPrefix"))
+              .registerPersistenceIdMapper(system, envelope ->
+                  envelope.persistenceId().replace("originalPrefix", "newPrefix"))
               .registerTagMapper(String.class, envelope -> {
                   Set<String> newTags = new HashSet<>();
                   newTags.addAll(envelope.getTags());

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/ProtoAnySerializationSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/ProtoAnySerializationSpec.scala
@@ -21,15 +21,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import com.google.protobuf.any.{ Any => ScalaPbAny }
 import com.google.protobuf.{ Any => PbAny }
 
-class ProtoAnySerializationSpec
-    extends ScalaTestWithActorTestKit("""
-    akka.actor.serialization-bindings {
-      # // FIXME important to document this for the SerializedEvent optimization to work
-      "scalapb.GeneratedMessage" = proto
-    }
-    """)
-    with AnyWordSpecLike
-    with LogCapturing {
+class ProtoAnySerializationSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
 
   private val serializationJava =
     new ProtoAnySerialization(

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/ProtoAnySerializationSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/ProtoAnySerializationSpec.scala
@@ -21,7 +21,15 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import com.google.protobuf.any.{ Any => ScalaPbAny }
 import com.google.protobuf.{ Any => PbAny }
 
-class ProtoAnySerializationSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
+class ProtoAnySerializationSpec
+    extends ScalaTestWithActorTestKit("""
+    akka.actor.serialization-bindings {
+      # // FIXME important to document this for the SerializedEvent optimization to work
+      "scalapb.GeneratedMessage" = proto
+    }
+    """)
+    with AnyWordSpecLike
+    with LogCapturing {
 
   private val serializationJava =
     new ProtoAnySerialization(
@@ -43,6 +51,7 @@ class ProtoAnySerializationSpec extends ScalaTestWithActorTestKit with AnyWordSp
       ProtoAnySerialization.Prefer.Scala)
 
   private val akkaSerialization = SerializationExtension(system.classicSystem)
+  private val akkaProtobufSerializer = akkaSerialization.serializerFor(classOf[com.google.protobuf.GeneratedMessageV3])
 
   private val addLineItem = AddLineItem(name = "item", productId = "id", quantity = 10)
 
@@ -60,6 +69,15 @@ class ProtoAnySerializationSpec extends ScalaTestWithActorTestKit with AnyWordSp
       val deserializedEvent = serializationJava.deserialize(pbAny)
       deserializedEvent.getClass shouldBe classOf[com.google.protobuf.Timestamp]
       deserializedEvent shouldBe event
+
+      val serializedEvent = serializationJava.toSerializedEvent(pbAny).get
+      serializedEvent.serializerId shouldBe akkaProtobufSerializer.identifier
+      serializedEvent.serializerManifest shouldBe event.getClass.getName
+      val deserializedEvent2 = akkaSerialization
+        .deserialize(serializedEvent.bytes, serializedEvent.serializerId, serializedEvent.serializerManifest)
+        .get
+      deserializedEvent2.getClass shouldBe classOf[com.google.protobuf.Timestamp]
+      deserializedEvent2 shouldBe event
     }
 
     "encode and decode ScalaPb proto message" in {
@@ -68,6 +86,14 @@ class ProtoAnySerializationSpec extends ScalaTestWithActorTestKit with AnyWordSp
       pbAny.typeUrl shouldBe "type.googleapis.com/akka.projection.grpc.internal.TestEvent"
       val deserializedEvent = serializationScala.deserialize(pbAny)
       deserializedEvent shouldBe event
+
+      val serializedEvent = serializationScala.toSerializedEvent(pbAny).get
+      serializedEvent.serializerId shouldBe akkaProtobufSerializer.identifier
+      serializedEvent.serializerManifest shouldBe event.getClass.getName
+      val deserializedEvent2 = akkaSerialization
+        .deserialize(serializedEvent.bytes, serializedEvent.serializerId, serializedEvent.serializerManifest)
+        .get
+      deserializedEvent2 shouldBe event
     }
 
     "pass through Java proto Any" in {
@@ -84,9 +110,11 @@ class ProtoAnySerializationSpec extends ScalaTestWithActorTestKit with AnyWordSp
         serializationJava.deserialize(pbAny).asInstanceOf[PbAny]
       deserializedEvent.getTypeUrl shouldBe typeUrl
       deserializedEvent.getValue.toString(StandardCharsets.UTF_8) shouldBe value
+
+      serializationJava.toSerializedEvent(pbAny) shouldBe None
     }
 
-    "pass through ScalaPb Any and decode it as preferred Any Any" in {
+    "pass through ScalaPb Any and decode it as preferred Any" in {
       val value = "hello"
       val typeUrl = "type.my.io/custom"
       val event =
@@ -103,6 +131,9 @@ class ProtoAnySerializationSpec extends ScalaTestWithActorTestKit with AnyWordSp
         serializationJava.deserialize(pbAny).asInstanceOf[PbAny]
       deserializedEventJava.getTypeUrl shouldBe typeUrl
       deserializedEventJava.getValue.toString(StandardCharsets.UTF_8) shouldBe value
+
+      serializationScala.toSerializedEvent(pbAny) shouldBe None
+      serializationJava.toSerializedEvent(pbAny) shouldBe None
     }
 
     "pass through Java proto Any with Google typeUrl" in {
@@ -124,6 +155,8 @@ class ProtoAnySerializationSpec extends ScalaTestWithActorTestKit with AnyWordSp
       val deserializedEvent = serializationJava.deserialize(pbAny).asInstanceOf[PbAny]
       deserializedEvent.getTypeUrl shouldBe typeUrl
       com.google.protobuf.Timestamp.parseFrom(deserializedEvent.getValue) shouldBe value
+
+      serializationJava.toSerializedEvent(pbAny) shouldBe None
     }
 
     "pass through ScalaPb Any with Google typeUrl" in {
@@ -138,18 +171,25 @@ class ProtoAnySerializationSpec extends ScalaTestWithActorTestKit with AnyWordSp
         serializationScala.deserialize(pbAny).asInstanceOf[ScalaPbAny]
       deserializedEvent.typeUrl shouldBe typeUrl
       TestEvent.parseFrom(deserializedEvent.value.toByteArray) shouldBe value
+
+      serializationScala.toSerializedEvent(pbAny) shouldBe None
     }
 
     "encode and decode with Akka serialization with string manifest" in {
       val event = Address("akka", system.name, "localhost", 2552)
       val pbAny = serializationJava.serialize(event)
       val serializer = akkaSerialization.findSerializerFor(event)
-      // no manifest for String serializer
-      pbAny.typeUrl shouldBe s"ser.akka.io/${serializer.identifier}:${Serializers
-        .manifestFor(serializer, event)}"
+      val expectedTypeUrl = s"ser.akka.io/${serializer.identifier}:${Serializers.manifestFor(serializer, event)}"
+      pbAny.typeUrl shouldBe expectedTypeUrl
 
       val deserializedEvent = serializationJava.deserialize(pbAny)
       deserializedEvent shouldBe event
+
+      val serializedEvent = serializationJava.toSerializedEvent(pbAny).get
+      val deserializedEvent2 = akkaSerialization
+        .deserialize(serializedEvent.bytes, serializedEvent.serializerId, serializedEvent.serializerManifest)
+        .get
+      deserializedEvent2 shouldBe event
     }
 
     "encode and decode with Akka serialization without string manifest" in {
@@ -157,10 +197,17 @@ class ProtoAnySerializationSpec extends ScalaTestWithActorTestKit with AnyWordSp
       val pbAny = serializationJava.serialize(event)
       val serializer = akkaSerialization.findSerializerFor(event)
       // no manifest for String serializer
-      pbAny.typeUrl shouldBe s"ser.akka.io/${serializer.identifier}"
+      val expectedTypeUrl = s"ser.akka.io/${serializer.identifier}"
+      pbAny.typeUrl shouldBe expectedTypeUrl
 
       val deserializedEvent = serializationJava.deserialize(pbAny)
       deserializedEvent shouldBe event
+
+      val serializedEvent = serializationJava.toSerializedEvent(pbAny).get
+      val deserializedEvent2 = akkaSerialization
+        .deserialize(serializedEvent.bytes, serializedEvent.serializerId, serializedEvent.serializerManifest)
+        .get
+      deserializedEvent2 shouldBe event
     }
 
     "support se/deserializing java protobufs" in {

--- a/akka-projection-grpc/src/main/mima-filters/1.5.0-M3.backwards.excludes/SerializedEvent.excludes
+++ b/akka-projection-grpc/src/main/mima-filters/1.5.0-M3.backwards.excludes/SerializedEvent.excludes
@@ -1,0 +1,7 @@
+# not yet in a published release, or internals
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.grpc.consumer.javadsl.Transformation.registerPersistenceIdMapper")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.grpc.consumer.scaladsl.EventProducerPushDestination#Transformation.registerPersistenceIdMapper")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.grpc.internal.ProtoAnySerialization#JavaPbResolvedType.this")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.projection.grpc.internal.ProtoAnySerialization#ResolvedType.messageClass")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.projection.grpc.internal.ProtoAnySerialization#ResolvedType.akkaSerializer")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.grpc.internal.ProtoAnySerialization#ScalaPbResolvedType.this")

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/javadsl/Transformation.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/javadsl/Transformation.scala
@@ -15,6 +15,8 @@ import java.util.function.{ Function => JFunction }
 import scala.compat.java8.OptionConverters._
 import scala.reflect.ClassTag
 
+import akka.actor.typed.ActorSystem
+
 object Transformation {
 
   /**
@@ -49,8 +51,8 @@ final class Transformation private (val delegate: scaladsl.EventProducerPushDest
    * same incoming persistence id to the same stored persistence id to not introduce gaps in the sequence numbers
    * and break consuming projections.
    */
-  def registerPersistenceIdMapper(f: JFunction[EventEnvelope[Any], String]): Transformation = {
-    new Transformation(delegate.registerPersistenceIdMapper(f.apply))
+  def registerPersistenceIdMapper(system: ActorSystem[_], f: JFunction[EventEnvelope[Any], String]): Transformation = {
+    new Transformation(delegate.registerPersistenceIdMapper(f.apply)(system))
   }
 
   /**


### PR DESCRIPTION
See https://github.com/akka/akka/pull/32068 and https://github.com/akka/akka-persistence-r2dbc/pull/441