### PR TITLE
chore: More factory overloads for grpc read journal

### DIFF
--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/javadsl/GrpcReadJournal.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/javadsl/GrpcReadJournal.scala
@@ -38,18 +38,31 @@ object GrpcReadJournal {
   /**
    * Construct a gRPC read journal from configuration `akka.projection.grpc.consumer`. The `stream-id` must
    * be defined in the configuration.
+   *
+   * Configuration from `akka.projection.grpc.consumer.client` will be used to connect to the remote producer.
    */
   def create(
       system: ClassicActorSystemProvider,
       protobufDescriptors: java.util.List[Descriptors.FileDescriptor]): GrpcReadJournal =
+    create(system, GrpcQuerySettings(system), protobufDescriptors)
+
+  /**
+   * Construct a gRPC read journal for the given settings.
+   *
+   * Configuration from `akka.projection.grpc.consumer.client` will be used to connect to the remote producer.
+   */
+  def create(
+      system: ClassicActorSystemProvider,
+      settings: GrpcQuerySettings,
+      protobufDescriptors: java.util.List[Descriptors.FileDescriptor]): GrpcReadJournal =
     create(
       system,
-      GrpcQuerySettings(system),
+      settings,
       GrpcClientSettings.fromConfig(system.classicSystem.settings.config.getConfig(Identifier + ".client"))(system),
       protobufDescriptors)
 
   /**
-   * Construct a gRPC read journal for the given stream-id and explicit `GrpcClientSettings` to control
+   * Construct a gRPC read journal for the given settings and explicit `GrpcClientSettings` to control
    * how to reach the Akka Projection gRPC producer service (host, port etc).
    */
   def create(

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
@@ -74,13 +74,27 @@ object GrpcReadJournal {
    * Construct a gRPC read journal from configuration `akka.projection.grpc.consumer`. The `stream-id` must
    * be defined in the configuration.
    *
+   * Configuration from `akka.projection.grpc.consumer.client` will be used to connect to the remote producer.
+   *
    * Note that the `protobufDescriptors` is a list of the `javaDescriptor` for the used protobuf messages. It is
    * defined in the ScalaPB generated `Proto` companion object.
    */
   def apply(protobufDescriptors: immutable.Seq[Descriptors.FileDescriptor])(
       implicit system: ClassicActorSystemProvider): GrpcReadJournal =
+    apply(GrpcQuerySettings(system), protobufDescriptors)
+
+  /**
+   * Construct a gRPC read journal for the given settings.
+   *
+   * Configuration from `akka.projection.grpc.consumer.client` will be used to connect to the remote producer.
+   *
+   * Note that the `protobufDescriptors` is a list of the `javaDescriptor` for the used protobuf messages. It is
+   * defined in the ScalaPB generated `Proto` companion object.
+   */
+  def apply(settings: GrpcQuerySettings, protobufDescriptors: immutable.Seq[Descriptors.FileDescriptor])(
+      implicit system: ClassicActorSystemProvider): GrpcReadJournal =
     apply(
-      GrpcQuerySettings(system),
+      settings,
       GrpcClientSettings.fromConfig(system.classicSystem.settings.config.getConfig(Identifier + ".client")),
       protobufDescriptors)
 


### PR DESCRIPTION
Turns out creating it with GrpcClientSettings just to be able to specify settings was messy.