### PR TITLE
build: release snapshot via workflow dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     tags: ["*"]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
* useful when publishing snapshot from non main branch
