### PR TITLE
chore: A bit less noise on gRPC journal client fail/reconnect

### DIFF
--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
@@ -30,6 +30,7 @@ import akka.projection.grpc.consumer.ConsumerFilter
 import akka.projection.grpc.consumer.GrpcQuerySettings
 import akka.projection.grpc.consumer.scaladsl
 import akka.projection.grpc.consumer.scaladsl.GrpcReadJournal.withChannelBuilderOverrides
+import akka.projection.grpc.internal.ConnectionException
 import akka.projection.grpc.internal.ProtoAnySerialization
 import akka.projection.grpc.internal.ProtobufProtocolConversions
 import akka.projection.grpc.internal.proto
@@ -62,16 +63,6 @@ import java.util.concurrent.TimeUnit
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import scala.util.control.NoStackTrace
-
-/**
- * INTERNAL API
- */
-@InternalApi
-private[akka] final class ConnectionException(host: String, port: String, streamId: String)
-    extends RuntimeException(s"Connection to $host:$port for stream id $streamId failed or lost")
-    with NoStackTrace
-
 @ApiMayChange
 object GrpcReadJournal {
   val Identifier = "akka.projection.grpc.consumer"

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
@@ -64,6 +64,14 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.util.control.NoStackTrace
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] final class ConnectionException(host: String, port: String, streamId: String)
+    extends RuntimeException(s"Connection to $host:$port for stream id $streamId failed or lost")
+    with NoStackTrace
+
 @ApiMayChange
 object GrpcReadJournal {
   val Identifier = "akka.projection.grpc.consumer"
@@ -342,10 +350,11 @@ final class GrpcReadJournal private (
         .invoke(streamIn)
         .recover {
           case ex: akka.grpc.GrpcServiceException if ex.status.getCode == Status.Code.UNAVAILABLE =>
-            // this means we couldn't connect, will be retried, so make it less noisy
-            throw new RuntimeException(
-              s"Connection to ${clientSettings.serviceName}:${clientSettings.servicePortName.getOrElse(clientSettings.defaultPort)} failed or lost")
-              with NoStackTrace
+            // this means we couldn't connect, will be retried, relatively common, so make it less noisy
+            throw new ConnectionException(
+              clientSettings.serviceName,
+              clientSettings.servicePortName.getOrElse(clientSettings.defaultPort.toString),
+              streamId)
 
           case th: Throwable =>
             throw new RuntimeException(s"Failure to consume gRPC event stream for [${streamId}]", th)

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/ConnectionException.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/ConnectionException.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2009-2023 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.projection.grpc.internal
 
 import akka.annotation.InternalApi

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/ConnectionException.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/ConnectionException.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2009-2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.projection.grpc.internal
+
+import akka.annotation.InternalApi
+
+import scala.util.control.NoStackTrace
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] final class ConnectionException(host: String, port: String, streamId: String)
+    extends RuntimeException(s"Connection to $host:$port for stream id $streamId failed or lost")
+    with NoStackTrace


### PR DESCRIPTION
There is something more spewing out a full stack trace but didn't figure out what yet.