### PR TITLE
fix: unexpected events when controlling replication with consumer filter

### DIFF
--- a/akka-projection-core/src/main/scala/akka/projection/internal/CanTriggerReplay.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/CanTriggerReplay.scala
@@ -11,5 +11,5 @@ import akka.annotation.InternalApi
  */
 @InternalApi
 private[akka] trait CanTriggerReplay {
-  private[akka] def triggerReplay(persistenceId: String, fromSeqNr: Long): Unit
+  private[akka] def triggerReplay(persistenceId: String, fromSeqNr: Long, triggeredBySeqNr: Long): Unit
 }

--- a/akka-projection-core/src/main/scala/akka/projection/internal/JavaToScalaSourceProviderAdapter.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/JavaToScalaSourceProviderAdapter.scala
@@ -122,6 +122,6 @@ private[projection] final class JavaToScalaBySliceSourceProviderAdapterWithCanTr
     delegate: javadsl.SourceProvider[Offset, Envelope] with CanTriggerReplay)
     extends JavaToScalaBySliceSourceProviderAdapter[Offset, Envelope](delegate)
     with CanTriggerReplay {
-  override private[akka] def triggerReplay(persistenceId: String, fromSeqNr: Long): Unit =
-    delegate.triggerReplay(persistenceId, fromSeqNr)
+  override private[akka] def triggerReplay(persistenceId: String, fromSeqNr: Long, triggeredBySeqNr: Long): Unit =
+    delegate.triggerReplay(persistenceId, fromSeqNr, triggeredBySeqNr)
 }

--- a/akka-projection-core/src/main/scala/akka/projection/internal/ScalaToJavaSourceProviderAdapter.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/ScalaToJavaSourceProviderAdapter.scala
@@ -94,6 +94,6 @@ private[projection] final class ScalaToJavaBySlicesSourceProviderAdapterWithCanT
     extends ScalaToJavaBySlicesSourceProviderAdapter[Offset, Envelope](delegate)
     with CanTriggerReplay {
 
-  override private[akka] def triggerReplay(persistenceId: String, fromSeqNr: Long): Unit =
-    delegate.triggerReplay(persistenceId, fromSeqNr)
+  override private[akka] def triggerReplay(persistenceId: String, fromSeqNr: Long, triggeredBySeqNr: Long): Unit =
+    delegate.triggerReplay(persistenceId, fromSeqNr, triggeredBySeqNr)
 }

--- a/akka-projection-eventsourced/src/main/scala/akka/projection/eventsourced/javadsl/EventSourcedProvider.scala
+++ b/akka-projection-eventsourced/src/main/scala/akka/projection/eventsourced/javadsl/EventSourcedProvider.scala
@@ -142,8 +142,11 @@ object EventSourcedProvider {
           maxSlice,
           adjustStartOffset) with CanTriggerReplay {
 
-          private[akka] override def triggerReplay(persistenceId: String, fromSeqNr: Long): Unit =
-            query.triggerReplay(persistenceId, fromSeqNr)
+          private[akka] override def triggerReplay(
+              persistenceId: String,
+              fromSeqNr: Long,
+              triggeredBySeqNr: Long): Unit =
+            query.triggerReplay(persistenceId, fromSeqNr, triggeredBySeqNr)
 
         }
       case _ =>
@@ -227,8 +230,11 @@ object EventSourcedProvider {
           transformSnapshot,
           adjustStartOffset) with CanTriggerReplay {
 
-          private[akka] override def triggerReplay(persistenceId: String, fromSeqNr: Long): Unit =
-            query.triggerReplay(persistenceId, fromSeqNr)
+          private[akka] override def triggerReplay(
+              persistenceId: String,
+              fromSeqNr: Long,
+              triggeredBySeqNr: Long): Unit =
+            query.triggerReplay(persistenceId, fromSeqNr, triggeredBySeqNr)
 
         }
       case _ =>

--- a/akka-projection-eventsourced/src/main/scala/akka/projection/eventsourced/scaladsl/EventSourcedProvider.scala
+++ b/akka-projection-eventsourced/src/main/scala/akka/projection/eventsourced/scaladsl/EventSourcedProvider.scala
@@ -125,8 +125,11 @@ object EventSourcedProvider {
           minSlice,
           maxSlice,
           adjustStartOffset) with CanTriggerReplay {
-          override private[akka] def triggerReplay(persistenceId: String, fromSeqNr: Long): Unit =
-            query.triggerReplay(persistenceId, fromSeqNr)
+          override private[akka] def triggerReplay(
+              persistenceId: String,
+              fromSeqNr: Long,
+              triggeredBySeqNr: Long): Unit =
+            query.triggerReplay(persistenceId, fromSeqNr, triggeredBySeqNr)
         }
       case _ =>
         new EventsBySlicesSourceProvider(system, eventsBySlicesQuery, entityType, minSlice, maxSlice, adjustStartOffset)
@@ -212,8 +215,11 @@ object EventSourcedProvider {
           maxSlice,
           transformSnapshot,
           adjustStartOffset) with CanTriggerReplay {
-          override private[akka] def triggerReplay(persistenceId: String, fromSeqNr: Long): Unit =
-            query.triggerReplay(persistenceId, fromSeqNr)
+          override private[akka] def triggerReplay(
+              persistenceId: String,
+              fromSeqNr: Long,
+              triggeredBySeqNr: Long): Unit =
+            query.triggerReplay(persistenceId, fromSeqNr, triggeredBySeqNr)
         }
       case _ =>
         new EventsBySlicesStartingFromSnapshotsSourceProvider(

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/EventProducerServiceSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/EventProducerServiceSpec.scala
@@ -428,7 +428,7 @@ class EventProducerServiceSpec
     "replay events" in {
       val persistenceId = nextPid(entityType3)
       val initReq = InitReq(streamId3, 0, 1023, offset = None)
-      val replayReq = ReplayReq(
+      val replayReq = ReplayReq(replayPersistenceIds =
         List(ReplayPersistenceId(Some(PersistenceIdSeqNr(persistenceId.id, 2L)), filterAfterSeqNr = Long.MaxValue)))
       val streamIn =
         Source(List(StreamIn(StreamIn.Message.Init(initReq)), StreamIn(StreamIn.Message.Replay(replayReq))))
@@ -490,7 +490,7 @@ class EventProducerServiceSpec
     "replay events StartingFromSnapshots" in {
       val persistenceId = nextPid(entityType5)
       val initReq = InitReq(streamId5, 0, 1023, offset = None)
-      val replayReq = ReplayReq(
+      val replayReq = ReplayReq(replayPersistenceIds =
         List(ReplayPersistenceId(Some(PersistenceIdSeqNr(persistenceId.id, 1L)), filterAfterSeqNr = Long.MaxValue)))
       val streamIn =
         Source(List(StreamIn(StreamIn.Message.Init(initReq)), StreamIn(StreamIn.Message.Replay(replayReq))))

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/EventProducerServiceSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/EventProducerServiceSpec.scala
@@ -36,6 +36,7 @@ import akka.projection.grpc.internal.proto.EventTimestampRequest
 import akka.projection.grpc.internal.proto.InitReq
 import akka.projection.grpc.internal.proto.LoadEventRequest
 import akka.projection.grpc.internal.proto.PersistenceIdSeqNr
+import akka.projection.grpc.internal.proto.ReplayPersistenceId
 import akka.projection.grpc.internal.proto.ReplayReq
 import akka.projection.grpc.internal.proto.ReplicaInfo
 import akka.projection.grpc.internal.proto.StreamIn
@@ -427,7 +428,8 @@ class EventProducerServiceSpec
     "replay events" in {
       val persistenceId = nextPid(entityType3)
       val initReq = InitReq(streamId3, 0, 1023, offset = None)
-      val replayReq = ReplayReq(List(PersistenceIdSeqNr(persistenceId.id, 2L)))
+      val replayReq = ReplayReq(
+        List(ReplayPersistenceId(Some(PersistenceIdSeqNr(persistenceId.id, 2L)), filterAfterSeqNr = Long.MaxValue)))
       val streamIn =
         Source(List(StreamIn(StreamIn.Message.Init(initReq)), StreamIn(StreamIn.Message.Replay(replayReq))))
           .concat(Source.maybe)
@@ -488,7 +490,8 @@ class EventProducerServiceSpec
     "replay events StartingFromSnapshots" in {
       val persistenceId = nextPid(entityType5)
       val initReq = InitReq(streamId5, 0, 1023, offset = None)
-      val replayReq = ReplayReq(List(PersistenceIdSeqNr(persistenceId.id, 1L)))
+      val replayReq = ReplayReq(
+        List(ReplayPersistenceId(Some(PersistenceIdSeqNr(persistenceId.id, 1L)), filterAfterSeqNr = Long.MaxValue)))
       val streamIn =
         Source(List(StreamIn(StreamIn.Message.Init(initReq)), StreamIn(StreamIn.Message.Replay(replayReq))))
           .concat(Source.maybe)

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/FilterStageSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/FilterStageSpec.scala
@@ -134,7 +134,9 @@ class FilterStageSpec extends ScalaTestWithActorTestKit("""
   }
 
   private def streamInReplayReq(pid: String, fromSeqNr: Long, filterAfterSeqNr: Long = Long.MaxValue): StreamIn =
-    StreamIn(StreamIn.Message.Replay(ReplayReq(List(replayPersistenceId(pid, fromSeqNr, filterAfterSeqNr)))))
+    StreamIn(
+      StreamIn.Message.Replay(
+        ReplayReq(replayPersistenceIds = List(replayPersistenceId(pid, fromSeqNr, filterAfterSeqNr)))))
 
   private def replayPersistenceId(pid: String, fromSeqNr: Long, filterAfterSeqNr: Long = Long.MaxValue) =
     ReplayPersistenceId(Some(PersistenceIdSeqNr(pid, fromSeqNr)), filterAfterSeqNr)
@@ -249,7 +251,7 @@ class FilterStageSpec extends ScalaTestWithActorTestKit("""
 
       inPublisher.sendNext(
         StreamIn(
-          StreamIn.Message.Replay(ReplayReq(List(
+          StreamIn.Message.Replay(ReplayReq(replayPersistenceIds = List(
             replayPersistenceId(PersistenceId(entityType, "b").id, 1L),
             replayPersistenceId(PersistenceId(entityType, "c").id, 1L))))))
 
@@ -296,14 +298,14 @@ class FilterStageSpec extends ScalaTestWithActorTestKit("""
         entityIds.map(id => createEnvelope(PersistenceId(entityType, id), 1, id))
 
       inPublisher.sendNext(
-        StreamIn(StreamIn.Message.Replay(
-          ReplayReq(entityIds.take(7).map(id => replayPersistenceId(PersistenceId(entityType, id).id, 1L))))))
+        StreamIn(StreamIn.Message.Replay(ReplayReq(replayPersistenceIds =
+          entityIds.take(7).map(id => replayPersistenceId(PersistenceId(entityType, id).id, 1L))))))
       inPublisher.sendNext(
-        StreamIn(StreamIn.Message.Replay(
-          ReplayReq(entityIds.slice(7, 10).map(id => replayPersistenceId(PersistenceId(entityType, id).id, 1L))))))
+        StreamIn(StreamIn.Message.Replay(ReplayReq(replayPersistenceIds =
+          entityIds.slice(7, 10).map(id => replayPersistenceId(PersistenceId(entityType, id).id, 1L))))))
       inPublisher.sendNext(
-        StreamIn(StreamIn.Message.Replay(
-          ReplayReq(entityIds.drop(10).map(id => replayPersistenceId(PersistenceId(entityType, id).id, 1L))))))
+        StreamIn(StreamIn.Message.Replay(ReplayReq(replayPersistenceIds =
+          entityIds.drop(10).map(id => replayPersistenceId(PersistenceId(entityType, id).id, 1L))))))
 
       outProbe.request(100)
       // no guarantee of order between different entityIds

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/FilterStageSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/FilterStageSpec.scala
@@ -30,6 +30,7 @@ import akka.projection.grpc.internal.proto.IncludeEntityIds
 import akka.projection.grpc.internal.proto.IncludeTags
 import akka.projection.grpc.internal.proto.PersistenceIdSeqNr
 import akka.projection.grpc.internal.proto.ReplayReq
+import akka.projection.grpc.internal.proto.ReplayPersistenceId
 import akka.projection.grpc.internal.proto.StreamIn
 import akka.projection.grpc.producer.EventProducerSettings
 import akka.stream.scaladsl.BidiFlow
@@ -131,6 +132,12 @@ class FilterStageSpec extends ScalaTestWithActorTestKit("""
     val (inPublisher, outProbe) = streamIn.via(envFlow).toMat(TestSink())(Keep.both).run()
     val envPublisher = envPublisherPromise.future.futureValue
   }
+
+  private def streamInReplayReq(pid: String, fromSeqNr: Long, filterAfterSeqNr: Long = Long.MaxValue): StreamIn =
+    StreamIn(StreamIn.Message.Replay(ReplayReq(List(replayPersistenceId(pid, fromSeqNr, filterAfterSeqNr)))))
+
+  private def replayPersistenceId(pid: String, fromSeqNr: Long, filterAfterSeqNr: Long = Long.MaxValue) =
+    ReplayPersistenceId(Some(PersistenceIdSeqNr(pid, fromSeqNr)), filterAfterSeqNr)
 
   "FilterStage" must {
     "emit EventEnvelope" in new Setup {
@@ -243,16 +250,15 @@ class FilterStageSpec extends ScalaTestWithActorTestKit("""
       inPublisher.sendNext(
         StreamIn(
           StreamIn.Message.Replay(ReplayReq(List(
-            PersistenceIdSeqNr(PersistenceId(entityType, "b").id, 1L),
-            PersistenceIdSeqNr(PersistenceId(entityType, "c").id, 1L))))))
+            replayPersistenceId(PersistenceId(entityType, "b").id, 1L),
+            replayPersistenceId(PersistenceId(entityType, "c").id, 1L))))))
 
       outProbe.request(10)
       // no guarantee of order between b and c
       outProbe.expectNextN(2).map(_.event).toSet shouldBe Set("b1", "c1")
       outProbe.expectNoMessage()
 
-      inPublisher.sendNext(
-        StreamIn(StreamIn.Message.Replay(ReplayReq(List(PersistenceIdSeqNr(PersistenceId(entityType, "d").id, 1L))))))
+      inPublisher.sendNext(streamInReplayReq(PersistenceId(entityType, "d").id, 1L))
       // it will not emit replayed event until there is some progress from the ordinary envSource, probably ok
       outProbe.expectNoMessage()
       envPublisher.sendNext(createEnvelope(PersistenceId(entityType, "e"), 1, "e1", tags = Set("WIP")))
@@ -272,9 +278,7 @@ class FilterStageSpec extends ScalaTestWithActorTestKit("""
       outProbe.request(10)
       outProbe.expectNext().event shouldBe "a2"
 
-      inPublisher.sendNext(
-        StreamIn(StreamIn.Message.Replay(
-          ReplayReq(List(PersistenceIdSeqNr(ReplicationId(entityType, "a", ReplicaId("A")).persistenceId.id, 1L))))))
+      inPublisher.sendNext(streamInReplayReq(ReplicationId(entityType, "a", ReplicaId("A")).persistenceId.id, 1L))
       // it will not emit replayed event until there is some progress from the ordinary envSource, probably ok
       envPublisher.sendNext(createEnvelope(PersistenceId(entityType, "e"), 1, "e1"))
       outProbe.expectNext().event shouldBe "e1"
@@ -282,9 +286,7 @@ class FilterStageSpec extends ScalaTestWithActorTestKit("""
       outProbe.expectNext().event shouldBe "a2"
 
       // but ignored if it's a request for another replicaId
-      inPublisher.sendNext(
-        StreamIn(StreamIn.Message.Replay(
-          ReplayReq(List(PersistenceIdSeqNr(ReplicationId(entityType, "a", ReplicaId("B")).persistenceId.id, 1L))))))
+      inPublisher.sendNext(streamInReplayReq(ReplicationId(entityType, "a", ReplicaId("B")).persistenceId.id, 1L))
       outProbe.expectNoMessage()
     }
 
@@ -295,13 +297,13 @@ class FilterStageSpec extends ScalaTestWithActorTestKit("""
 
       inPublisher.sendNext(
         StreamIn(StreamIn.Message.Replay(
-          ReplayReq(entityIds.take(7).map(id => PersistenceIdSeqNr(PersistenceId(entityType, id).id, 1L))))))
+          ReplayReq(entityIds.take(7).map(id => replayPersistenceId(PersistenceId(entityType, id).id, 1L))))))
       inPublisher.sendNext(
         StreamIn(StreamIn.Message.Replay(
-          ReplayReq(entityIds.slice(7, 10).map(id => PersistenceIdSeqNr(PersistenceId(entityType, id).id, 1L))))))
+          ReplayReq(entityIds.slice(7, 10).map(id => replayPersistenceId(PersistenceId(entityType, id).id, 1L))))))
       inPublisher.sendNext(
         StreamIn(StreamIn.Message.Replay(
-          ReplayReq(entityIds.drop(10).map(id => PersistenceIdSeqNr(PersistenceId(entityType, id).id, 1L))))))
+          ReplayReq(entityIds.drop(10).map(id => replayPersistenceId(PersistenceId(entityType, id).id, 1L))))))
 
       outProbe.request(100)
       // no guarantee of order between different entityIds
@@ -311,6 +313,34 @@ class FilterStageSpec extends ScalaTestWithActorTestKit("""
       outProbe.expectNoMessage()
 
       envPublisher.sendComplete()
+    }
+
+    "replay from ReplayReq and filter after seqNr" in new Setup {
+      override lazy val allEnvelopes =
+        Vector(
+          createEnvelope(PersistenceId(entityType, "d"), 1, "d1"),
+          createEnvelope(PersistenceId(entityType, "d"), 2, "d2"),
+          createEnvelope(PersistenceId(entityType, "d"), 3, "d3", tags = Set("WIP")),
+          createEnvelope(PersistenceId(entityType, "d"), 4, "d4"),
+          createEnvelope(PersistenceId(entityType, "d"), 5, "d5"))
+
+      // filter should not exclude events from replay, e.g. d1 without the WIP tag, but
+      // filters are applied for events with seqNr >= filterAfterSeqNr
+      val filterCriteria = List(
+        FilterCriteria(FilterCriteria.Message.ExcludeMatchingEntityIds(ExcludeRegexEntityIds(List(".*")))),
+        FilterCriteria(FilterCriteria.Message.IncludeTags(IncludeTags(List("WIP")))))
+      inPublisher.sendNext(StreamIn(StreamIn.Message.Filter(FilterReq(filterCriteria))))
+
+      outProbe.request(10)
+
+      inPublisher.sendNext(streamInReplayReq(PersistenceId(entityType, "d").id, 1L, filterAfterSeqNr = 4))
+      // it will not emit replayed event until there is some progress from the ordinary envSource, probably ok
+      outProbe.expectNoMessage()
+      envPublisher.sendNext(createEnvelope(PersistenceId(entityType, "e"), 1, "e1"))
+      outProbe.expectNext().event shouldBe "d1"
+      outProbe.expectNext().event shouldBe "d2"
+      outProbe.expectNext().event shouldBe "d3"
+      outProbe.expectNoMessage() // d4 and d5 filtered out
     }
 
   }

--- a/akka-projection-grpc/src/main/mima-filters/1.5.2.backwards.excludes/res-replay-filter.excludes
+++ b/akka-projection-grpc/src/main/mima-filters/1.5.2.backwards.excludes/res-replay-filter.excludes
@@ -1,0 +1,3 @@
+# adding filterAfterSeqNr
+ProblemFilters.exclude[Problem]("akka.projection.grpc.internal.FilterStage*")
+ProblemFilters.exclude[Problem]("akka.projection.grpc.internal.proto.ReplayReq*")

--- a/akka-projection-grpc/src/main/protobuf/akka/projection/grpc/event_producer.proto
+++ b/akka-projection-grpc/src/main/protobuf/akka/projection/grpc/event_producer.proto
@@ -75,7 +75,9 @@ message FilterReq {
 
 // Replay events for given entities.
 message ReplayReq {
-  repeated ReplayPersistenceId replay_persistence_ids = 1;
+  // deprecated in 1.5.3, use replay_persistence_ids
+  repeated PersistenceIdSeqNr persistence_id_offset = 1;
+  repeated ReplayPersistenceId replay_persistence_ids = 2;
 }
 
 message ReplayPersistenceId {

--- a/akka-projection-grpc/src/main/protobuf/akka/projection/grpc/event_producer.proto
+++ b/akka-projection-grpc/src/main/protobuf/akka/projection/grpc/event_producer.proto
@@ -75,7 +75,14 @@ message FilterReq {
 
 // Replay events for given entities.
 message ReplayReq {
-  repeated PersistenceIdSeqNr persistence_id_offset = 1;
+  repeated ReplayPersistenceId replay_persistence_ids = 1;
+}
+
+message ReplayPersistenceId {
+  PersistenceIdSeqNr from_persistence_id_offset = 1;
+  // apply filters for replayed events after this sequence number
+  int64 filter_after_seq_nr = 2;
+
 }
 
 message FilterCriteria {

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/ConsumerFilter.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/ConsumerFilter.scala
@@ -87,6 +87,17 @@ object ConsumerFilter extends ExtensionId[ConsumerFilter] {
       this(streamId, persistenceIdOffsets.asScala.toSet)
   }
 
+  /**
+   * Explicit request to replay events for given entities.
+   */
+  final case class ReplayWithFilter(streamId: String, replayPersistenceIds: Set[ReplayPersistenceId])
+      extends SubscriberCommand {
+
+    /** Java API */
+    def this(streamId: String, persistenceIdOffsets: JSet[ReplayPersistenceId]) =
+      this(streamId, persistenceIdOffsets.asScala.toSet)
+  }
+
   sealed trait FilterCriteria
   sealed trait RemoveCriteria extends FilterCriteria
 
@@ -305,6 +316,8 @@ object ConsumerFilter extends ExtensionId[ConsumerFilter] {
   final case class EntityIdOffset(entityId: String, seqNr: Long)
 
   final case class PersistenceIdOffset(persistenceIdId: String, seqNr: Long)
+
+  final case class ReplayPersistenceId(persistenceIdOffset: PersistenceIdOffset, filterAfterSeqNr: Long)
 
   override def createExtension(system: ActorSystem[_]): ConsumerFilter = new ConsumerFilter(system)
 

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/javadsl/GrpcReadJournal.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/javadsl/GrpcReadJournal.scala
@@ -99,8 +99,8 @@ class GrpcReadJournal(delegate: scaladsl.GrpcReadJournal)
     delegate.streamId
 
   @InternalApi
-  private[akka] override def triggerReplay(persistenceId: String, fromSeqNr: Long): Unit =
-    delegate.triggerReplay(persistenceId, fromSeqNr)
+  private[akka] override def triggerReplay(persistenceId: String, fromSeqNr: Long, triggeredBySeqNr: Long): Unit =
+    delegate.triggerReplay(persistenceId, fromSeqNr, triggeredBySeqNr)
 
   override def eventsBySlices[Event](
       entityType: String,

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
@@ -64,6 +64,7 @@ import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
+import akka.projection.grpc.internal.proto.ReplayPersistenceId
 import akka.projection.grpc.internal.proto.ReplicaInfo
 import akka.projection.grpc.replication.scaladsl.ReplicationSettings
 @ApiMayChange
@@ -205,10 +206,12 @@ final class GrpcReadJournal private (
     replicationSettings.map(s => ReplicaInfo(s.selfReplicaId.id, s.otherReplicas.toSeq.map(_.replicaId.id)))
 
   @InternalApi
-  private[akka] override def triggerReplay(persistenceId: String, fromSeqNr: Long): Unit = {
-    consumerFilter.ref ! ConsumerFilter.Replay(
+  private[akka] override def triggerReplay(persistenceId: String, fromSeqNr: Long, triggeredBySeqNr: Long): Unit = {
+    consumerFilter.ref ! ConsumerFilter.ReplayWithFilter(
       streamId,
-      Set(ConsumerFilter.PersistenceIdOffset(persistenceId, fromSeqNr)))
+      Set(
+        ConsumerFilter
+          .ReplayPersistenceId(ConsumerFilter.PersistenceIdOffset(persistenceId, fromSeqNr), triggeredBySeqNr + 1)))
   }
 
   private def addRequestHeaders[Req, Res](
@@ -318,24 +321,40 @@ final class GrpcReadJournal private (
               log.debug2("{}: Filter updated [{}]", streamId, criteria.mkString(", "))
             StreamIn(StreamIn.Message.Filter(FilterReq(protoCriteria)))
 
+          case r @ ConsumerFilter.ReplayWithFilter(`streamId`, _) =>
+            streamInReplay(r)
+
           case ConsumerFilter.Replay(`streamId`, persistenceIdOffsets) =>
-            val protoPersistenceIdOffsets = persistenceIdOffsets.collect {
-              case ConsumerFilter.PersistenceIdOffset(pid, seqNr) if sliceHandledByThisStream(pid) =>
-                PersistenceIdSeqNr(pid, seqNr)
-            }.toVector
-
-            if (log.isDebugEnabled() && protoPersistenceIdOffsets.nonEmpty)
-              log.debug2(
-                "{}: Replay triggered for [{}]",
-                streamId,
-                protoPersistenceIdOffsets.map(offset => offset.persistenceId -> offset.seqNr).mkString(", "))
-
-            StreamIn(StreamIn.Message.Replay(ReplayReq(protoPersistenceIdOffsets)))
+            val replayWithFilter = ConsumerFilter.ReplayWithFilter(
+              streamId,
+              persistenceIdOffsets.map(p => ConsumerFilter.ReplayPersistenceId(p, filterAfterSeqNr = Long.MaxValue)))
+            streamInReplay(replayWithFilter)
         }
         .mapMaterializedValue { ref =>
           consumerFilter.ref ! ConsumerFilter.Subscribe(streamId, initCriteria, ref)
           NotUsed
         }
+
+    def streamInReplay(r: ConsumerFilter.ReplayWithFilter): StreamIn = {
+      val protoReplayPersistenceIds = r.replayPersistenceIds.collect {
+        case ConsumerFilter.ReplayPersistenceId(ConsumerFilter.PersistenceIdOffset(pid, seqNr), filterAfterSeqNr)
+            if sliceHandledByThisStream(pid) =>
+          ReplayPersistenceId(Some(PersistenceIdSeqNr(pid, seqNr)), filterAfterSeqNr)
+      }.toVector
+
+      if (log.isDebugEnabled() && protoReplayPersistenceIds.nonEmpty)
+        log.debug2(
+          "{}: Replay triggered for [{}]",
+          streamId,
+          protoReplayPersistenceIds
+            .map { replayPersistenceId =>
+              val offset = replayPersistenceId.fromPersistenceIdOffset.get
+              s"${offset.persistenceId} -> ${offset.seqNr} (${replayPersistenceId.filterAfterSeqNr})"
+            }
+            .mkString(", "))
+
+      StreamIn(StreamIn.Message.Replay(ReplayReq(protoReplayPersistenceIds)))
+    }
 
     val initFilter = {
       import akka.actor.typed.scaladsl.AskPattern._

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
@@ -342,6 +342,9 @@ final class GrpcReadJournal private (
           ReplayPersistenceId(Some(PersistenceIdSeqNr(pid, seqNr)), filterAfterSeqNr)
       }.toVector
 
+      // need this for compatibility with 1.5.2
+      val protoPersistenceIdOffsets = protoReplayPersistenceIds.map(_.fromPersistenceIdOffset.get)
+
       if (log.isDebugEnabled() && protoReplayPersistenceIds.nonEmpty)
         log.debug2(
           "{}: Replay triggered for [{}]",
@@ -353,7 +356,7 @@ final class GrpcReadJournal private (
             }
             .mkString(", "))
 
-      StreamIn(StreamIn.Message.Replay(ReplayReq(protoReplayPersistenceIds)))
+      StreamIn(StreamIn.Message.Replay(ReplayReq(protoPersistenceIdOffsets, protoReplayPersistenceIds)))
     }
 
     val initFilter = {

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/ConsumerFilterRegistry.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/ConsumerFilterRegistry.scala
@@ -127,6 +127,10 @@ import akka.util.Timeout
 
           behavior(subscribers, stores.updated(streamId, store))
 
+        case cmd: ReplayWithFilter =>
+          publishToSubscribers(cmd)
+          Behaviors.same
+
         case cmd: Replay =>
           publishToSubscribers(cmd)
           Behaviors.same

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/FilterStage.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/FilterStage.scala
@@ -400,6 +400,12 @@ import org.slf4j.LoggerFactory
                   log.debug2("Stream [{}]: Replay requested for [{}]", logPrefix, replayReq.replayPersistenceIds)
                   replayAll(replayReq.replayPersistenceIds)
                 }
+                // needed for compatibility with 2.5.2
+                if (replayReq.replayPersistenceIds.isEmpty && replayReq.persistenceIdOffset.nonEmpty) {
+                  log.debug2("Stream [{}]: Replay requested for [{}]", logPrefix, replayReq.persistenceIdOffset)
+                  replayAll(replayReq.persistenceIdOffset.map(p =>
+                    ReplayPersistenceId(Some(p), filterAfterSeqNr = Long.MaxValue)))
+                }
 
               case StreamIn(StreamIn.Message.Init(_), _) =>
                 log.warn("Stream [{}]: Init request can only be used as the first message", logPrefix)

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/FilterStage.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/FilterStage.scala
@@ -22,6 +22,7 @@ import akka.persistence.typed.ReplicationId
 import akka.projection.grpc.internal.proto.EntityIdOffset
 import akka.projection.grpc.internal.proto.FilterCriteria
 import akka.projection.grpc.internal.proto.PersistenceIdSeqNr
+import akka.projection.grpc.internal.proto.ReplayPersistenceId
 import akka.projection.grpc.internal.proto.StreamIn
 import akka.stream.Attributes
 import akka.stream.BidiShape
@@ -141,7 +142,10 @@ import org.slf4j.LoggerFactory
 
   private case class ReplayEnvelope(persistenceId: String, env: Option[EventEnvelope[Any]])
 
-  private case class ReplaySession(fromSeqNr: Long, queue: SinkQueueWithCancel[EventEnvelope[Any]])
+  private case class ReplaySession(
+      fromSeqNr: Long,
+      filterAfterSeqNr: Long,
+      queue: SinkQueueWithCancel[EventEnvelope[Any]])
 
 }
 
@@ -177,7 +181,7 @@ import org.slf4j.LoggerFactory
 
       // only one pull replay stream -> async callback at a time
       private var replayHasBeenPulled = false
-      private var pendingReplayRequests: Vector[PersistenceIdSeqNr] = Vector.empty
+      private var pendingReplayRequests: Vector[ReplayPersistenceId] = Vector.empty
       // several replay streams may be in progress at the same time
       private var replayInProgress: Map[String, ReplaySession] = Map.empty
       private val replayCallback = getAsyncCallback[Try[ReplayEnvelope]] {
@@ -202,18 +206,35 @@ import org.slf4j.LoggerFactory
           pullInEnvOrReplay()
         }
 
+        val currentReplay = replayInProgress(replayEnv.persistenceId)
         replayHasBeenPulled = false
 
         replayEnv match {
           case ReplayEnvelope(_, Some(env)) =>
             // the predicate to replay events from start for a given pid
-            // Note: we do not apply the filter here as that may be what triggered the replay
-            log.traceN(
-              "Stream [{}]: Push replayed event persistenceId [{}], seqNr [{}]",
-              logPrefix,
-              env.persistenceId,
-              env.sequenceNr)
-            push(outEnv, env)
+
+            // protobuf ReplayReq was changed in akka-projection-grpc version 1.5.3 in a compatible way.
+            // For consumers running an earlier version the filterAfterSeqNr will be 0 (default value in protobuf)
+            val filterAfterSeqNr =
+              if (currentReplay.filterAfterSeqNr == 0) Long.MaxValue else currentReplay.filterAfterSeqNr
+
+            // Note: we do not apply the filter before filterAfterSeqNr as that may be what triggered the replay.
+            // replicatedEventOriginFilter not used for replay.
+            if (env.sequenceNr < filterAfterSeqNr || producerFilter(env) && filter.matches(env)) {
+              log.traceN(
+                "Stream [{}]: Push replayed event persistenceId [{}], seqNr [{}]",
+                logPrefix,
+                env.persistenceId,
+                env.sequenceNr)
+              push(outEnv, env)
+            } else {
+              log.debugN(
+                "Stream [{}]: Filter out replayed event persistenceId [{}], seqNr [{}]",
+                logPrefix,
+                env.persistenceId,
+                env.sequenceNr)
+              pullInEnvOrReplay()
+            }
 
           case ReplayEnvelope(persistenceId, None) =>
             log.debug2("Stream [{}]: Completed replay of persistenceId [{}]", logPrefix, persistenceId)
@@ -285,24 +306,28 @@ import org.slf4j.LoggerFactory
         criteria.foreach {
           _.message match {
             case FilterCriteria.Message.IncludeEntityIds(include) =>
-              replayAll(mapEntityIdOffsetToPidHandledByThisStream(include.entityIdOffset))
+              val replayPersistenceIds = mapEntityIdOffsetToPidHandledByThisStream(include.entityIdOffset)
+                .map(p => ReplayPersistenceId(Some(p), filterAfterSeqNr = Long.MaxValue))
+              replayAll(replayPersistenceIds)
             case _ =>
           }
         }
       }
 
-      private def replayAll(persistenceIdOffsets: Iterable[PersistenceIdSeqNr]): Unit = {
-        persistenceIdOffsets.foreach { offset =>
-          if (offset.seqNr >= 1)
-            replay(offset)
-        // FIXME seqNr 0 would be to support a mode where we only deliver events after the include filter
-        // change. In that case we must have a way to signal to the R2dbcOffsetStore that the
-        // first seqNr of that new pid is ok to pass through even though it isn't 1
-        // and the offset store doesn't know about previous seqNr.
+      private def replayAll(replayPersistenceIds: Iterable[ReplayPersistenceId]): Unit = {
+        replayPersistenceIds.foreach {
+          case r @ ReplayPersistenceId(Some(fromOffset), _, _) if fromOffset.seqNr >= 1 =>
+            replay(r)
+          case _ =>
+          // FIXME seqNr 0 would be to support a mode where we only deliver events after the include filter
+          // change. In that case we must have a way to signal to the R2dbcOffsetStore that the
+          // first seqNr of that new pid is ok to pass through even though it isn't 1
+          // and the offset store doesn't know about previous seqNr.
         }
       }
 
-      private def replay(persistenceIdOffset: PersistenceIdSeqNr): Unit = {
+      private def replay(replayPersistenceId: ReplayPersistenceId): Unit = {
+        val persistenceIdOffset = replayPersistenceId.fromPersistenceIdOffset.get
         val fromSeqNr = persistenceIdOffset.seqNr
         val pid = persistenceIdOffset.persistenceId
         if (replicaIdHandledByThisStream(pid) && sliceHandledByThisStream(pid)) {
@@ -326,25 +351,30 @@ import org.slf4j.LoggerFactory
               logPrefix,
               pid,
               fromSeqNr)
+            replayInProgress = replayInProgress.updated(
+              pid,
+              replayInProgress(pid).copy(filterAfterSeqNr = replayPersistenceId.filterAfterSeqNr))
           } else if (replayInProgress.size < replayParallelism) {
             log.debugN("Stream [{}]: Starting replay of persistenceId [{}], from seqNr [{}]", logPrefix, pid, fromSeqNr)
             val queue =
               currentEventsByPersistenceId(pid, fromSeqNr)
                 .runWith(Sink.queue())(materializer)
-            replayInProgress = replayInProgress.updated(pid, ReplaySession(fromSeqNr, queue))
+            replayInProgress =
+              replayInProgress.updated(pid, ReplaySession(fromSeqNr, replayPersistenceId.filterAfterSeqNr, queue))
             tryPullReplay(pid)
           } else {
             log.debugN("Stream [{}]: Queueing replay of persistenceId [{}], from seqNr [{}]", logPrefix, pid, fromSeqNr)
-            pendingReplayRequests = pendingReplayRequests.filterNot(_.persistenceId == pid) :+ persistenceIdOffset
+            pendingReplayRequests =
+              pendingReplayRequests.filterNot(_.fromPersistenceIdOffset.get.persistenceId == pid) :+ replayPersistenceId
           }
         }
       }
 
       private def pullInEnvOrReplay(): Unit = {
         if (replayInProgress.size < replayParallelism && pendingReplayRequests.nonEmpty) {
-          val pendingEntityOffset = pendingReplayRequests.head
+          val pendingReplay = pendingReplayRequests.head
           pendingReplayRequests = pendingReplayRequests.tail
-          replay(pendingEntityOffset)
+          replay(pendingReplay)
         }
 
         if (replayInProgress.isEmpty) {
@@ -366,9 +396,9 @@ import org.slf4j.LoggerFactory
                 replayFromFilterCriteria(filterReq.criteria)
 
               case StreamIn(StreamIn.Message.Replay(replayReq), _) =>
-                if (replayReq.persistenceIdOffset.nonEmpty) {
-                  log.debug2("Stream [{}]: Replay requested for [{}]", logPrefix, replayReq.persistenceIdOffset)
-                  replayAll(replayReq.persistenceIdOffset)
+                if (replayReq.replayPersistenceIds.nonEmpty) {
+                  log.debug2("Stream [{}]: Replay requested for [{}]", logPrefix, replayReq.replayPersistenceIds)
+                  replayAll(replayReq.replayPersistenceIds)
                 }
 
               case StreamIn(StreamIn.Message.Init(_), _) =>

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
@@ -453,7 +453,7 @@ private[projection] object R2dbcProjectionImpl {
         sourceProvider match {
           case provider: CanTriggerReplay =>
             val fromSeqNr = offsetStore.storedSeqNr(env.persistenceId) + 1
-            provider.triggerReplay(env.persistenceId, fromSeqNr)
+            provider.triggerReplay(env.persistenceId, fromSeqNr, env.sequenceNr)
             true
           case _ =>
             false // no replay support for other source providers


### PR DESCRIPTION
* filters are not used in replay requests, because the change of consumer
  filter is typically what triggers a replay request (missing preceding events)
* but that means that a replica may receive unexpected events, so
  apply the filters after the sequence number that triggered the replay