### PR TITLE
feat: Accept/push-publish multiple RES types from edge

### DIFF
--- a/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/replication/EdgeReplicationMultiIntegrationSpec.scala
+++ b/akka-projection-grpc-tests/src/it/scala/akka/projection/grpc/replication/EdgeReplicationMultiIntegrationSpec.scala
@@ -1,0 +1,297 @@
+/*
+ * Copyright (C) 2009-2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.grpc.replication
+
+import akka.actor.testkit.typed.scaladsl.ActorTestKit
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.LoggerOps
+import akka.actor.typed.scaladsl.adapter.ClassicActorSystemOps
+import akka.cluster.MemberStatus
+import akka.cluster.sharding.typed.scaladsl.ClusterSharding
+import akka.cluster.sharding.typed.scaladsl.EntityTypeKey
+import akka.cluster.typed.Cluster
+import akka.cluster.typed.Join
+import akka.grpc.GrpcClientSettings
+import akka.http.scaladsl.Http
+import akka.persistence.typed.ReplicaId
+import akka.projection.grpc.TestContainerConf
+import akka.projection.grpc.TestData
+import akka.projection.grpc.TestDbLifecycle
+import akka.projection.grpc.consumer.scaladsl.EventProducerPushDestination
+import akka.projection.grpc.producer.EventProducerSettings
+import akka.projection.grpc.producer.scaladsl.EventProducer
+import akka.projection.grpc.replication.ReplicationIntegrationSpec.LWWHelloWorld.Command
+import akka.projection.grpc.replication.scaladsl.Replica
+import akka.projection.grpc.replication.scaladsl.Replication
+import akka.projection.grpc.replication.scaladsl.Replication.EdgeReplication
+import akka.projection.grpc.replication.scaladsl.ReplicationSettings
+import akka.projection.r2dbc.R2dbcProjectionSettings
+import akka.projection.r2dbc.scaladsl.R2dbcReplication
+import akka.testkit.SocketUtil
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.DurationInt
+
+/**
+ * Covers setting up multiple RES entity types between one edge and one cloud replica
+ */
+object EdgeReplicationMultiIntegrationSpec {
+
+  private def config(dc: ReplicaId): Config =
+    ConfigFactory.parseString(s"""
+       akka.actor.provider = cluster
+       akka.actor {
+         serialization-bindings {
+           "${classOf[ReplicationIntegrationSpec].getName}$$LWWHelloWorld$$Event" = jackson-json
+         }
+       }
+       akka.http.server.preview.enable-http2 = on
+       akka.persistence.r2dbc {
+          query {
+            refresh-interval = 500 millis
+            # reducing this to have quicker test, triggers backtracking earlier
+            backtracking.behind-current-time = 3 seconds
+          }
+        }
+        akka.projection.grpc {
+          producer {
+            query-plugin-id = "akka.persistence.r2dbc.query"
+          }
+        }
+        akka.projection.r2dbc.offset-store {
+          timestamp-offset-table = "akka_projection_timestamp_offset_store_${dc.id}"
+        }
+        akka.remote.artery.canonical.host = "127.0.0.1"
+        akka.remote.artery.canonical.port = 0
+        akka.actor.testkit.typed {
+          filter-leeway = 10s
+          system-shutdown-default = 30s
+        }
+      """)
+
+  private val CloudReplicaA = ReplicaId("DCA")
+  private val EdgeReplicaC = ReplicaId("DCC")
+
+  // re-use the same RES impl but pretend it is a different type of RES
+  object LWWHelloWorld2 {
+    val EntityType: EntityTypeKey[Command] = EntityTypeKey[Command]("hello-world2")
+  }
+}
+
+class EdgeReplicationMultiIntegrationSpec(testContainerConf: TestContainerConf)
+    extends ScalaTestWithActorTestKit(
+      akka.actor
+        .ActorSystem(
+          "EdgeReplicationMultiIntegrationSpecA",
+          EdgeReplicationMultiIntegrationSpec
+            .config(EdgeReplicationMultiIntegrationSpec.CloudReplicaA)
+            .withFallback(testContainerConf.config))
+        .toTyped)
+    with AnyWordSpecLike
+    with TestDbLifecycle
+    with BeforeAndAfterAll
+    with LogCapturing
+    with TestData {
+  import EdgeReplicationMultiIntegrationSpec._
+  import ReplicationIntegrationSpec.LWWHelloWorld
+  implicit val ec: ExecutionContext = system.executionContext
+
+  def this() = this(new TestContainerConf)
+
+  private val logger = LoggerFactory.getLogger(classOf[EdgeReplicationMultiIntegrationSpec])
+  override def typedSystem: ActorSystem[_] = testKit.system
+
+  private val cloudReplicaSystem = typedSystem
+  private val edgeSystem = akka.actor
+    .ActorSystem(
+      "EdgeReplicationMultiIntegrationSpecC",
+      EdgeReplicationMultiIntegrationSpec.config(EdgeReplicaC).withFallback(testContainerConf.config))
+    .toTyped
+
+  private val systems = Seq[ActorSystem[_]](typedSystem, edgeSystem)
+
+  private val cloudReplicaPort = SocketUtil.temporaryServerAddress("127.0.0.1")
+  private val cloudReplica = Replica(
+    CloudReplicaA,
+    1,
+    GrpcClientSettings.connectToServiceAt("127.0.0.1", cloudReplicaPort.getPort).withTls(false))
+
+  private val testKitsPerDc = Map(CloudReplicaA -> testKit, EdgeReplicaC -> ActorTestKit(edgeSystem))
+  private val systemPerDc = Map(CloudReplicaA -> system, EdgeReplicaC -> edgeSystem)
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    // We can share the journal to save a bit of work, because the persistence id contains
+    // the dc so is unique (this is ofc completely synthetic, the whole point of replication
+    // over grpc is to replicate between different dcs/regions with completely separate databases).
+    // The offset tables need to be separate though to not get conflicts on projection names
+    systemPerDc.values.foreach { system =>
+      val r2dbcProjectionSettings = R2dbcProjectionSettings(system)
+      Await.result(
+        r2dbcExecutor.updateOne("beforeAll delete")(
+          _.createStatement(s"delete from ${r2dbcProjectionSettings.timestampOffsetTableWithSchema}")),
+        10.seconds)
+
+    }
+  }
+
+  def startCloudReplica(): (Replication[LWWHelloWorld.Command], Replication[LWWHelloWorld.Command]) = {
+
+    def replicaSettings(entityTypeKey: EntityTypeKey[LWWHelloWorld.Command]) =
+      ReplicationSettings[LWWHelloWorld.Command](
+        entityTypeKey.name,
+        CloudReplicaA,
+        EventProducerSettings(cloudReplicaSystem),
+        Set.empty[Replica],
+        10.seconds,
+        2,
+        R2dbcReplication())
+        .withEdgeReplication(true)
+
+    val replication1 =
+      Replication.grpcReplication(replicaSettings(LWWHelloWorld.EntityType))(LWWHelloWorld.apply)(cloudReplicaSystem)
+    val replication2 =
+      Replication.grpcReplication(replicaSettings(LWWHelloWorld2.EntityType))(LWWHelloWorld.apply)(cloudReplicaSystem)
+
+    // this is the tricky part, binding both these into listening services
+    (replication1, replication2)
+  }
+
+  def startEdgeReplica(): (EdgeReplication[LWWHelloWorld.Command], EdgeReplication[LWWHelloWorld.Command]) = {
+    def replicationSettings(entityTypeKey: EntityTypeKey[LWWHelloWorld.Command]) = {
+      ReplicationSettings[LWWHelloWorld.Command](
+        entityTypeKey.name,
+        EdgeReplicaC,
+        EventProducerSettings(edgeSystem),
+        Set(cloudReplica),
+        10.seconds,
+        1,
+        R2dbcReplication())
+    }
+
+    val replication1 =
+      Replication.grpcEdgeReplication(replicationSettings(LWWHelloWorld.EntityType))(LWWHelloWorld.apply)(edgeSystem)
+    val replication2 =
+      Replication.grpcEdgeReplication(replicationSettings(LWWHelloWorld2.EntityType))(LWWHelloWorld.apply)(edgeSystem)
+
+    // this one is straightforward, no gRPC services bound, only locally running sharding and event push-projections
+    (replication1, replication2)
+  }
+
+  def assertGreeting(entityTypeKey: EntityTypeKey[LWWHelloWorld.Command], entityId: String, expected: String): Unit = {
+    testKitsPerDc.values.foreach { testKit =>
+      withClue(s"on ${testKit.system.name}") {
+        val probe = testKit.createTestProbe()
+        withClue(s"for entity id $entityId") {
+          val entityRef = ClusterSharding(testKit.system)
+            .entityRefFor(entityTypeKey, entityId)
+
+          probe.awaitAssert({
+            entityRef
+              .ask(LWWHelloWorld.Get.apply)
+              .futureValue should ===(expected)
+          }, 10.seconds)
+        }
+      }
+    }
+  }
+
+  "Replication over gRPC" should {
+    "form one node clusters" in {
+      testKitsPerDc.values.foreach { testKit =>
+        val cluster = Cluster(testKit.system)
+        cluster.manager ! Join(cluster.selfMember.address)
+        testKit.createTestProbe().awaitAssert {
+          cluster.selfMember.status should ===(MemberStatus.Up)
+        }
+      }
+    }
+
+    "start replicas" in {
+      logger
+        .infoN(
+          "Starting replica [{}], system [{}] on port [{}]",
+          cloudReplica.replicaId,
+          system.name,
+          cloudReplica.grpcClientSettings.defaultPort)
+
+      val (replication1, replication2) = startCloudReplica()
+      val grpcPort = cloudReplica.grpcClientSettings.defaultPort
+
+      // same Akka Projection gRPC for both entities for the edge pulling events
+      val consumeHandler =
+        EventProducer.grpcServiceHandler(Set(replication1.eventProducerSource, replication2.eventProducerSource))(
+          system)
+
+      // same Akka Projection gRPC service for both entities for the edge pushing events
+      // FIXME annoying that it is an option, could we type our way around it somehow?
+      val produceHandler = EventProducerPushDestination.grpcServiceHandler(
+        Set(replication1.eventProducerPushDestination, replication2.eventProducerPushDestination).flatten)(system)
+
+      val combinedHandler = consumeHandler.orElse(produceHandler)
+
+      // start producer server
+      Http(system)
+        .newServerAt("127.0.0.1", grpcPort)
+        .bind(combinedHandler)
+        .map(_.addToCoordinatedShutdown(3.seconds)(system))(system.executionContext)
+        .futureValue
+
+      startEdgeReplica()
+      logger.info("All replication/producer services bound")
+    }
+
+    "replicate directly" in {
+      // simple verification of replication in both directions only,
+      // more extensive replication tests in other specs
+      val entity1Id = nextPid(LWWHelloWorld.EntityType.name).entityId
+
+      ClusterSharding(cloudReplicaSystem)
+        .entityRefFor(LWWHelloWorld.EntityType, entity1Id)
+        .ask(LWWHelloWorld.SetGreeting("Hello from Cloud 1", _))
+        .futureValue
+      assertGreeting(LWWHelloWorld.EntityType, entity1Id, "Hello from Cloud 1")
+
+      // the second entity type
+      val entity2Id = nextPid(LWWHelloWorld2.EntityType.name).entityId
+      ClusterSharding(cloudReplicaSystem)
+        .entityRefFor(LWWHelloWorld2.EntityType, entity2Id)
+        .ask(LWWHelloWorld.SetGreeting("Hello from Cloud 2", _))
+        .futureValue
+      assertGreeting(LWWHelloWorld2.EntityType, entity2Id, "Hello from Cloud 2")
+
+      ClusterSharding(edgeSystem)
+        .entityRefFor(LWWHelloWorld.EntityType, entity1Id)
+        .ask(LWWHelloWorld.SetGreeting("Hello from Edge 1", _))
+        .futureValue
+      assertGreeting(LWWHelloWorld.EntityType, entity1Id, "Hello from Edge 1")
+
+      // the second entity type
+      ClusterSharding(cloudReplicaSystem)
+        .entityRefFor(LWWHelloWorld2.EntityType, entity2Id)
+        .ask(LWWHelloWorld.SetGreeting("Hello from Edge 2", _))
+        .futureValue
+      assertGreeting(LWWHelloWorld2.EntityType, entity2Id, "Hello from Edge 2")
+    }
+  }
+
+  protected override def afterAll(): Unit = {
+    logger.info("Shutting down all DCs")
+    systems.foreach(_.terminate()) // speed up termination by terminating all at the once
+    // and then make sure they are completely shutdown
+    systems.foreach { system =>
+      ActorTestKit.shutdown(system)
+    }
+    super.afterAll()
+  }
+}

--- a/akka-projection-grpc-tests/src/test/java/akka/projection/grpc/replication/javdsl/ReplicationCompileTest.java
+++ b/akka-projection-grpc-tests/src/test/java/akka/projection/grpc/replication/javdsl/ReplicationCompileTest.java
@@ -21,6 +21,7 @@ import akka.persistence.query.typed.EventEnvelope;
 import akka.persistence.typed.ReplicaId;
 import akka.projection.ProjectionContext;
 import akka.projection.ProjectionId;
+import akka.projection.grpc.consumer.javadsl.EventProducerPushDestination;
 import akka.projection.grpc.producer.EventProducerSettings;
 import akka.projection.grpc.producer.javadsl.EventProducer;
 import akka.projection.grpc.producer.javadsl.EventProducerSource;
@@ -134,6 +135,12 @@ public class ReplicationCompileTest {
     Function<HttpRequest, CompletionStage<HttpResponse>> handler =
         ServiceHandler.concatOrNotFound(route);
     // #multi-service
+
+    // RES push
+    Set<EventProducerPushDestination> destinations = new HashSet<>();
+    destinations.add(replication.eventProducerPushDestination().get());
+    // ... .add other destinations ...
+    EventProducerPushDestination.grpcServiceHandler(destinations, system);
 
     CompletionStage<ServerBinding> bound =
         Http.get(system).newServerAt(host, port).bind(handler);

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/replication/scaladsl/ProducerApiSample.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/replication/scaladsl/ProducerApiSample.scala
@@ -38,7 +38,7 @@ object ProducerApiSample {
     // #multi-service
 
     // RES push to combine with multiple other services
-    val pushHandler = EventProducerPushDestination.grpcServiceHandler(replication.eventProducerPushDestination.toSet)
+    val _ = EventProducerPushDestination.grpcServiceHandler(replication.eventProducerPushDestination.toSet)
 
     val _ = Http(system).newServerAt(host, port).bind(handler)
   }

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/replication/scaladsl/ProducerApiSample.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/replication/scaladsl/ProducerApiSample.scala
@@ -8,6 +8,7 @@ import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
 import akka.grpc.scaladsl.ServiceHandler
 import akka.http.scaladsl.Http
+import akka.projection.grpc.consumer.scaladsl.EventProducerPushDestination
 import akka.projection.grpc.producer.scaladsl.EventProducer
 import akka.projection.grpc.producer.scaladsl.EventProducer.EventProducerSource
 
@@ -33,10 +34,11 @@ object ProducerApiSample {
     }
     val route = EventProducer.grpcServiceHandler(allSources)
 
-    // FIXME Java API for replication.eventProducerPushDestination
-
     val handler = ServiceHandler.concatOrNotFound(route)
     // #multi-service
+
+    // RES push to combine with multiple other services
+    val pushHandler = EventProducerPushDestination.grpcServiceHandler(replication.eventProducerPushDestination.toSet)
 
     val _ = Http(system).newServerAt(host, port).bind(handler)
   }

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/replication/scaladsl/ProducerApiSample.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/replication/scaladsl/ProducerApiSample.scala
@@ -27,11 +27,13 @@ object ProducerApiSample {
 
     val allSources: Set[EventProducerSource] = {
       Set(
-        replication.eventProducerService,
+        replication.eventProducerSource,
         // producers from other replicated entities or gRPC projections
-        otherReplication.eventProducerService)
+        otherReplication.eventProducerSource)
     }
     val route = EventProducer.grpcServiceHandler(allSources)
+
+    // FIXME Java API for replication.eventProducerPushDestination
 
     val handler = ServiceHandler.concatOrNotFound(route)
     // #multi-service

--- a/akka-projection-grpc/src/main/mima-filters/1.5.1-M1.backwards.excludes/edge-initiated-multiple-entities.excludes
+++ b/akka-projection-grpc/src/main/mima-filters/1.5.1-M1.backwards.excludes/edge-initiated-multiple-entities.excludes
@@ -1,0 +1,6 @@
+# internal constructor, new methods in not-for-extension
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.grpc.consumer.scaladsl.EventProducerPushDestination.this")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.projection.grpc.replication.javadsl.Replication.eventProducerSource")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.projection.grpc.replication.javadsl.Replication.eventProducerPushDestination")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.projection.grpc.replication.scaladsl.Replication.eventProducerSource")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.projection.grpc.replication.scaladsl.Replication.eventProducerPushDestination")

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/javadsl/EventProducerPushDestination.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/javadsl/EventProducerPushDestination.scala
@@ -160,5 +160,6 @@ final class EventProducerPushDestination private (
         (streamId, meta) => javaInterceptor.intercept(streamId, new JavaMetadataImpl(meta)).toScala),
       filters.asScala.toVector,
       protobufDescriptors.asScala.toVector,
-      settings)
+      settings,
+      None)
 }

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/javadsl/EventProducerPushDestination.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/javadsl/EventProducerPushDestination.scala
@@ -4,6 +4,7 @@
 
 package akka.projection.grpc.consumer.javadsl
 
+import akka.Done
 import akka.actor.typed.ActorSystem
 import akka.annotation.ApiMayChange
 import akka.annotation.InternalApi
@@ -30,6 +31,7 @@ import java.util.{ List => JList, Set => JSet }
 import scala.compat.java8.FutureConverters.CompletionStageOps
 import scala.compat.java8.FutureConverters.FutureOps
 import scala.compat.java8.OptionConverters.RichOptionalGeneric
+import scala.jdk.OptionConverters.RichOption
 
 /**
  * A passive consumer service for event producer push that can be bound as a gRPC endpoint accepting active producers
@@ -83,6 +85,26 @@ object EventProducerPushDestination {
           .toJava
     }
   }
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
+  private[akka] def fromScala(scalaDestination: scaladsl.EventProducerPushDestination): EventProducerPushDestination =
+    new EventProducerPushDestination(
+      scalaDestination.journalPluginId.toJava,
+      scalaDestination.acceptedStreamId,
+      (origin, meta) => Transformation.adapted(scalaDestination.transformationForOrigin.apply(origin, meta.asScala)),
+      scalaDestination.interceptor
+        .map(scalaInterceptor =>
+          new EventDestinationInterceptor {
+            override def intercept(streamId: String, requestMetadata: Metadata): CompletionStage[Done] =
+              scalaInterceptor.intercept(streamId, requestMetadata.asScala).toJava
+          })
+        .toJava,
+      scalaDestination.filters.asJava,
+      scalaDestination.protobufDescriptors.asJava,
+      scalaDestination.settings)
 
 }
 

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/javadsl/Transformation.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/javadsl/Transformation.scala
@@ -14,8 +14,8 @@ import java.util.Optional
 import java.util.function.{ Function => JFunction }
 import scala.compat.java8.OptionConverters._
 import scala.reflect.ClassTag
-
 import akka.actor.typed.ActorSystem
+import akka.annotation.InternalApi
 
 object Transformation {
 
@@ -30,6 +30,13 @@ object Transformation {
    */
   val identity: Transformation =
     new Transformation(scaladsl.EventProducerPushDestination.Transformation.identity)
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
+  private[akka] def adapted(delegate: scaladsl.EventProducerPushDestination.Transformation) =
+    new Transformation(delegate)
 }
 
 /**

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/EventProducerPushDestination.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/EventProducerPushDestination.scala
@@ -195,6 +195,7 @@ final class EventProducerPushDestination private[akka] (
     val protobufDescriptors: immutable.Seq[Descriptors.FileDescriptor],
     val settings: EventProducerPushDestinationSettings,
     /** INTERNAL API */
+    @InternalApi
     private[akka] val replicationSettings: Option[ReplicationSettings[_]]) {
   import EventProducerPushDestination._
 

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/EventPusher.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/EventPusher.scala
@@ -7,6 +7,7 @@ package akka.projection.grpc.internal
 import akka.Done
 import akka.NotUsed
 import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.LoggerOps
 import akka.annotation.InternalApi
 import akka.grpc.scaladsl.BytesEntry
 import akka.grpc.scaladsl.Metadata
@@ -70,6 +71,11 @@ private[akka] object EventPusher {
         : Flow[(EventEnvelope[Event], ProjectionContext), (ConsumeEventIn, ProjectionContext), NotUsed] =
       Flow
         .futureFlow(filters.map { startMessage =>
+          logger.infoN(
+            "Starting event push flow for [{}], origin id: [{}]{}",
+            eps.streamId,
+            originId,
+            startMessage.replicaInfo.map(ri => s", remote replica: [${ri.replicaId}]").getOrElse(""))
           val (consumerFilter, replicatedEventOriginFilter) = {
 
             startMessage.replicaInfo match {

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/replication/scaladsl/Replication.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/replication/scaladsl/Replication.scala
@@ -40,10 +40,15 @@ trait Replication[Command] {
   /**
    * If combining multiple replicated entity types, or combining with direct usage of
    * Akka Projection gRPC, you will have to use the EventProducerSource of each of them
-   * in a set passed to EventProducer.grpcServiceHandler to create a single gRPC endpoint
+   * in a set passed to EventProducer.grpcServiceHandler to create a single gRPC endpoint.
    */
   def eventProducerSource: EventProducerSource
 
+  /**
+   * Scala API: Push destinations for accepting/combining multiple Replicated Event Sourced entity types
+   * and possibly also regular projections into one producer push destination handler in a set passed to
+   * EventProducerPushDestination.grpcServiceHandler to create a single gRPC endpoint.
+   */
   def eventProducerPushDestination: Option[EventProducerPushDestination]
 
   /**

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/replication/scaladsl/Replication.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/replication/scaladsl/Replication.scala
@@ -5,7 +5,6 @@
 package akka.projection.grpc.replication.scaladsl
 
 import scala.concurrent.Future
-
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
 import akka.annotation.ApiMayChange
@@ -19,6 +18,7 @@ import akka.http.scaladsl.model.HttpResponse
 import akka.persistence.query.typed.EventEnvelope
 import akka.persistence.typed.ReplicationId
 import akka.persistence.typed.scaladsl.ReplicatedEventSourcing
+import akka.projection.grpc.consumer.scaladsl.EventProducerPushDestination
 import akka.projection.grpc.producer.scaladsl.EventProducer.EventProducerSource
 import akka.projection.grpc.replication.internal.ReplicationImpl
 
@@ -34,12 +34,17 @@ import akka.projection.grpc.replication.internal.ReplicationImpl
 @DoNotInherit
 trait Replication[Command] {
 
+  @deprecated("Use eventProducerSource instead", "1.5.1")
+  def eventProducerService: EventProducerSource
+
   /**
    * If combining multiple replicated entity types, or combining with direct usage of
-   * Akka Projection gRPC, you will have to use the EventProducerService of each of them
+   * Akka Projection gRPC, you will have to use the EventProducerSource of each of them
    * in a set passed to EventProducer.grpcServiceHandler to create a single gRPC endpoint
    */
-  def eventProducerService: EventProducerSource
+  def eventProducerSource: EventProducerSource
+
+  def eventProducerPushDestination: Option[EventProducerPushDestination]
 
   /**
    * If only replicating one Replicated Event Sourced Entity and not using


### PR DESCRIPTION
I don't have test coverage but I think this also covers the combination of regular push projections and a replicated entity (needed for the Drone sample)