### PR TITLE
sample: update local-drone-control-scala for kubernetes

### DIFF
--- a/samples/grpc/local-drone-control-scala/src/main/resources/META-INF/native-image/com.typesafe.config/resource-config.json
+++ b/samples/grpc/local-drone-control-scala/src/main/resources/META-INF/native-image/com.typesafe.config/resource-config.json
@@ -1,0 +1,9 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": ".+\\.conf"
+      }
+    ]
+  }
+}

--- a/samples/grpc/local-drone-control-scala/src/main/resources/META-INF/native-image/generated/jni-config.json
+++ b/samples/grpc/local-drone-control-scala/src/main/resources/META-INF/native-image/generated/jni-config.json
@@ -1,0 +1,115 @@
+[
+{
+  "name":"[Lcom.sun.management.internal.DiagnosticCommandArgumentInfo;"
+},
+{
+  "name":"[Lcom.sun.management.internal.DiagnosticCommandInfo;"
+},
+{
+  "name":"com.sun.management.internal.DiagnosticCommandArgumentInfo",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.String","java.lang.String","java.lang.String","java.lang.String","boolean","boolean","boolean","int"] }]
+},
+{
+  "name":"com.sun.management.internal.DiagnosticCommandInfo",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.String","java.lang.String","java.lang.String","java.lang.String","java.lang.String","java.lang.String","boolean","java.util.List"] }]
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.channel.ChannelException"
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.channel.DefaultFileRegion",
+  "fields":[{"name":"file"}, {"name":"transferred"}]
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.channel.epoll.LinuxSocket"
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.channel.epoll.Native"
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.channel.epoll.NativeDatagramPacketArray$NativeDatagramPacket",
+  "fields":[{"name":"count"}, {"name":"memoryAddress"}, {"name":"recipientAddr"}, {"name":"recipientAddrLen"}, {"name":"recipientPort"}, {"name":"recipientScopeId"}, {"name":"segmentSize"}, {"name":"senderAddr"}, {"name":"senderAddrLen"}, {"name":"senderPort"}, {"name":"senderScopeId"}]
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.channel.epoll.NativeStaticallyReferencedJniMethods"
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.channel.unix.Buffer"
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.channel.unix.DatagramSocketAddress",
+  "methods":[{"name":"<init>","parameterTypes":["byte[]","int","int","int","io.grpc.netty.shaded.io.netty.channel.unix.DatagramSocketAddress"] }]
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.channel.unix.DomainDatagramSocketAddress",
+  "methods":[{"name":"<init>","parameterTypes":["byte[]","int","io.grpc.netty.shaded.io.netty.channel.unix.DomainDatagramSocketAddress"] }]
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods"
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.channel.unix.FileDescriptor"
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.channel.unix.LimitsStaticallyReferencedJniMethods"
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.channel.unix.PeerCredentials",
+  "methods":[{"name":"<init>","parameterTypes":["int","int","int[]"] }]
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.channel.unix.Socket"
+},
+{
+  "name":"java.io.FileDescriptor",
+  "fields":[{"name":"fd"}]
+},
+{
+  "name":"java.io.IOException"
+},
+{
+  "name":"java.lang.Boolean",
+  "methods":[{"name":"getBoolean","parameterTypes":["java.lang.String"] }]
+},
+{
+  "name":"java.lang.OutOfMemoryError"
+},
+{
+  "name":"java.lang.RuntimeException"
+},
+{
+  "name":"java.lang.SecurityManager",
+  "fields":[{"name":"initialized"}]
+},
+{
+  "name":"java.net.InetSocketAddress",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.String","int"] }]
+},
+{
+  "name":"java.net.PortUnreachableException"
+},
+{
+  "name":"java.nio.Buffer",
+  "fields":[{"name":"limit"}, {"name":"position"}],
+  "methods":[{"name":"limit","parameterTypes":[] }, {"name":"position","parameterTypes":[] }]
+},
+{
+  "name":"java.nio.DirectByteBuffer"
+},
+{
+  "name":"java.nio.channels.ClosedChannelException",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"java.util.Arrays",
+  "methods":[{"name":"asList","parameterTypes":["java.lang.Object[]"] }]
+},
+{
+  "name":"sun.management.VMManagementImpl",
+  "fields":[{"name":"compTimeMonitoringSupport"}, {"name":"currentThreadCpuTimeSupport"}, {"name":"objectMonitorUsageSupport"}, {"name":"otherThreadCpuTimeSupport"}, {"name":"remoteDiagnosticCommandsSupport"}, {"name":"synchronizerUsageSupport"}, {"name":"threadAllocatedMemorySupport"}, {"name":"threadContentionMonitoringSupport"}]
+},
+{
+  "name":"sun.nio.ch.FileChannelImpl",
+  "fields":[{"name":"fd"}]
+}
+]

--- a/samples/grpc/local-drone-control-scala/src/main/resources/META-INF/native-image/generated/reflect-config.json
+++ b/samples/grpc/local-drone-control-scala/src/main/resources/META-INF/native-image/generated/reflect-config.json
@@ -42,6 +42,12 @@
     "name": "[Lakka.routing.ConsistentRoutee;"
   },
   {
+    "name": "[Lakka.stream.impl.BatchingInputBuffer;"
+  },
+  {
+    "name": "[Lakka.stream.impl.FanOut$FanoutOutputs;"
+  },
+  {
     "name": "[Lakka.stream.stage.GraphStageLogic;"
   },
   {
@@ -190,6 +196,9 @@
   },
   {
     "name": "[Lscala.Tuple4;"
+  },
+  {
+    "name": "[Lsun.security.pkcs.SignerInfo;"
   },
   {
     "name": "[S"
@@ -758,6 +767,63 @@
         ]
       }
     ]
+  },
+  {
+    "name": "akka.discovery.kubernetes.KubernetesApiServiceDiscovery",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "akka.actor.ActorSystem"
+        ]
+      },
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "akka.actor.ExtendedActorSystem"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "akka.discovery.kubernetes.PodList",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.discovery.kubernetes.PodList$Container",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.discovery.kubernetes.PodList$ContainerPort",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.discovery.kubernetes.PodList$ContainerStatus",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.discovery.kubernetes.PodList$Metadata",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.discovery.kubernetes.PodList$Pod",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.discovery.kubernetes.PodList$PodSpec",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "akka.discovery.kubernetes.PodList$PodStatus",
+    "allDeclaredFields": true,
+    "queryAllPublicMethods": true
   },
   {
     "name": "akka.dispatch.AbstractNodeQueue",
@@ -2961,7 +3027,25 @@
     ]
   },
   {
+    "name": "com.sun.crypto.provider.TlsKeyMaterialGenerator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
     "name": "com.sun.crypto.provider.TlsMasterSecretGenerator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.sun.crypto.provider.TlsPrfGenerator$V12",
     "methods": [
       {
         "name": "<init>",
@@ -3556,6 +3640,47 @@
     ]
   },
   {
+    "name": "io.grpc.netty.shaded.io.netty.channel.epoll.EpollChannelOption",
+    "fields": [
+      {
+        "name": "TCP_USER_TIMEOUT"
+      }
+    ]
+  },
+  {
+    "name": "io.grpc.netty.shaded.io.netty.channel.epoll.EpollDomainSocketChannel"
+  },
+  {
+    "name": "io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoopGroup",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "int",
+          "java.util.concurrent.ThreadFactory"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.grpc.netty.shaded.io.netty.channel.epoll.EpollServerSocketChannel",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "io.grpc.netty.shaded.io.netty.channel.epoll.EpollSocketChannel",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
     "name": "io.grpc.netty.shaded.io.netty.channel.epoll.NativeDatagramPacketArray$NativeDatagramPacket"
   },
   {
@@ -3564,6 +3689,20 @@
       {
         "name": "<init>",
         "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "io.grpc.netty.shaded.io.netty.channel.unix.DatagramSocketAddress"
+  },
+  {
+    "name": "io.grpc.netty.shaded.io.netty.channel.unix.DomainDatagramSocketAddress"
+  },
+  {
+    "name": "io.grpc.netty.shaded.io.netty.channel.unix.FileDescriptor",
+    "fields": [
+      {
+        "name": "state"
       }
     ]
   },
@@ -3704,6 +3843,18 @@
       },
       {
         "name": "threadProperties"
+      }
+    ]
+  },
+  {
+    "name": "io.grpc.netty.shaded.io.netty.util.internal.NativeLibraryUtil",
+    "methods": [
+      {
+        "name": "loadLibrary",
+        "parameterTypes": [
+          "java.lang.String",
+          "boolean"
+        ]
       }
     ]
   },
@@ -4258,6 +4409,18 @@
     ]
   },
   {
+    "name": "io.netty.util.internal.NativeLibraryUtil",
+    "methods": [
+      {
+        "name": "loadLibrary",
+        "parameterTypes": [
+          "java.lang.String",
+          "boolean"
+        ]
+      }
+    ]
+  },
+  {
     "name": "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields",
     "fields": [
       {
@@ -4338,6 +4501,9 @@
   },
   {
     "name": "java.io.FilePermission"
+  },
+  {
+    "name": "java.io.IOException"
   },
   {
     "name": "java.io.Serializable",
@@ -4425,6 +4591,9 @@
     ]
   },
   {
+    "name": "java.lang.OutOfMemoryError"
+  },
+  {
     "name": "java.lang.ProcessHandle",
     "methods": [
       {
@@ -4439,6 +4608,9 @@
   },
   {
     "name": "java.lang.Runtime$Version"
+  },
+  {
+    "name": "java.lang.RuntimeException"
   },
   {
     "name": "java.lang.RuntimePermission"
@@ -4606,7 +4778,13 @@
     "name": "java.math.BigInteger"
   },
   {
+    "name": "java.net.InetSocketAddress"
+  },
+  {
     "name": "java.net.NetPermission"
+  },
+  {
+    "name": "java.net.PortUnreachableException"
   },
   {
     "name": "java.net.SocketPermission"
@@ -4671,6 +4849,9 @@
     ]
   },
   {
+    "name": "java.nio.channels.ClosedChannelException"
+  },
+  {
     "name": "java.nio.channels.FileChannel"
   },
   {
@@ -4698,6 +4879,12 @@
   },
   {
     "name": "java.security.SecurityPermission"
+  },
+  {
+    "name": "java.security.interfaces.ECPrivateKey"
+  },
+  {
+    "name": "java.security.interfaces.ECPublicKey"
   },
   {
     "name": "java.util.Date"
@@ -6686,6 +6873,15 @@
     ]
   },
   {
+    "name": "sun.security.provider.JavaKeyStore$DualFormatJKS",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
     "name": "sun.security.provider.JavaKeyStore$JKS",
     "methods": [
       {
@@ -6773,6 +6969,15 @@
     ]
   },
   {
+    "name": "sun.security.provider.certpath.PKIXCertPathValidator",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
     "name": "sun.security.rsa.PSSParameters",
     "methods": [
       {
@@ -6827,6 +7032,15 @@
     ]
   },
   {
+    "name": "sun.security.ssl.SSLContextImpl$TLS12Context",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
     "name": "sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
     "methods": [
       {
@@ -6834,6 +7048,9 @@
         "parameterTypes": []
       }
     ]
+  },
+  {
+    "name": "sun.security.util.ObjectIdentifier"
   },
   {
     "name": "sun.security.x509.AuthorityInfoAccessExtension",
@@ -6882,6 +7099,9 @@
         ]
       }
     ]
+  },
+  {
+    "name": "sun.security.x509.CertificateExtensions"
   },
   {
     "name": "sun.security.x509.CertificatePoliciesExtension",

--- a/samples/grpc/local-drone-control-scala/src/main/resources/META-INF/native-image/generated/reflect-config.json
+++ b/samples/grpc/local-drone-control-scala/src/main/resources/META-INF/native-image/generated/reflect-config.json
@@ -213,6 +213,9 @@
     "name": "[[I"
   },
   {
+    "name": "[[J"
+  },
+  {
     "name": "akka.Done"
   },
   {
@@ -602,6 +605,17 @@
   },
   {
     "name": "akka.cluster.routing.ClusterRouterPool"
+  },
+  {
+    "name": "akka.cluster.sbr.SplitBrainResolverProvider",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "akka.actor.ActorSystem"
+        ]
+      }
+    ]
   },
   {
     "name": "akka.cluster.sharding.ClusterShardingGuardian",

--- a/samples/grpc/local-drone-control-scala/src/main/resources/META-INF/native-image/generated/resource-config.json
+++ b/samples/grpc/local-drone-control-scala/src/main/resources/META-INF/native-image/generated/resource-config.json
@@ -29,6 +29,9 @@
         "pattern": "\\Qakka-http-version.conf\\E"
       },
       {
+        "pattern": "\\Qapplication-kubernetes.conf\\E"
+      },
+      {
         "pattern": "\\Qapplication.conf\\E"
       },
       {
@@ -102,9 +105,6 @@
       },
       {
         "pattern": "\\Qpostgres.conf\\E"
-      },
-      {
-        "pattern": "\\Qprod.conf\\E"
       },
       {
         "pattern": "\\Qreference.conf\\E"

--- a/samples/grpc/local-drone-control-scala/src/main/resources/META-INF/native-image/generated/resource-config.json
+++ b/samples/grpc/local-drone-control-scala/src/main/resources/META-INF/native-image/generated/resource-config.json
@@ -5,6 +5,12 @@
         "pattern": "\\QMETA-INF/MANIFEST.MF\\E"
       },
       {
+        "pattern": "\\QMETA-INF/native/libio_grpc_netty_shaded_netty_transport_native_epoll_aarch_64.so\\E"
+      },
+      {
+        "pattern": "\\QMETA-INF/native/libio_grpc_netty_shaded_netty_transport_native_epoll_x86_64.so\\E"
+      },
+      {
         "pattern": "\\QMETA-INF/services/io.grpc.LoadBalancerProvider\\E"
       },
       {
@@ -36,9 +42,6 @@
       },
       {
         "pattern": "\\Qh2-default-projection-schema.conf\\E"
-      },
-      {
-        "pattern": "\\Qlocal-persistence.conf\\E"
       },
       {
         "pattern": "\\Qlocal-shared.conf\\E"
@@ -98,6 +101,12 @@
         "pattern": "\\Qpersistence.conf\\E"
       },
       {
+        "pattern": "\\Qpostgres.conf\\E"
+      },
+      {
+        "pattern": "\\Qprod.conf\\E"
+      },
+      {
         "pattern": "\\Qreference.conf\\E"
       },
       {
@@ -105,6 +114,9 @@
       },
       {
         "pattern": "java.base:\\Qjdk/internal/icu/impl/data/icudt67b/nfc.nrm\\E"
+      },
+      {
+        "pattern": "java.base:\\Qjdk/internal/icu/impl/data/icudt67b/nfkc.nrm\\E"
       },
       {
         "pattern": "java.base:\\Qsun/net/www/content-types.properties\\E"

--- a/samples/grpc/local-drone-control-scala/src/main/resources/application-kubernetes.conf
+++ b/samples/grpc/local-drone-control-scala/src/main/resources/application-kubernetes.conf
@@ -18,22 +18,9 @@ local-drone-control {
   ask-timeout = 3s
 }
 
-akka.remote.artery {
-  canonical.port = 2552
-  canonical.port = ${?REMOTE_PORT}
-}
-
-akka.management {
-  http {
-    port = 8558
-    port = ${?HTTP_MGMT_PORT}
-  }
-  cluster.bootstrap {
-    contact-point-discovery {
-      service-name = "local-drone-control"
-      discovery-method = kubernetes-api
-      required-contact-point-nr = 1
-      required-contact-point-nr = ${?REQUIRED_CONTACT_POINT_NR}
-    }
-  }
+akka.management.cluster.bootstrap.contact-point-discovery {
+  service-name = "local-drone-control"
+  discovery-method = kubernetes-api
+  required-contact-point-nr = 1
+  required-contact-point-nr = ${?REQUIRED_CONTACT_POINT_NR}
 }

--- a/samples/grpc/local-drone-control-scala/src/main/resources/application.conf
+++ b/samples/grpc/local-drone-control-scala/src/main/resources/application.conf
@@ -8,6 +8,7 @@ include "cluster"
 
 akka {
   loglevel = DEBUG
+  remote.artery.canonical.hostname = "127.0.0.1"
 }
 
 local-drone-control {

--- a/samples/grpc/local-drone-control-scala/src/main/resources/application.conf
+++ b/samples/grpc/local-drone-control-scala/src/main/resources/application.conf
@@ -1,14 +1,13 @@
 include "h2-default-projection-schema.conf"
 include "grpc"
 include "persistence"
-include "cluster"
 
 # Default config, used for running a single-node cluster that cannot scale out to many nodes, using H2 for
 # persistence, started through local.drones.Main
 
 akka {
+  actor.provider = cluster
   loglevel = DEBUG
-  remote.artery.canonical.hostname = "127.0.0.1"
 }
 
 local-drone-control {

--- a/samples/grpc/local-drone-control-scala/src/main/resources/cluster.conf
+++ b/samples/grpc/local-drone-control-scala/src/main/resources/cluster.conf
@@ -1,3 +1,24 @@
 akka {
   actor.provider = cluster
+
+  remote.artery {
+    canonical.port = 2552
+    canonical.port = ${?REMOTE_PORT}
+  }
+
+  cluster {
+    downing-provider-class = "akka.cluster.sbr.SplitBrainResolverProvider"
+
+    shutdown-after-unsuccessful-join-seed-nodes = 120s
+
+    sharding {
+      least-shard-allocation-strategy.rebalance-absolute-limit = 20
+      passivation.strategy = default-strategy
+    }
+  }
+
+  management {
+    http.port = 8558
+    http.port = ${?HTTP_MGMT_PORT}
+  }
 }

--- a/samples/grpc/local-drone-control-scala/src/main/resources/cluster.conf
+++ b/samples/grpc/local-drone-control-scala/src/main/resources/cluster.conf
@@ -1,5 +1,3 @@
 akka {
   actor.provider = cluster
-  # just the single node cluster for now
-  remote.artery.canonical.hostname = "127.0.0.1"
 }

--- a/samples/grpc/local-drone-control-scala/src/main/resources/grpc.conf
+++ b/samples/grpc/local-drone-control-scala/src/main/resources/grpc.conf
@@ -15,8 +15,11 @@ local-drone-control {
 # gRPC client config for connecting to central cloud to publish events
 akka.grpc.client.central-drone-control = {
   host = "127.0.0.1"
+  host = ${?CENTRAL_DRONE_CONTROL_HOST}
   port = 8101
+  port = ${?CENTRAL_DRONE_CONTROL_PORT}
   use-tls = false
+  use-tls = ${?CENTRAL_DRONE_CONTROL_TLS}
 }
 
 akka.projection.grpc.consumer {

--- a/samples/grpc/local-drone-control-scala/src/main/resources/local-shared.conf
+++ b/samples/grpc/local-drone-control-scala/src/main/resources/local-shared.conf
@@ -17,13 +17,6 @@ local-drone-control {
   ask-timeout = 3s
 }
 
-akka.management {
-  http {
-    port = 9201
-    port = ${?HTTP_MGMT_PORT}
-  }
-}
-
 akka.management.cluster.bootstrap.contact-point-discovery {
   service-name = "local-drone-control"
   discovery-method = config

--- a/samples/grpc/local-drone-control-scala/src/main/resources/local-shared.conf
+++ b/samples/grpc/local-drone-control-scala/src/main/resources/local-shared.conf
@@ -2,7 +2,7 @@
 # through the local.drones.ClusteredMain and a separate PostgreSQL database
 include "cluster"
 include "grpc"
-include "local-persistence.conf"
+include "postgres"
 
 local-drone-control.grpc.interface = "127.0.0.1"
 akka.remote.artery.canonical.hostname = "127.0.0.1"
@@ -21,14 +21,6 @@ akka.management {
   http {
     port = 9201
     port = ${?HTTP_MGMT_PORT}
-  }
-  cluster.bootstrap {
-    contact-point-discovery {
-      service-name = "local-drone-control"
-      discovery-method = kubernetes-api
-      required-contact-point-nr = 1
-      required-contact-point-nr = ${?REQUIRED_CONTACT_POINT_NR}
-    }
   }
 }
 

--- a/samples/grpc/local-drone-control-scala/src/main/resources/postgres.conf
+++ b/samples/grpc/local-drone-control-scala/src/main/resources/postgres.conf
@@ -20,7 +20,9 @@ akka {
         host = ${?DB_HOST}
         # note: different port for running in parallel with db for restaurant-drone-deliveries-service
         port = 5433
+        port = ${?DB_PORT}
         database = "postgres"
+        database = ${?DB_DATABASE}
         user = "postgres"
         user = ${?DB_USER}
         password = "postgres"

--- a/samples/grpc/local-drone-control-scala/src/main/resources/prod.conf
+++ b/samples/grpc/local-drone-control-scala/src/main/resources/prod.conf
@@ -1,0 +1,39 @@
+# Production configuration for running the local-drone-control service in Kubernetes,
+# as a multi-node cluster and with a separate PostgreSQL database.
+
+include "cluster"
+include "grpc"
+include "postgres"
+
+local-drone-control {
+  # consider setting this to a specific interface for your environment
+  grpc.interface = "0.0.0.0"
+  grpc.interface = ${?GRPC_INTERFACE}
+
+  nr-of-event-producers = 4
+  # unique identifier for the instance of local control, must be known up front by the cloud service
+  location-id = "sweden/stockholm/kungsholmen"
+  location-id = ${?LOCATION_ID}
+
+  ask-timeout = 3s
+}
+
+akka.remote.artery {
+  canonical.port = 2552
+  canonical.port = ${?REMOTE_PORT}
+}
+
+akka.management {
+  http {
+    port = 8558
+    port = ${?HTTP_MGMT_PORT}
+  }
+  cluster.bootstrap {
+    contact-point-discovery {
+      service-name = "local-drone-control"
+      discovery-method = kubernetes-api
+      required-contact-point-nr = 1
+      required-contact-point-nr = ${?REQUIRED_CONTACT_POINT_NR}
+    }
+  }
+}


### PR DESCRIPTION
Update local-drone-control config to run in kubernetes. Run with the native image tracing agent to generate updated native image config. Tested with k3s.
