### PR TITLE
chore: More debug logging for R2DBC tests

### DIFF
--- a/akka-projection-r2dbc/src/it/resources/application.conf
+++ b/akka-projection-r2dbc/src/it/resources/application.conf
@@ -1,2 +1,7 @@
 # default is postgres
 include "application-postgres.conf"
+
+akka.actor.testkit.typed {
+  # some tests observed flakey/failing with the default 3s
+  single-expect-default = 5s
+}

--- a/akka-projection-r2dbc/src/it/scala/akka/projection/r2dbc/R2dbcProjectionSpec.scala
+++ b/akka-projection-r2dbc/src/it/scala/akka/projection/r2dbc/R2dbcProjectionSpec.scala
@@ -20,6 +20,7 @@ import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.LoggerOps
 import akka.persistence.r2dbc.internal.Sql.Interpolation
 import akka.persistence.r2dbc.internal.R2dbcExecutor
 import akka.projection.HandlerRecoveryStrategy
@@ -103,7 +104,7 @@ object R2dbcProjectionSpec {
       val savedStrOpt = findById(id)
 
       savedStrOpt.flatMap { strOpt =>
-        logger.debug("Find by id [{}] found [{}]", id, strOpt)
+        logger.debug2("Find by id [{}] found [{}]", id, strOpt)
         val newConcatStr = strOpt
           .map {
             _.concat(payload)
@@ -153,7 +154,7 @@ object R2dbcProjectionSpec {
           if (updated != 1L) {
             throw new RuntimeException(
               s"Update '$stmtSql' of $concatStr didn't see the expected 1 updated rows (was $updated)")
-          } else logger.debug(s"Successfully updated [{}] to [{}]", concatStr.id, concatStr.text)
+          } else logger.debug2(s"Successfully updated [{}] to [{}]", concatStr.id, concatStr.text)
           Done
         }
     }


### PR DESCRIPTION
References #992 

With these logs and running a repeat test run of `R2dbcTimestampOffsetProjectionSpec` on H2 I have observed a select after a write not finding the written row (different tests failing but it seems like the same underlying problem):
```
[2023-09-07 16:06:22,256] [DEBUG] [akka.projection.r2dbc.R2dbcProjectionSpec$TestRepository] [] [] [R2dbcTimestampOffsetProjectionSpec-akka.actor.default-dispatcher-3] - TestRepository.findById: [221177bd-a73d-40e7-b601-1a84f84cb502]
[2023-09-07 16:06:22,256] [DEBUG] [akka.projection.r2dbc.R2dbcProjectionSpec$TestRepository] [] [] [R2dbcTimestampOffsetProjectionSpec-akka.actor.default-dispatcher-3] - Find by id [221177bd-a73d-40e7-b601-1a84f84cb502] found [None]
[2023-09-07 16:06:22,256] [DEBUG] [akka.projection.r2dbc.R2dbcProjectionSpec$TestRepository] [] [] [R2dbcTimestampOffsetProjectionSpec-akka.actor.default-dispatcher-3] - TestRepository.upsert: [ConcatStr(221177bd-a73d-40e7-b601-1a84f84cb502,e1-1)]
[2023-09-07 16:06:22,257] [DEBUG] [akka.projection.r2dbc.R2dbcProjectionSpec$TestRepository] [] [] [R2dbcTimestampOffsetProjectionSpec-akka.actor.default-dispatcher-8] - TestRepository.findById: [221177bd-a73d-40e7-b601-1a84f84cb502]
[2023-09-07 16:06:22,257] [DEBUG] [akka.projection.r2dbc.R2dbcProjectionSpec$TestRepository] [] [] [R2dbcTimestampOffsetProjectionSpec-akka.actor.default-dispatcher-3] - Successfully updated [221177bd-a73d-40e7-b601-1a84f84cb502] to [e1-1]
[2023-09-07 16:06:22,257] [DEBUG] [akka.projection.r2dbc.R2dbcTimestampOffsetProjectionSpec$ConcatHandler] [] [] [R2dbcTimestampOffsetProjectionSpec-akka.actor.default-dispatcher-7] - handling EventEnvelope(TimestampOffset(2023-09-07T14:06:22.242590Z,2023-09-07T14:06:23.242590Z,Map(221177bd-a73d-40e7-b601-1a84f84cb502 -> 2)),221177bd-a73d-40e7-b601-1a84f84cb502,2,java.lang.String,1694095582242,,,566,false,,[])
[2023-09-07 16:06:22,257] [DEBUG] [akka.projection.r2dbc.R2dbcProjectionSpec$TestRepository] [] [] [R2dbcTimestampOffsetProjectionSpec-akka.actor.default-dispatcher-7] - TestRepository.findById: [221177bd-a73d-40e7-b601-1a84f84cb502]
[2023-09-07 16:06:22,258] [DEBUG] [akka.projection.r2dbc.R2dbcProjectionSpec$TestRepository] [] [] [R2dbcTimestampOffsetProjectionSpec-akka.actor.default-dispatcher-7] - Find by id [221177bd-a73d-40e7-b601-1a84f84cb502] found [None]
[2023-09-07 16:06:22,258] [DEBUG] [akka.projection.r2dbc.R2dbcProjectionSpec$TestRepository] [] [] [R2dbcTimestampOffsetProjectionSpec-akka.actor.default-dispatcher-7] - TestRepository.upsert: [ConcatStr(221177bd-a73d-40e7-b601-1a84f84cb502,e1-2)]
[2023-09-07 16:06:22,258] [DEBUG] [akka.projection.r2dbc.R2dbcProjectionSpec$TestRepository] [] [] [R2dbcTimestampOffsetProjectionSpec-akka.actor.default-dispatcher-7] - Successfully updated [221177bd-a73d-40e7-b601-1a84f84cb502] to [e1-2]
[2023-09-07 16:06:22,258] [DEBUG] [akka.projection.r2dbc.R2dbcTimestampOffsetProjectionSpec$ConcatHandler] [] [] [R2dbcTimestampOffsetProjectionSpec-akka.actor.default-dispatcher-8] - handling EventEnvelope(TimestampOffset(2023-09-07T14:06:22.243590Z,2023-09-07T14:06:23.243590Z,Map(c03dfed6-68e7-4f12-8fba-187393fad0c2 -> 1)),c03dfed6-68e7-4f12-8fba-187393fad0c2,1,java.lang.String,1694095582243,,,948,false,,[])
```