### PR TITLE
fix: replicatedEventOriginFilter should not filter replayed events

### DIFF
--- a/akka-projection-grpc-integration/src/test/resources/db/default-init.sql
+++ b/akka-projection-grpc-integration/src/test/resources/db/default-init.sql
@@ -96,6 +96,127 @@ CREATE TABLE IF NOT EXISTS akka_projection_management (
 );
 
 -- For Replicated Event Sourcing over gRPC tests
+
+CREATE TABLE IF NOT EXISTS event_journal_DCA(
+                                            slice INT NOT NULL,
+                                            entity_type VARCHAR(255) NOT NULL,
+    persistence_id VARCHAR(255) NOT NULL,
+    seq_nr BIGINT NOT NULL,
+    db_timestamp timestamp with time zone NOT NULL,
+
+                               event_ser_id INTEGER NOT NULL,
+                               event_ser_manifest VARCHAR(255) NOT NULL,
+    event_payload BYTEA NOT NULL,
+
+    deleted BOOLEAN DEFAULT FALSE NOT NULL,
+    writer VARCHAR(255) NOT NULL,
+    adapter_manifest VARCHAR(255),
+    tags TEXT ARRAY,
+
+    meta_ser_id INTEGER,
+    meta_ser_manifest VARCHAR(255),
+    meta_payload BYTEA,
+
+    PRIMARY KEY(persistence_id, seq_nr)
+    );
+CREATE INDEX IF NOT EXISTS event_journal_slice_DCA_idx ON event_journal_DCA(slice, entity_type, db_timestamp, seq_nr);
+
+CREATE TABLE IF NOT EXISTS event_journal_DCB(
+                                                slice INT NOT NULL,
+                                                entity_type VARCHAR(255) NOT NULL,
+    persistence_id VARCHAR(255) NOT NULL,
+    seq_nr BIGINT NOT NULL,
+    db_timestamp timestamp with time zone NOT NULL,
+
+                               event_ser_id INTEGER NOT NULL,
+                               event_ser_manifest VARCHAR(255) NOT NULL,
+    event_payload BYTEA NOT NULL,
+
+    deleted BOOLEAN DEFAULT FALSE NOT NULL,
+    writer VARCHAR(255) NOT NULL,
+    adapter_manifest VARCHAR(255),
+    tags TEXT ARRAY,
+
+    meta_ser_id INTEGER,
+    meta_ser_manifest VARCHAR(255),
+    meta_payload BYTEA,
+
+    PRIMARY KEY(persistence_id, seq_nr)
+    );
+CREATE INDEX IF NOT EXISTS event_journal_slice_DCB_idx ON event_journal_DCB(slice, entity_type, db_timestamp, seq_nr);
+
+CREATE TABLE IF NOT EXISTS event_journal_DCC(
+                                                slice INT NOT NULL,
+                                                entity_type VARCHAR(255) NOT NULL,
+    persistence_id VARCHAR(255) NOT NULL,
+    seq_nr BIGINT NOT NULL,
+    db_timestamp timestamp with time zone NOT NULL,
+
+                               event_ser_id INTEGER NOT NULL,
+                               event_ser_manifest VARCHAR(255) NOT NULL,
+    event_payload BYTEA NOT NULL,
+
+    deleted BOOLEAN DEFAULT FALSE NOT NULL,
+    writer VARCHAR(255) NOT NULL,
+    adapter_manifest VARCHAR(255),
+    tags TEXT ARRAY,
+
+    meta_ser_id INTEGER,
+    meta_ser_manifest VARCHAR(255),
+    meta_payload BYTEA,
+
+    PRIMARY KEY(persistence_id, seq_nr)
+    );
+CREATE INDEX IF NOT EXISTS event_journal_slice_DCC_idx ON event_journal_DCC(slice, entity_type, db_timestamp, seq_nr);
+
+CREATE TABLE IF NOT EXISTS event_journal_DCD(
+                                                slice INT NOT NULL,
+                                                entity_type VARCHAR(255) NOT NULL,
+    persistence_id VARCHAR(255) NOT NULL,
+    seq_nr BIGINT NOT NULL,
+    db_timestamp timestamp with time zone NOT NULL,
+
+                               event_ser_id INTEGER NOT NULL,
+                               event_ser_manifest VARCHAR(255) NOT NULL,
+    event_payload BYTEA NOT NULL,
+
+    deleted BOOLEAN DEFAULT FALSE NOT NULL,
+    writer VARCHAR(255) NOT NULL,
+    adapter_manifest VARCHAR(255),
+    tags TEXT ARRAY,
+
+    meta_ser_id INTEGER,
+    meta_ser_manifest VARCHAR(255),
+    meta_payload BYTEA,
+
+    PRIMARY KEY(persistence_id, seq_nr)
+    );
+CREATE INDEX IF NOT EXISTS event_journal_slice_DCD_idx ON event_journal_DCD(slice, entity_type, db_timestamp, seq_nr);
+
+CREATE TABLE IF NOT EXISTS event_journal_EdgeA(
+                                                slice INT NOT NULL,
+                                                entity_type VARCHAR(255) NOT NULL,
+    persistence_id VARCHAR(255) NOT NULL,
+    seq_nr BIGINT NOT NULL,
+    db_timestamp timestamp with time zone NOT NULL,
+
+                               event_ser_id INTEGER NOT NULL,
+                               event_ser_manifest VARCHAR(255) NOT NULL,
+    event_payload BYTEA NOT NULL,
+
+    deleted BOOLEAN DEFAULT FALSE NOT NULL,
+    writer VARCHAR(255) NOT NULL,
+    adapter_manifest VARCHAR(255),
+    tags TEXT ARRAY,
+
+    meta_ser_id INTEGER,
+    meta_ser_manifest VARCHAR(255),
+    meta_payload BYTEA,
+
+    PRIMARY KEY(persistence_id, seq_nr)
+    );
+CREATE INDEX IF NOT EXISTS event_journal_slice_EdgeA_idx ON event_journal_EdgeA(slice, entity_type, db_timestamp, seq_nr);
+
 CREATE TABLE IF NOT EXISTS akka_projection_timestamp_offset_store_DCA (
     projection_name VARCHAR(255) NOT NULL,
     projection_key VARCHAR(255) NOT NULL,

--- a/akka-projection-grpc-integration/src/test/scala/akka/projection/grpc/replication/EdgeReplicationIntegrationSpec.scala
+++ b/akka-projection-grpc-integration/src/test/scala/akka/projection/grpc/replication/EdgeReplicationIntegrationSpec.scala
@@ -4,7 +4,6 @@
 
 package akka.projection.grpc.replication
 
-import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
@@ -34,7 +33,6 @@ import akka.projection.grpc.replication.scaladsl.Replica
 import akka.projection.grpc.replication.scaladsl.Replication
 import akka.projection.grpc.replication.scaladsl.Replication.EdgeReplication
 import akka.projection.grpc.replication.scaladsl.ReplicationSettings
-import akka.projection.r2dbc.R2dbcProjectionSettings
 import akka.projection.r2dbc.scaladsl.R2dbcReplication
 import akka.testkit.SocketUtil
 import com.typesafe.config.Config
@@ -55,6 +53,7 @@ object EdgeReplicationIntegrationSpec {
        }
        akka.http.server.preview.enable-http2 = on
        akka.persistence.r2dbc {
+          journal.table = "event_journal_${dc.id}"
           query {
             refresh-interval = 500 millis
             # reducing this to have quicker test, triggers backtracking earlier
@@ -146,18 +145,7 @@ class EdgeReplicationIntegrationSpec(testContainerConf: TestContainerConf)
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    // We can share the journal to save a bit of work, because the persistence id contains
-    // the dc so is unique (this is ofc completely synthetic, the whole point of replication
-    // over grpc is to replicate between different dcs/regions with completely separate databases).
-    // The offset tables need to be separate though to not get conflicts on projection names
-    systemPerDc.values.foreach { system =>
-      val r2dbcProjectionSettings = R2dbcProjectionSettings(system)
-      Await.result(
-        r2dbcExecutor.updateOne("beforeAll delete")(
-          _.createStatement(s"delete from ${r2dbcProjectionSettings.timestampOffsetTableWithSchema}")),
-        10.seconds)
-
-    }
+    systemPerDc.values.foreach(beforeAllDeleteFromTables)
   }
 
   def startReplica(replicaSystem: ActorSystem[_], selfReplicaId: ReplicaId): Replication[LWWHelloWorld.Command] = {

--- a/akka-projection-grpc-integration/src/test/scala/akka/projection/grpc/replication/EdgeReplicationMultiIntegrationSpec.scala
+++ b/akka-projection-grpc-integration/src/test/scala/akka/projection/grpc/replication/EdgeReplicationMultiIntegrationSpec.scala
@@ -29,7 +29,6 @@ import akka.projection.grpc.replication.scaladsl.Replica
 import akka.projection.grpc.replication.scaladsl.Replication
 import akka.projection.grpc.replication.scaladsl.Replication.EdgeReplication
 import akka.projection.grpc.replication.scaladsl.ReplicationSettings
-import akka.projection.r2dbc.R2dbcProjectionSettings
 import akka.projection.r2dbc.scaladsl.R2dbcReplication
 import akka.testkit.SocketUtil
 import com.typesafe.config.Config
@@ -38,7 +37,6 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.slf4j.LoggerFactory
 
-import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.DurationInt
 
@@ -57,6 +55,7 @@ object EdgeReplicationMultiIntegrationSpec {
        }
        akka.http.server.preview.enable-http2 = on
        akka.persistence.r2dbc {
+          journal.table = "event_journal_${dc.id}"
           query {
             refresh-interval = 500 millis
             # reducing this to have quicker test, triggers backtracking earlier
@@ -131,18 +130,7 @@ class EdgeReplicationMultiIntegrationSpec(testContainerConf: TestContainerConf)
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    // We can share the journal to save a bit of work, because the persistence id contains
-    // the dc so is unique (this is ofc completely synthetic, the whole point of replication
-    // over grpc is to replicate between different dcs/regions with completely separate databases).
-    // The offset tables need to be separate though to not get conflicts on projection names
-    systemPerDc.values.foreach { system =>
-      val r2dbcProjectionSettings = R2dbcProjectionSettings(system)
-      Await.result(
-        r2dbcExecutor.updateOne("beforeAll delete")(
-          _.createStatement(s"delete from ${r2dbcProjectionSettings.timestampOffsetTableWithSchema}")),
-        10.seconds)
-
-    }
+    systemPerDc.values.foreach(beforeAllDeleteFromTables)
   }
 
   def startCloudReplica(): (Replication[LWWHelloWorld.Command], Replication[LWWHelloWorld.Command]) = {

--- a/akka-projection-grpc-integration/src/test/scala/akka/projection/grpc/replication/IndirectReplicationIntegrationSpec.scala
+++ b/akka-projection-grpc-integration/src/test/scala/akka/projection/grpc/replication/IndirectReplicationIntegrationSpec.scala
@@ -4,7 +4,6 @@
 
 package akka.projection.grpc.replication
 
-import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
@@ -32,7 +31,6 @@ import akka.projection.grpc.producer.EventProducerSettings
 import akka.projection.grpc.replication.scaladsl.Replica
 import akka.projection.grpc.replication.scaladsl.Replication
 import akka.projection.grpc.replication.scaladsl.ReplicationSettings
-import akka.projection.r2dbc.R2dbcProjectionSettings
 import akka.projection.r2dbc.scaladsl.R2dbcReplication
 import akka.testkit.SocketUtil
 import com.typesafe.config.Config
@@ -53,6 +51,7 @@ object IndirectReplicationIntegrationSpec {
        }
        akka.http.server.preview.enable-http2 = on
        akka.persistence.r2dbc {
+          journal.table = "event_journal_${dc.id}"
           query {
             refresh-interval = 500 millis
             # reducing this to have quicker test, triggers backtracking earlier
@@ -144,18 +143,7 @@ class IndirectReplicationIntegrationSpec(testContainerConf: TestContainerConf)
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    // We can share the journal to save a bit of work, because the persistence id contains
-    // the dc so is unique (this is ofc completely synthetic, the whole point of replication
-    // over grpc is to replicate between different dcs/regions with completely separate databases).
-    // The offset tables need to be separate though to not get conflicts on projection names
-    systemPerDc.values.foreach { system =>
-      val r2dbcProjectionSettings = R2dbcProjectionSettings(system)
-      Await.result(
-        r2dbcExecutor.updateOne("beforeAll delete")(
-          _.createStatement(s"delete from ${r2dbcProjectionSettings.timestampOffsetTableWithSchema}")),
-        10.seconds)
-
-    }
+    systemPerDc.values.foreach(beforeAllDeleteFromTables)
   }
 
   def startReplica(replicaSystem: ActorSystem[_], selfReplicaId: ReplicaId): Replication[LWWHelloWorld.Command] = {

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/FilterStageSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/FilterStageSpec.scala
@@ -122,6 +122,7 @@ class FilterStageSpec extends ScalaTestWithActorTestKit("""
             initFilter,
             testCurrentEventsByPersistenceIdQuery(allEnvelopes),
             producerFilter = initProducerFilter,
+            replicatedEventOriginFilter = _ => true,
             topicTagPrefix = producerSettings.topicTagPrefix,
             replayParallelism = producerSettings.replayParallelism))
         .join(Flow.fromSinkAndSource(Sink.ignore, envSource))

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/FilterStage.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/FilterStage.scala
@@ -223,7 +223,7 @@ import org.slf4j.LoggerFactory
 
       private def tryPullReplay(pid: String): Unit = {
         if (!replayHasBeenPulled && isAvailable(outEnv) && !hasBeenPulled(inEnv)) {
-          log.trace2("Stream [{}]: tryPullReplay persistenceId [{}}]", logPrefix, pid)
+          log.trace2("Stream [{}]: tryPullReplay persistenceId [{}]", logPrefix, pid)
           val next =
             replayInProgress(pid).queue.pull().map(ReplayEnvelope(pid, _))(ExecutionContexts.parasitic)
           next.value match {

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/FilterStage.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/FilterStage.scala
@@ -13,6 +13,7 @@ import akka.NotUsed
 import akka.actor.typed.scaladsl.LoggerOps
 import akka.annotation.InternalApi
 import akka.dispatch.ExecutionContexts
+import akka.persistence.FilteredPayload
 import akka.persistence.Persistence
 import akka.persistence.query.typed.EventEnvelope
 import akka.persistence.typed.PersistenceId
@@ -154,6 +155,7 @@ import org.slf4j.LoggerFactory
     var initFilter: Iterable[FilterCriteria],
     currentEventsByPersistenceId: (String, Long) => Source[EventEnvelope[Any], NotUsed],
     val producerFilter: EventEnvelope[Any] => Boolean,
+    replicatedEventOriginFilter: EventEnvelope[_] => Boolean,
     topicTagPrefix: String,
     replayParallelism: Int)
     extends GraphStage[BidiShape[StreamIn, NotUsed, EventEnvelope[Any], EventEnvelope[Any]]] {
@@ -366,7 +368,6 @@ import org.slf4j.LoggerFactory
               case StreamIn(StreamIn.Message.Replay(replayReq), _) =>
                 if (replayReq.persistenceIdOffset.nonEmpty) {
                   log.debug2("Stream [{}]: Replay requested for [{}]", logPrefix, replayReq.persistenceIdOffset)
-                  // FIXME for RES, can we check if the replicaId is handled by this stream, to avoid unnecessary replay queries
                   replayAll(replayReq.persistenceIdOffset)
                 }
 
@@ -393,11 +394,20 @@ import org.slf4j.LoggerFactory
             if (replicaId.isEmpty && ReplicationId.isReplicationId(pid))
               replicaId = Some(ReplicationId.fromString(pid).replicaId)
 
-            // Note that the producer filter has higher priority - if a producer decides to filter events out the consumer
-            // can never include them
             if (producerFilter(env) && filter.matches(env)) {
-              log.traceN("Stream [{}]: Push event persistenceId [{}], seqNr [{}]", logPrefix, pid, env.sequenceNr)
-              push(outEnv, env)
+              if (replicatedEventOriginFilter(env)) {
+                // Note that the producer filter has higher priority - if a producer decides to filter events out the consumer
+                // can never include them
+                log.traceN("Stream [{}]: Push event persistenceId [{}], seqNr [{}]", logPrefix, pid, env.sequenceNr)
+                push(outEnv, env)
+              } else {
+                log.traceN(
+                  "Stream [{}]: Filter event, due to origin, persistenceId [{}], seqNr [{}]",
+                  logPrefix,
+                  pid,
+                  env.sequenceNr)
+                push(outEnv, env.withEvent(FilteredPayload)) // FilteredPayload will be transformed to FilteredEvent
+              }
             } else {
               log.debugN("Stream [{}]: Filter out event persistenceId [{}], seqNr [{}]", logPrefix, pid, env.sequenceNr)
               pullInEnvOrReplay()


### PR DESCRIPTION
I'll have to test this more, and think about if it is the right solution. It works for the reported problematic scenario.

* EventOriginFilter is only used for ReplicatedEventSourcing
* It was applied after the FilterStage and therefore also filtered events from replay requests. That works if the replica can instead receive the event from the origin replica, but if combined with dynamic consumer filter the original replica may not emit anything due to the consumer filter on that replica.
* Solution is to use the EventOriginFilter inside the FilterStage instead, so that is not used for replay requests.
