### PR TITLE
fix: Adjust start offset for downscaling scenario

### DIFF
--- a/akka-projection-r2dbc/src/main/resources/reference.conf
+++ b/akka-projection-r2dbc/src/main/resources/reference.conf
@@ -37,6 +37,11 @@ akka.projection.r2dbc {
 
     # Trying to batch insert offsets in batches of this size.
     offset-batch-size = 20
+
+    # Same as akka.persistence.r2dbc.query.backtracking but if query plugin (source provider query)
+    # is using another config that should be set here so that the offset store is aware of
+    # the right backtracking settings.
+    backtracking = ${akka.persistence.r2dbc.query.backtracking}
   }
 
   # By default it shares connection-factory with akka-persistence-r2dbc (write side),

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/R2dbcProjectionSettings.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/R2dbcProjectionSettings.scala
@@ -51,7 +51,9 @@ object R2dbcProjectionSettings {
       deleteInterval = config.getDuration("offset-store.delete-interval"),
       logDbCallsExceeding,
       warnAboutFilteredEventsInFlow = config.getBoolean("warn-about-filtered-events-in-flow"),
-      offsetBatchSize = config.getInt("offset-store.offset-batch-size"))
+      offsetBatchSize = config.getInt("offset-store.offset-batch-size"),
+      backtrackingEnabled = config.getBoolean("offset-store.backtracking.enabled"),
+      backtrackingWindow = config.getDuration("offset-store.backtracking.window"))
   }
 
   /**
@@ -74,7 +76,9 @@ final class R2dbcProjectionSettings private (
     val deleteInterval: JDuration,
     val logDbCallsExceeding: FiniteDuration,
     val warnAboutFilteredEventsInFlow: Boolean,
-    val offsetBatchSize: Int) {
+    val offsetBatchSize: Int,
+    val backtrackingEnabled: Boolean,
+    val backtrackingWindow: JDuration) {
 
   val offsetTableWithSchema: String = schema.map(_ + ".").getOrElse("") + offsetTable
   val timestampOffsetTableWithSchema: String = schema.map(_ + ".").getOrElse("") + timestampOffsetTable
@@ -153,7 +157,10 @@ final class R2dbcProjectionSettings private (
       deleteInterval,
       logDbCallsExceeding,
       warnAboutFilteredEventsInFlow,
-      offsetBatchSize)
+      offsetBatchSize,
+      backtrackingEnabled, // no copy, only from config
+      backtrackingWindow // no copy, only from config
+    )
 
   override def toString =
     s"R2dbcProjectionSettings($schema, $offsetTable, $timestampOffsetTable, $managementTable, $useConnectionFactory, $timeWindow, $keepNumberOfEntries, $evictInterval, $deleteInterval, $logDbCallsExceeding, $warnAboutFilteredEventsInFlow, $offsetBatchSize)"


### PR DESCRIPTION
* When downscaling projection instances (changing slice distribution) there is a possibility that one of the previous projection instances was further behind than the backtracking window, which would cause missed events if we started from latest. In that case we adjust the start offset.

based on `release-1.4` and can be forward ported when tested
