### PR TITLE
feat: updateTimestampOffset

### DIFF
--- a/akka-projection-core/src/main/scala/akka/projection/ProjectionBehavior.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/ProjectionBehavior.scala
@@ -3,6 +3,8 @@
  */
 
 package akka.projection
+import java.time.Instant
+
 import akka.actor.typed.scaladsl.LoggerOps
 import scala.util.Failure
 import scala.util.Success
@@ -19,6 +21,7 @@ import akka.actor.typed.scaladsl.StashBuffer
 import akka.annotation.InternalApi
 import akka.projection.internal.ManagementState
 import akka.projection.scaladsl.ProjectionManagement
+import akka.projection.scaladsl.ProjectionManagement.UpdateTimestampOffset
 
 object ProjectionBehavior {
 
@@ -47,6 +50,12 @@ object ProjectionBehavior {
     final case class SetOffset[Offset](projectionId: ProjectionId, offset: Option[Offset], replyTo: ActorRef[Done])
         extends ProjectionManagementCommand
     final case class SetOffsetResult[Offset](replyTo: ActorRef[Done]) extends ProjectionManagementCommand
+
+    final case class SetTimestampOffset(
+        projectionId: ProjectionId,
+        updates: Set[UpdateTimestampOffset],
+        replyTo: ActorRef[Done])
+        extends ProjectionManagementCommand
 
     final case class IsPaused(projectionId: ProjectionId, replyTo: ActorRef[Boolean])
         extends ProjectionManagementCommand


### PR DESCRIPTION
Just an idea so far...

For the Durable State change events it's possible that you start out with ordinary Durable State and then enable change events later. Meaning that there will missing events and offsets for earlier sequence numbers (revisions). The offset validation will reject them and the projection will be stuck.

One way would be to populate the offset store with known "starting points" via the projection management api.

In general, we are lacking projection management for timestamp offsets, because they are not a single value.