### PR TITLE
Fix Distributed Cluster Example Project 

### DIFF
--- a/samples/replicated/shopping-cart-service-java/src/main/java/shopping/cart/ShoppingCart.java
+++ b/samples/replicated/shopping-cart-service-java/src/main/java/shopping/cart/ShoppingCart.java
@@ -525,6 +525,7 @@ public final class ShoppingCart
         .forAnyState()
         .onEvent(
             ItemUpdated.class, (state, event) -> state.updateItem(event.itemId, event.quantity))
+        .onEvent(CustomerMarkedVip.class, (state, event) -> state.markCustomerVip())
         .onEvent(
             Closed.class,
             (state, event) -> {


### PR DESCRIPTION
I discovered that the sample project from the [Akka DC docs](https://doc.akka.io/docs/akka-distributed-cluster/current/guide/4-deploying.html) was throwing an error, when I run the following command from the README:
 
```
grpcurl -d '{"cartId":"cart1"}' -plaintext 127.0.0.1:8101 shoppingcart.ShoppingCartService.MarkCustomerVip
```

The java implementation was missing an event handler for the `CustomerMarkedVip` event, so I added it.
The scala implementation is working correct.
