### PR TITLE
doc: mvn docker.registry

### DIFF
--- a/akka-distributed-cluster-docs/src/main/paradox/guide/4-deploying.md
+++ b/akka-distributed-cluster-docs/src/main/paradox/guide/4-deploying.md
@@ -145,7 +145,7 @@ sbt -Ddocker.username=<username> -Ddocker.registry=docker.io docker:publish
 
 Java
 :  ```
-mvn -DskipTests -Ddocker.registry=<username>/shopping-cart-service clean package docker:push
+mvn -DskipTests -Ddocker.registry=<username> clean package docker:push
 ```
 
 The Kubernetes `Deployment` in `deployment.yml` file:
@@ -238,7 +238,7 @@ sbt -Ddocker.username=<username> -Ddocker.registry=docker.io docker:publish
 
 Java
 :  ```
-mvn -DskipTests -Ddocker.registry=<username>/shopping-analytics-service clean package docker:push
+mvn -DskipTests -Ddocker.registry=<username> clean package docker:push
 ```
 
 The Kubernetes `Deployment` in `deployment.yml` file:
@@ -326,7 +326,7 @@ sbt -Ddocker.username=<username> -Ddocker.registry=docker.io docker:publish
 
 Java
 :  ```
-mvn -DskipTests -Ddocker.registry=<username>/shopping-cart-service clean package docker:push
+mvn -DskipTests -Ddocker.registry=<username> clean package docker:push
 ```
 
 Update the `image:` in the `deployment.yml` with the specific image version and location you published.

--- a/akka-edge-docs/src/main/paradox/guide/5-deploying-the-services.md
+++ b/akka-edge-docs/src/main/paradox/guide/5-deploying-the-services.md
@@ -128,7 +128,7 @@ sbt -Ddocker.username=<username> -Ddocker.registry=docker.io docker:publish
 
 Java
 :  ```
-mvn -DskipTests -Ddocker.registry=<username>/restaurant-drone-deliveries-service clean package docker:push
+mvn -DskipTests -Ddocker.registry=<username> clean package docker:push
 ```
 
 The Kubernetes `Deployment` in `deployment.yml` file:
@@ -259,7 +259,7 @@ sbt -Ddocker.username=<username> -Ddocker.registry=docker.io Docker/publish
 
 Java
 :  ```
-mvn -DskipTests -Ddocker.registry=<username>/local-drone-control clean package docker:push
+mvn -DskipTests -Ddocker.registry=<username> clean package docker:push
 ```
 
 Update the `image:` in the `deployment.yml` with the specific image version and location you published.


### PR DESCRIPTION
When using `mvn -X -Ddocker.registry=<username>` it shows 
```
The push refers to repository [docker.io/patriknw/restaurant-drone-deliveries-service]
```

otherwise it will be double `restaurant-drone-deliveries-service`

There is something that has changed with how credentials are retrieved. Seems like the default docker login that stores in ~/.docker/config.json doesn't work with the maven plugin any more. I could get it working in another way, but the recommended credsStore doesn't work for me. See
*  https://docs.docker.com/engine/reference/commandline/login/#credentials-store
* https://dmp.fabric8.io/#authentication