### PR TITLE
fix: Trigger replay only for a specific projection instance

### DIFF
--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/ConsumerFilter.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/ConsumerFilter.scala
@@ -4,11 +4,14 @@
 
 package akka.projection.grpc.consumer
 
+import java.util.Optional
+import java.util.UUID
 import java.util.{ List => JList }
 import java.util.{ Set => JSet }
 
 import scala.annotation.tailrec
 import scala.collection.immutable
+import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration.FiniteDuration
 
 import akka.actor.typed.ActorRef
@@ -88,12 +91,15 @@ object ConsumerFilter extends ExtensionId[ConsumerFilter] {
   /**
    * Explicit request to replay events for given entities.
    */
-  final case class ReplayWithFilter(streamId: String, replayPersistenceIds: Set[ReplayPersistenceId])
+  final case class ReplayWithFilter(
+      streamId: String,
+      replayPersistenceIds: Set[ReplayPersistenceId],
+      correlationId: Option[UUID]) // FIXME bin compat
       extends SubscriberCommand {
 
     /** Java API */
-    def this(streamId: String, persistenceIdOffsets: JSet[ReplayPersistenceId]) =
-      this(streamId, persistenceIdOffsets.asScala.toSet)
+    def this(streamId: String, persistenceIdOffsets: JSet[ReplayPersistenceId], correlationId: Optional[UUID]) =
+      this(streamId, persistenceIdOffsets.asScala.toSet, correlationId.asScala)
   }
 
   sealed trait FilterCriteria


### PR DESCRIPTION
* when using same streamId from several projections a replay request from one will send the replay request to all eventsBySlices queries with that same streamId
* this adds a correlation id between the triggerReplay and the eventsBySlices query via the GrpcReadJournal instance
* projection instances with different slice ranges of the same projection is not a problem, slice ranges are checked separately
