### PR TITLE
test: Harden JdbcProjectionTest atLeastOnceShouldRestartFromPreviousOffset

### DIFF
--- a/akka-projection-jdbc/src/it/scala/akka/projection/jdbc/JdbcProjectionSpec.scala
+++ b/akka-projection-jdbc/src/it/scala/akka/projection/jdbc/JdbcProjectionSpec.scala
@@ -670,7 +670,9 @@ class JdbcProjectionSpec
       projectionTestKit.run(projection) {
         result.toString shouldBe "e1|e2|e3|e4|e5|e6|"
       }
-      offsetShouldBe(6L)
+      eventually {
+        offsetShouldBe(6L)
+      }
     }
   }
 
@@ -691,7 +693,9 @@ class JdbcProjectionSpec
       projectionTestKit.run(projection) {
         projectedValueShouldBe("e1|e2|e3|e4|e5|e6")
       }
-      offsetShouldBe(6L)
+      eventually {
+        offsetShouldBe(6L)
+      }
     }
 
     "skip failing events when using RecoveryStrategy.skip, save after 1" in {
@@ -712,7 +716,9 @@ class JdbcProjectionSpec
       projectionTestKit.run(projection) {
         projectedValueShouldBe("e1|e2|e3|e5|e6")
       }
-      offsetShouldBe(6L)
+      eventually {
+        offsetShouldBe(6L)
+      }
     }
 
     "skip failing events when using RecoveryStrategy.skip, save after 2" in {
@@ -733,7 +739,9 @@ class JdbcProjectionSpec
       projectionTestKit.run(projection) {
         projectedValueShouldBe("e1|e2|e3|e5|e6")
       }
-      offsetShouldBe(6L)
+      eventually {
+        offsetShouldBe(6L)
+      }
     }
 
     "restart from previous offset - handler throwing an exception, save after 1" in {
@@ -775,7 +783,9 @@ class JdbcProjectionSpec
         projectedValueShouldBe("e1|e2|e3|e4|e5|e6")
       }
 
-      offsetShouldBe(6L)
+      eventually {
+        offsetShouldBe(6L)
+      }
     }
 
     "restart from previous offset - handler throwing an exception, save after 2" in {
@@ -1030,7 +1040,9 @@ class JdbcProjectionSpec
       projectionTestKit.run(projection) {
         projectedValueShouldBe("e1|e2|e3|e4|e5|e6")
       }
-      offsetShouldBe(6L)
+      eventually {
+        offsetShouldBe(6L)
+      }
 
     }
   }

--- a/akka-projection-jdbc/src/test/java/akka/projection/jdbc/JdbcProjectionTest.java
+++ b/akka-projection-jdbc/src/test/java/akka/projection/jdbc/JdbcProjectionTest.java
@@ -331,16 +331,11 @@ public class JdbcProjectionTest extends JUnitSuite {
     projectionTestKit.runWithTestSink(
         projection,
         (probe) -> {
-          /*
-           * We only want to process 3 elements through the handler, but given buffering within the projections
-           * at-least-once impl. we actually process +1 element than we requested with the TestSink probe.
-           *
-           * See https://github.com/akka/akka-projection/issues/462 for a possible solution.
-           */
-          probe.request(2);
-          probe.expectNextN(2);
-          assertEquals("abc|def|ghi|", str.toString());
-          expectNextUntilErrorMessage(probe, failMessage(4));
+          probe.request(3);
+          testKit.createTestProbe().awaitAssert(() -> {
+            assertEquals("abc|def|ghi|", str.toString());
+            return null;
+          });
         });
 
     assertStoredOffset(projectionId, 3L);
@@ -360,6 +355,7 @@ public class JdbcProjectionTest extends JUnitSuite {
         () -> {
           assertEquals("abc|def|ghi|jkl|mno|pqr|", str.toString());
         });
+    assertStoredOffset(projectionId, 6L);
   }
 
   @Test


### PR DESCRIPTION
* awaitAssert, trying to make it more simular to R2dbcProjectionSpec and JdbcProjectionSpec

Refs https://github.com/akka/akka-projection/issues/465