### PR TITLE
fix: kafka to depend on testkit via Test scope

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,7 @@ lazy val eventsourced =
 lazy val kafka =
   Project(id = "akka-projection-kafka", base = file("akka-projection-kafka"))
     .settings(Dependencies.kafka)
-    .dependsOn(testkit)
+    .dependsOn(testkit % Test)
     .dependsOn(core)
     .disablePlugins(CiReleasePlugin)
 


### PR DESCRIPTION
Avoid `akka-projection-kafka` to include `akka-projection-testkit` via non-test scoped builds.