### PR TITLE
ci: pin sqlserver to the previous version

### DIFF
--- a/.github/workflows/integration-tests-r2dbc.yml
+++ b/.github/workflows/integration-tests-r2dbc.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Start DB
         run: |-
-          docker-compose -f docker-files/docker-compose-yugabyte.yml up -d
+          docker compose -f docker-files/docker-compose-yugabyte.yml up -d
           # TODO: could we poll the port instead of sleep?
           sleep 10
           docker exec -i yb-tserver-n1 /home/yugabyte/bin/ysqlsh -h yb-tserver-n1 -t < akka-projection-r2dbc/ddl-scripts/create_tables_yugabyte.sql

--- a/docker-files/docker-compose-sqlserver.yml
+++ b/docker-files/docker-compose-sqlserver.yml
@@ -1,7 +1,7 @@
 version: '2.2'
 services:
   sqlserver:
-    image: mcr.microsoft.com/mssql/server:2022-latest
+    image: mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04
     container_name: sqlserver-db
     environment:
       - MSSQL_SA_PASSWORD=<YourStrong@Passw0rd>


### PR DESCRIPTION
Latest version currently failing to start.

```
OCI runtime exec failed: exec failed: unable to start container process: exec: "/opt/mssql-tools/bin/sqlcmd": stat /opt/mssql-tools/bin/sqlcmd: no such file or directory: unknown
```

Looks like this path `/opt/mssql-tools/bin/sqlcmd` is now `/opt/mssql-tools18/bin/sqlcmd`. But updating that then fails with:

```
Sqlcmd: Error: Microsoft ODBC Driver 18 for SQL Server : TCP Provider: Error code 0x2749.
Sqlcmd: Error: Microsoft ODBC Driver 18 for SQL Server : SSL Provider: [error:0A000086:SSL routines::certificate verify failed:self-signed certificate].
Sqlcmd: Error: Microsoft ODBC Driver 18 for SQL Server : A network-related or instance-specific error has occurred while establishing a connection to localhost. Server is not found or not accessible. Check if instance name is correct and if SQL Server is configured to allow remote connections. For more information see SQL Server Books Online..
```

So pinning to the previous version. Same applied in https://github.com/akka/akka-persistence-r2dbc/pull/586