### PR TITLE
build: Run unit tests on JDK 21 

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,6 +20,7 @@ jobs:
         include:
           - { jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
           - { jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
+          - { jdkVersion: "1.21.0", jvmName: "temurin:1.21", extraOpts: '' }
     steps:
       - name: Checkout
         # https://github.com/actions/checkout/releases
@@ -40,11 +41,11 @@ jobs:
         uses: coursier/cache-action@d1039466d0812d6370649b9afb02bbf5f646bacf
 
       - name: Set up JDK ${{ matrix.jdkVersion }}
-        # https://github.com/coursier/setup-action/releases
-        # v1.3.0
-        uses: coursier/setup-action@70323223454ac2a9eb2de46f389b4d045cbcdea5
+        uses: coursier/setup-action@v1.3.4
         with:
           jvm: ${{ matrix.jvmName }}
+          # FIXME default index not giving us access to JDK 21 (yet)
+          jvm-index: https://raw.githubusercontent.com/coursier/jvm-index/32d659500e6c65efb9eee91718a0fb0e797ad4ee/index.json
 
       - name: Run tests with default Scala and Java ${{ matrix.jdkVersion }}
         run: sbt "test" ${{ matrix.extraOpts }}


### PR DESCRIPTION
Didn't want to go all the way with the integration tests since those are so flakey and another matrix entry for them is another chance they'll fail on every push...