### PR TITLE
fix: ConsumerFilterRegistry unique actor name

### DIFF
--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/ConsumerFilterRegistry.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/ConsumerFilterRegistry.scala
@@ -72,7 +72,7 @@ import akka.util.Timeout
               // but not removed yet. The actor name isn't important, but could be useful for debugging.
               context.spawn(
                 ConsumerFilterStore(context.system, settings, streamId, context.self),
-                s"encodedStreamId-${UUID.randomUUID()}")
+                s"$encodedStreamId-${UUID.randomUUID()}")
           }
       }
     }

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/ConsumerFilterRegistry.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/ConsumerFilterRegistry.scala
@@ -7,11 +7,13 @@ package akka.projection.grpc.internal
 import scala.concurrent.duration._
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import java.util.UUID
 
 import scala.collection.immutable
 import scala.util.Failure
 import scala.util.Success
 
+import akka.actor.InvalidActorNameException
 import akka.actor.typed.ActorRef
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.ActorContext
@@ -61,9 +63,17 @@ import akka.util.Timeout
       stores.get(streamId) match {
         case Some(store) => store
         case None =>
-          context.spawn(
-            ConsumerFilterStore(context.system, settings, streamId, context.self),
-            URLEncoder.encode(streamId, StandardCharsets.UTF_8.name))
+          val encodedStreamId = URLEncoder.encode(streamId, StandardCharsets.UTF_8.name)
+          try {
+            context.spawn(ConsumerFilterStore(context.system, settings, streamId, context.self), encodedStreamId)
+          } catch {
+            case _: InvalidActorNameException =>
+              // There could be a race condition from SubscriberTerminated where the child is stopped,
+              // but not removed yet. The actor name isn't important, but could be useful for debugging.
+              context.spawn(
+                ConsumerFilterStore(context.system, settings, streamId, context.self),
+                s"encodedStreamId-${UUID.randomUUID()}")
+          }
       }
     }
 


### PR DESCRIPTION
Noticed this occasionally:

```
Caused by: akka.grpc.GrpcServiceException: NOT_FOUND: Stream id [customer] is not available for consumption
	at akka.grpc.GrpcServiceException$.apply(GrpcServiceException.scala:40)
	at akka.grpc.internal.RequestBuilderImpl$.lift(RequestBuilderImpl.scala:481)
	at akka.grpc.internal.RequestBuilderImpl$$anonfun$richErrorStream$1.applyOrElse(RequestBuilderImpl.scala:473)
	at akka.grpc.internal.RequestBuilderImpl$$anonfun$richErrorStream$1.applyOrElse(RequestBuilderImpl.scala:472)
	at akka.stream.impl.fusing.RecoverWith$$anon$43.akka$stream$impl$fusing$RecoverWith$$anon$$onFailure(Ops.scala:2156)
	at akka.stream.impl.fusing.RecoverWith$$anon$43.onUpstreamFailure(Ops.scala:2151)
	... 21 more

09:00:06.737 ERROR akka.actor.typed.Behavior$ - Supervisor StopSupervisor saw failure: actor name [customer] is not unique!
akka.actor.InvalidActorNameException: actor name [customer] is not unique!
	at akka.actor.dungeon.ChildrenContainer$TerminatingChildrenContainer.reserve(ChildrenContainer.scala:200)
	at akka.actor.dungeon.Children.reserveChild(Children.scala:154)
	at akka.actor.dungeon.Children.reserveChild$(Children.scala:152)
	at akka.actor.ActorCell.reserveChild(ActorCell.scala:408)
	at akka.actor.dungeon.Children.makeChild(Children.scala:307)
	at akka.actor.dungeon.Children.actorOf(Children.scala:56)
	at akka.actor.dungeon.Children.actorOf$(Children.scala:55)
	at akka.actor.ActorCell.actorOf(ActorCell.scala:408)
	at akka.actor.typed.internal.adapter.ActorRefFactoryAdapter$.spawn(ActorRefFactoryAdapter.scala:55)
	at akka.actor.typed.internal.adapter.ActorContextAdapter.spawn(ActorContextAdapter.scala:73)
	at akka.projection.grpc.internal.ConsumerFilterRegistry.getOrCreateStore$1(ConsumerFilterRegistry.scala:64)
	at akka.projection.grpc.internal.ConsumerFilterRegistry.$anonfun$behavior$3(ConsumerFilterRegistry.scala:125)
	at akka.actor.typed.internal.BehaviorImpl$ReceiveMessageBehavior.receive(BehaviorImpl.scala:152)
	at akka.actor.typed.Behavior$.interpret(Behavior.scala:282)
	at akka.actor.typed.Behavior$.interpretMessage(Behavior.scala:238)
	at akka.actor.typed.internal.InterceptorImpl$$anon$2.apply(InterceptorImpl.scala:57)
	at akka.actor.typed.internal.SimpleSupervisor.aroundReceive(Supervision.scala:129)
	at akka.actor.typed.internal.InterceptorImpl.receive(InterceptorImpl.scala:85)
	at akka.actor.typed.Behavior$.interpret(Behavior.scala:282)
	at akka.actor.typed.Behavior$.interpretMessage(Behavior.scala:238)
	at akka.actor.typed.internal.adapter.ActorAdapter.handleMessage(ActorAdapter.scala:133)
	at akka.actor.typed.internal.adapter.ActorAdapter.aroundReceive(ActorAdapter.scala:109)
```