### PR TITLE
chore: remove sensorId

### DIFF
--- a/samples/grpc/iot-service-scala/README.md
+++ b/samples/grpc/iot-service-scala/README.md
@@ -37,7 +37,7 @@
 6. Try it with [grpcurl](https://github.com/fullstorydev/grpcurl). Register a sensor:
 
     ```shell
-    grpcurl -d '{"sensor_id":"temp-1", "secret":"foo"}' -plaintext 127.0.0.1:8101 iot.registration.RegistrationService.Register
+    grpcurl -d '{"sensor_entity_id":"temp-1", "secret":"foo"}' -plaintext 127.0.0.1:8101 iot.registration.RegistrationService.Register
     ```
 
     or same `grpcurl` commands to port 8102 to reach node 2.
@@ -51,6 +51,6 @@
 8. After registration of a sensor the EdgeApp will simulate temperature readings, which will be consumed by the iot-service. Read current temperature, which should be updated with a random value: 
 
 9. ```shell
-    grpcurl -d '{"sensor_id":"temp-1"}' -plaintext 127.0.0.1:8101 iot.temperature.SensorTwinService.GetTemperature
+    grpcurl -d '{"sensor_entity_id":"temp-1"}' -plaintext 127.0.0.1:8101 iot.temperature.SensorTwinService.GetTemperature
     ```
 

--- a/samples/grpc/iot-service-scala/src/main/protobuf/iot/registration/RegistrationEvents.proto
+++ b/samples/grpc/iot-service-scala/src/main/protobuf/iot/registration/RegistrationEvents.proto
@@ -8,8 +8,7 @@ package iot.registration;
 // Events published to external services
 
 message Registered {
-    string sensor_id = 1;
-    SecretDataValue secret = 2;
+    SecretDataValue secret = 1;
 }
 
 message SecretDataValue {

--- a/samples/grpc/iot-service-scala/src/main/protobuf/iot/registration/RegistrationService.proto
+++ b/samples/grpc/iot-service-scala/src/main/protobuf/iot/registration/RegistrationService.proto
@@ -15,6 +15,6 @@ service RegistrationService {
 
 
 message RegisterRequest {
-    string sensor_id = 1;
+    string sensor_entity_id = 1;
     string secret = 2;
 }

--- a/samples/grpc/iot-service-scala/src/main/protobuf/iot/registration/SensorTwinService.proto
+++ b/samples/grpc/iot-service-scala/src/main/protobuf/iot/registration/SensorTwinService.proto
@@ -12,10 +12,10 @@ service SensorTwinService {
 }
 
 message GetTemperatureRequest {
-    string sensor_id = 1;
+    string sensor_entity_id = 1;
 }
 
 message CurrentTemperature {
-    string sensor_id = 1;
+    string sensor_entity_id = 1;
     int32 temperature = 2;
 }

--- a/samples/grpc/iot-service-scala/src/main/protobuf/iot/registration/TemperatureEvents.proto
+++ b/samples/grpc/iot-service-scala/src/main/protobuf/iot/registration/TemperatureEvents.proto
@@ -8,6 +8,5 @@ package iot.temperature;
 // Events consumed from external services
 
 message TemperatureRead {
-    string sensor_id = 1;
-    int32 temperature = 2;
+    int32 temperature = 1;
 }

--- a/samples/grpc/iot-service-scala/src/main/scala/iot/registration/Registration.scala
+++ b/samples/grpc/iot-service-scala/src/main/scala/iot/registration/Registration.scala
@@ -72,10 +72,10 @@ object Registration {
       Registration(entityContext.entityId)))
   }
 
-  def apply(sensorId: String): Behavior[Command] = {
+  def apply(entityId: String): Behavior[Command] = {
     EventSourcedBehavior
       .withEnforcedReplies[Command, Event, State](
-        persistenceId = PersistenceId(EntityKey.name, sensorId),
+        persistenceId = PersistenceId(EntityKey.name, entityId),
         emptyState = State.empty,
         commandHandler =
           (state, command) => handleCommand(state, command),

--- a/samples/grpc/iot-service-scala/src/main/scala/iot/registration/RegistrationEvents.scala
+++ b/samples/grpc/iot-service-scala/src/main/scala/iot/registration/RegistrationEvents.scala
@@ -31,9 +31,7 @@ object RegistrationEvents {
   private def transformRegistered(
       envelope: EventEnvelope[Registration.Registered]): proto.Registered = {
     val event = envelope.event
-    proto.Registered(
-      sensorId = PersistenceId.extractEntityId(envelope.persistenceId),
-      secret = Some(proto.SecretDataValue(event.secret.value)))
+    proto.Registered(secret = Some(proto.SecretDataValue(event.secret.value)))
   }
 
 }

--- a/samples/grpc/iot-service-scala/src/main/scala/iot/registration/RegistrationServiceImpl.scala
+++ b/samples/grpc/iot-service-scala/src/main/scala/iot/registration/RegistrationServiceImpl.scala
@@ -27,8 +27,8 @@ class RegistrationServiceImpl(system: ActorSystem[_])
   private val sharding = ClusterSharding(system)
 
   override def register(in: proto.RegisterRequest): Future[Empty] = {
-    logger.info("register sensor {}", in.sensorId)
-    val entityRef = sharding.entityRefFor(Registration.EntityKey, in.sensorId)
+    logger.info("register sensor {}", in.sensorEntityId)
+    val entityRef = sharding.entityRefFor(Registration.EntityKey, in.sensorEntityId)
     val reply: Future[Done] =
       entityRef.askWithStatus(
         Registration.Register(Registration.SecretDataValue(in.secret), _))

--- a/samples/grpc/iot-service-scala/src/main/scala/iot/temperature/SensorTwin.scala
+++ b/samples/grpc/iot-service-scala/src/main/scala/iot/temperature/SensorTwin.scala
@@ -33,9 +33,9 @@ object SensorTwin {
       SensorTwin(entityContext.entityId)))
   }
 
-  def apply(sensorId: String): Behavior[Command] =
+  def apply(entityId: String): Behavior[Command] =
     DurableStateBehavior[Command, State](
-      PersistenceId(EntityKey.name, sensorId),
+      PersistenceId(EntityKey.name, entityId),
       State(0),
       (state, cmd) =>
         cmd match {

--- a/samples/grpc/iot-service-scala/src/main/scala/iot/temperature/SensorTwinServiceImpl.scala
+++ b/samples/grpc/iot-service-scala/src/main/scala/iot/temperature/SensorTwinServiceImpl.scala
@@ -23,12 +23,12 @@ class SensorTwinServiceImpl(system: ActorSystem[_]) extends SensorTwinService {
 
   override def getTemperature(
       in: proto.GetTemperatureRequest): Future[proto.CurrentTemperature] = {
-    val entityRef = sharding.entityRefFor(SensorTwin.EntityKey, in.sensorId)
+    val entityRef = sharding.entityRefFor(SensorTwin.EntityKey, in.sensorEntityId)
     val reply: Future[Int] =
       entityRef.askWithStatus(SensorTwin.GetTemperature(_))
     val response =
       reply.map(temperature =>
-        proto.CurrentTemperature(in.sensorId, temperature))
+        proto.CurrentTemperature(in.sensorEntityId, temperature))
     convertError(response)
   }
 


### PR DESCRIPTION
* Learned from domain expert that sensor id (DevEUI) should not be used as entityId.
* To not convolute the sample we just skip the sensor id.
