### PR TITLE
bump: Jackson 2.15.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
     val scalaTest = "3.2.16"
     val testContainers = "1.19.0"
     val junit = "4.13.2"
-    val jacksonDatabind = "2.13.5" // this should match the version of jackson used by akka-serialization-jackson
+    val jacksonDatabind = "2.15.2" // this should match the version of jackson used by akka-serialization-jackson
   }
 
   object Compile {


### PR DESCRIPTION
Use same Jackson version as in upcoming Akka 2.9