### PR TITLE
feat: RES initial consumer filter

### DIFF
--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/replication/javadsl/ReplicationSettings.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/replication/javadsl/ReplicationSettings.scala
@@ -4,6 +4,9 @@
 
 package akka.projection.grpc.replication.javadsl
 
+import java.util.function.{ Function => JFunction }
+import java.util.{ List => JList }
+
 import akka.actor.typed.ActorSystem
 import akka.annotation.ApiMayChange
 import akka.annotation.DoNotInherit
@@ -19,10 +22,15 @@ import akka.projection.grpc.replication.internal.ReplicaImpl
 import akka.projection.grpc.replication.scaladsl.{ ReplicationSettings => SReplicationSettings }
 import akka.util.JavaDurationConverters.JavaDurationOps
 import com.typesafe.config.Config
-
 import java.time.Duration
+import java.util.Collections
 import java.util.Optional
+import java.util.function.Predicate
 import java.util.{ Set => JSet }
+
+import akka.persistence.query.typed.EventEnvelope
+import akka.projection.grpc.consumer.ConsumerFilter
+import akka.projection.grpc.internal.TopicMatcher
 import akka.util.ccompat.JavaConverters._
 import akka.projection.grpc.replication.internal.ReplicationProjectionProviderAdapter
 
@@ -68,7 +76,9 @@ object ReplicationSettings {
       replicationProjectionProvider,
       Optional.empty(),
       identity,
-      indirectReplication = false)
+      indirectReplication = false,
+      _ => true,
+      Collections.emptyList)
   }
 
   /**
@@ -119,7 +129,9 @@ object ReplicationSettings {
       replicationProjectionProvider = replicationProjectionProvider,
       Optional.empty(),
       identity,
-      indirectReplication = false)
+      indirectReplication = false,
+      _ => true,
+      Collections.emptyList)
   }
 }
 
@@ -138,10 +150,12 @@ final class ReplicationSettings[Command] private (
     val parallelUpdates: Int,
     val replicationProjectionProvider: ReplicationProjectionProvider,
     val eventProducerInterceptor: Optional[EventProducerInterceptor],
-    val configureEntity: java.util.function.Function[
+    val configureEntity: JFunction[
       Entity[Command, ShardingEnvelope[Command]],
       Entity[Command, ShardingEnvelope[Command]]],
-    val indirectReplication: Boolean) {
+    val indirectReplication: Boolean,
+    val producerFilter: Predicate[EventEnvelope[Any]],
+    val initialConsumerFilter: JList[ConsumerFilter.FilterCriteria]) {
 
   def withSelfReplicaId(selfReplicaId: ReplicaId): ReplicationSettings[Command] =
     copy(selfReplicaId = selfReplicaId)
@@ -184,9 +198,8 @@ final class ReplicationSettings[Command] private (
    * Allows for changing the settings of the replicated entity, such as stop message, passivation strategy etc.
    */
   def configureEntity(
-      configure: java.util.function.Function[
-        Entity[Command, ShardingEnvelope[Command]],
-        Entity[Command, ShardingEnvelope[Command]]]): ReplicationSettings[Command] =
+      configure: JFunction[Entity[Command, ShardingEnvelope[Command]], Entity[Command, ShardingEnvelope[Command]]])
+      : ReplicationSettings[Command] =
     copy(configureEntity = configure)
 
   /**
@@ -196,6 +209,30 @@ final class ReplicationSettings[Command] private (
    */
   def withIndirectReplication(enabled: Boolean): ReplicationSettings[Command] =
     copy(indirectReplication = enabled)
+
+  /**
+   * Filter events matching the `producerFilter` predicate, for example based on tags.
+   */
+  def withProducerFilter[Event](producerFilter: Predicate[EventEnvelope[Event]]): ReplicationSettings[Command] =
+    copy(producerFilter = producerFilter.asInstanceOf[Predicate[EventEnvelope[Any]]])
+
+  /**
+   * Filter events matching the topic expression according to MQTT specification, including wildcards.
+   * The topic of an event is defined by a tag with certain prefix, see `topic-tag-prefix` configuration.
+   */
+  def withProducerFilterTopicExpression(topicExpression: String): ReplicationSettings[Command] = {
+    val topicMatcher = TopicMatcher(topicExpression)
+    withProducerFilter[Any](env => topicMatcher.matches(env, eventProducerSettings.topicTagPrefix))
+  }
+
+  /**
+   * Set the initial consumer filter to use for events. Should only be used for static, up front consumer filters.
+   * Combining this with updating consumer filters directly means that the filters may be reset to these
+   * filters.
+   */
+  def withInitialConsumerFilter(
+      initialConsumerFilter: JList[ConsumerFilter.FilterCriteria]): ReplicationSettings[Command] =
+    copy(initialConsumerFilter = initialConsumerFilter)
 
   private def copy(
       selfReplicaId: ReplicaId = selfReplicaId,
@@ -207,10 +244,13 @@ final class ReplicationSettings[Command] private (
       parallelUpdates: Int = parallelUpdates,
       projectionProvider: ReplicationProjectionProvider = replicationProjectionProvider,
       eventProducerInterceptor: Optional[EventProducerInterceptor] = eventProducerInterceptor,
-      configureEntity: java.util.function.Function[
+      configureEntity: JFunction[
         Entity[Command, ShardingEnvelope[Command]],
         Entity[Command, ShardingEnvelope[Command]]] = configureEntity,
-      indirectReplication: Boolean = indirectReplication): ReplicationSettings[Command] =
+      indirectReplication: Boolean = indirectReplication,
+      producerFilter: Predicate[EventEnvelope[Any]] = producerFilter,
+      initialConsumerFilter: JList[ConsumerFilter.FilterCriteria] = initialConsumerFilter)
+      : ReplicationSettings[Command] =
     new ReplicationSettings[Command](
       selfReplicaId,
       entityTypeKey,
@@ -222,7 +262,9 @@ final class ReplicationSettings[Command] private (
       projectionProvider,
       eventProducerInterceptor,
       configureEntity,
-      indirectReplication)
+      indirectReplication,
+      producerFilter,
+      initialConsumerFilter)
 
   override def toString =
     s"ReplicationSettings($selfReplicaId, $entityTypeKey, $streamId, ${otherReplicas.asScala.mkString(", ")})"
@@ -241,5 +283,7 @@ final class ReplicationSettings[Command] private (
       parallelUpdates = parallelUpdates,
       replicationProjectionProvider = ReplicationProjectionProviderAdapter.toScala(replicationProjectionProvider))
       .withIndirectReplication(indirectReplication)
+      .withProducerFilter(producerFilter.test)
+      .withInitialConsumerFilter(initialConsumerFilter.asScala.toVector)
 
 }


### PR DESCRIPTION
* and define filters via ReplicationSettings
* deprecate grpcReplication with producer filter params, via settings instead

TODO:
- [ ] add test using filters with RES

Documentation about RES filters should also be updated, but that's another PR