### PR TITLE
bump: logback 1.2.13

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -11,8 +11,7 @@ updates.ignore = [
   { groupId = "com.typesafe.slick" }
   
   {groupId = "com.fasterxml.jackson.core" }
-  # Logback 1.4 requires JDK11
-  { groupId = "ch.qos.logback", artifactId = "logback-classic", version = "1.3." }
+  { groupId = "ch.qos.logback", artifactId = "logback-classic", version = "1.2." }
 ]
 
 updatePullRequests = false

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -86,7 +86,7 @@ object Dependencies {
     val msSQLServerDriver = "com.microsoft.sqlserver" % "mssql-jdbc" % "7.4.1.jre8" % allTestConfig
     val oracleDriver = "com.oracle.ojdbc" % "ojdbc8" % "19.3.0.0" % allTestConfig
 
-    val logback = "ch.qos.logback" % "logback-classic" % "1.3.6" % allTestConfig
+    val logback = "ch.qos.logback" % "logback-classic" % "1.2.13" % allTestConfig
 
     val cassandraContainer =
       "org.testcontainers" % "cassandra" % Versions.testContainers % allTestConfig

--- a/samples/grpc/iot-service-scala/build.sbt
+++ b/samples/grpc/iot-service-scala/build.sbt
@@ -63,7 +63,7 @@ libraryDependencies ++= Seq(
   "com.lightbend.akka" %% "akka-diagnostics" % AkkaDiagnosticsVersion,
   // Common dependencies for logging and testing
   "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-  "ch.qos.logback" % "logback-classic" % "1.3.6",
+  "ch.qos.logback" % "logback-classic" % "1.2.13",
   "org.scalatest" %% "scalatest" % "3.1.2" % Test,
   // 2. Using Akka Persistence
   "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,

--- a/samples/grpc/local-drone-control-java/pom.xml
+++ b/samples/grpc/local-drone-control-java/pom.xml
@@ -25,7 +25,7 @@
         <akka-http.version>10.5.1</akka-http.version>
         <akka-grpc.version>2.4.0</akka-grpc.version>
         <akka-grpc-maven-plugin.version>2.4.0</akka-grpc-maven-plugin.version>
-        <logback.version>1.3.11</logback.version>
+        <logback.version>1.2.13</logback.version>
         <prometheus.client.version>0.16.0</prometheus.client.version>
         <junit.version>4.13.1</junit.version>
         <scala.binary.version>2.13</scala.binary.version>

--- a/samples/grpc/local-drone-control-scala/build.sbt
+++ b/samples/grpc/local-drone-control-scala/build.sbt
@@ -69,7 +69,7 @@ libraryDependencies ++= Seq(
   "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % AkkaManagementVersion,
   // Common dependencies for logging and testing
   "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-  "ch.qos.logback" % "logback-classic" % "1.3.11",
+  "ch.qos.logback" % "logback-classic" % "1.2.13",
   "org.scalatest" %% "scalatest" % "3.1.2" % Test,
   // Prometheus client for custom metrics
   "io.prometheus" % "simpleclient" % "0.16.0",

--- a/samples/grpc/restaurant-drone-deliveries-service-java/pom.xml
+++ b/samples/grpc/restaurant-drone-deliveries-service-java/pom.xml
@@ -24,7 +24,7 @@
         <akka-diagnostics.version>2.1.0</akka-diagnostics.version>
         <akka-grpc.version>2.4.0</akka-grpc.version>
         <akka-grpc-maven-plugin.version>2.4.0</akka-grpc-maven-plugin.version>
-        <logback.version>1.3.6</logback.version>
+        <logback.version>1.2.13</logback.version>
         <junit.version>4.13.1</junit.version>
         <scala.binary.version>2.13</scala.binary.version>
         <!-- needs to be defined to allow for overriding through mvn exec:exec -DAPP_CONFIG=local1.conf -->

--- a/samples/grpc/restaurant-drone-deliveries-service-scala/build.sbt
+++ b/samples/grpc/restaurant-drone-deliveries-service-scala/build.sbt
@@ -64,7 +64,7 @@ libraryDependencies ++= Seq(
   "com.lightbend.akka" %% "akka-diagnostics" % AkkaDiagnosticsVersion,
   // Common dependencies for logging and testing
   "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-  "ch.qos.logback" % "logback-classic" % "1.3.6",
+  "ch.qos.logback" % "logback-classic" % "1.2.13",
   "org.scalatest" %% "scalatest" % "3.1.2" % Test,
   // 2. Using Akka Persistence
   "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,

--- a/samples/grpc/shopping-analytics-service-java/pom.xml
+++ b/samples/grpc/shopping-analytics-service-java/pom.xml
@@ -24,7 +24,7 @@
         <akka-diagnostics.version>2.1.0</akka-diagnostics.version>
         <akka-grpc.version>2.4.0</akka-grpc.version>
         <akka-grpc-maven-plugin.version>2.4.0</akka-grpc-maven-plugin.version>
-        <logback.version>1.3.6</logback.version>
+        <logback.version>1.2.13</logback.version>
         <junit.version>4.13.1</junit.version>
         <scala.binary.version>2.13</scala.binary.version>
         <!-- needs to be defined to allow for overriding through mvn exec:exec -DAPP_CONFIG=local1.conf -->

--- a/samples/grpc/shopping-analytics-service-scala/build.sbt
+++ b/samples/grpc/shopping-analytics-service-scala/build.sbt
@@ -64,7 +64,7 @@ libraryDependencies ++= Seq(
   "com.lightbend.akka" %% "akka-diagnostics" % AkkaDiagnosticsVersion,
   // Common dependencies for logging and testing
   "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-  "ch.qos.logback" % "logback-classic" % "1.3.6",
+  "ch.qos.logback" % "logback-classic" % "1.2.13",
   "org.scalatest" %% "scalatest" % "3.1.2" % Test,
   // 2. Using Akka Persistence
   "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,

--- a/samples/grpc/shopping-cart-service-java/pom.xml
+++ b/samples/grpc/shopping-cart-service-java/pom.xml
@@ -24,7 +24,7 @@
         <akka-diagnostics.version>2.1.0</akka-diagnostics.version>
         <akka-grpc.version>2.4.0</akka-grpc.version>
         <akka-grpc-maven-plugin.version>2.4.0</akka-grpc-maven-plugin.version>
-        <logback.version>1.3.6</logback.version>
+        <logback.version>1.2.13</logback.version>
         <junit.version>4.13.1</junit.version>
         <scala.binary.version>2.13</scala.binary.version>
         <!-- needs to be defined to allow for overriding through mvn exec:exec -DAPP_CONFIG=local1.conf -->

--- a/samples/grpc/shopping-cart-service-scala/build.sbt
+++ b/samples/grpc/shopping-cart-service-scala/build.sbt
@@ -64,7 +64,7 @@ libraryDependencies ++= Seq(
   "com.lightbend.akka" %% "akka-diagnostics" % AkkaDiagnosticsVersion,
   // Common dependencies for logging and testing
   "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-  "ch.qos.logback" % "logback-classic" % "1.3.6",
+  "ch.qos.logback" % "logback-classic" % "1.2.13",
   "org.scalatest" %% "scalatest" % "3.1.2" % Test,
   // 2. Using Akka Persistence
   "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,

--- a/samples/replicated/shopping-cart-service-java/pom.xml
+++ b/samples/replicated/shopping-cart-service-java/pom.xml
@@ -24,7 +24,7 @@
         <akka-diagnostics.version>2.1.0</akka-diagnostics.version>
         <akka-grpc.version>2.4.0</akka-grpc.version>
         <akka-grpc-maven-plugin.version>2.4.0</akka-grpc-maven-plugin.version>
-        <logback.version>1.3.6</logback.version>
+        <logback.version>1.2.13</logback.version>
         <junit.version>4.13.1</junit.version>
         <scala.binary.version>2.13</scala.binary.version>
         <!-- needs to be defined to allow for overriding through mvn exec:exec -DAPP_CONFIG=local1.conf -->

--- a/samples/replicated/shopping-cart-service-scala/build.sbt
+++ b/samples/replicated/shopping-cart-service-scala/build.sbt
@@ -65,7 +65,7 @@ libraryDependencies ++= Seq(
   "com.lightbend.akka" %% "akka-diagnostics" % AkkaDiagnosticsVersion,
   // Common dependencies for logging and testing
   "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-  "ch.qos.logback" % "logback-classic" % "1.3.6",
+  "ch.qos.logback" % "logback-classic" % "1.2.13",
   "org.scalatest" %% "scalatest" % "3.1.2" % Test,
   // 2. Using Akka Persistence
   "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,


### PR DESCRIPTION
Only in tests and samples. I don't know if there was a reason for not using the same version as in Akka https://github.com/akka/akka-projection/pull/828 ?
