### PR TITLE
bump: akka-persistence-r2dbc 1.2.6 (backport 1.5)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
     val akka = sys.props.getOrElse("build.akka.version", "2.9.6")
     val akkaPersistenceCassandra = "1.2.1"
     val akkaPersistenceJdbc = "5.4.1"
-    val akkaPersistenceR2dbc = "1.2.4"
+    val akkaPersistenceR2dbc = "1.2.6"
     val alpakka = "8.0.0"
     val alpakkaKafka = sys.props.getOrElse("build.alpakka.kafka.version", "6.0.0")
     val slick = "3.5.2"

--- a/samples/grpc/iot-service-java/pom.xml
+++ b/samples/grpc/iot-service-java/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <akka.version>2.9.6</akka.version>
         <akka-projection.version>1.5.8</akka-projection.version>
-        <akka-persistence-r2dbc.version>1.2.5</akka-persistence-r2dbc.version>
+        <akka-persistence-r2dbc.version>1.2.6</akka-persistence-r2dbc.version>
         <akka-management.version>1.5.2</akka-management.version>
         <akka-diagnostics.version>2.1.0</akka-diagnostics.version>
         <akka-grpc.version>2.4.4</akka-grpc.version>

--- a/samples/grpc/iot-service-scala/build.sbt
+++ b/samples/grpc/iot-service-scala/build.sbt
@@ -31,7 +31,7 @@ Global / cancelable := false // ctrl-c
 val AkkaVersion = "2.9.6"
 val AkkaHttpVersion = "10.6.3"
 val AkkaManagementVersion = "1.5.2"
-val AkkaPersistenceR2dbcVersion = "1.2.5"
+val AkkaPersistenceR2dbcVersion = "1.2.6"
 val AkkaProjectionVersion =
   sys.props.getOrElse("akka-projection.version", "1.5.8")
 val AkkaDiagnosticsVersion = "2.1.1"

--- a/samples/grpc/local-drone-control-java/pom.xml
+++ b/samples/grpc/local-drone-control-java/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <akka.version>2.9.6</akka.version>
         <akka-projection.version>1.5.8</akka-projection.version>
-        <akka-persistence-r2dbc.version>1.2.5</akka-persistence-r2dbc.version>
+        <akka-persistence-r2dbc.version>1.2.6</akka-persistence-r2dbc.version>
         <akka-management.version>1.5.2</akka-management.version>
         <akka-diagnostics.version>2.1.0</akka-diagnostics.version>
         <akka-http.version>10.6.3</akka-http.version>

--- a/samples/grpc/local-drone-control-scala/build.sbt
+++ b/samples/grpc/local-drone-control-scala/build.sbt
@@ -33,7 +33,7 @@ Global / cancelable := false // ctrl-c
 val AkkaVersion = "2.9.6"
 val AkkaHttpVersion = "10.6.3"
 val AkkaManagementVersion = "1.5.2"
-val AkkaPersistenceR2dbcVersion = "1.2.5"
+val AkkaPersistenceR2dbcVersion = "1.2.6"
 val AkkaProjectionVersion =
   sys.props.getOrElse("akka-projection.version", "1.5.8")
 val AkkaDiagnosticsVersion = "2.1.0"

--- a/samples/grpc/restaurant-drone-deliveries-service-java/pom.xml
+++ b/samples/grpc/restaurant-drone-deliveries-service-java/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <akka.version>2.9.6</akka.version>
         <akka-projection.version>1.5.2</akka-projection.version>
-        <akka-persistence-r2dbc.version>1.2.5</akka-persistence-r2dbc.version>
+        <akka-persistence-r2dbc.version>1.2.6</akka-persistence-r2dbc.version>
         <akka-management.version>1.5.1</akka-management.version>
         <akka-diagnostics.version>2.1.0</akka-diagnostics.version>
         <akka-grpc.version>2.4.4</akka-grpc.version>

--- a/samples/grpc/restaurant-drone-deliveries-service-scala/build.sbt
+++ b/samples/grpc/restaurant-drone-deliveries-service-scala/build.sbt
@@ -31,7 +31,7 @@ Global / cancelable := false // ctrl-c
 val AkkaVersion = "2.9.6"
 val AkkaHttpVersion = "10.6.3"
 val AkkaManagementVersion = "1.5.2"
-val AkkaPersistenceR2dbcVersion = "1.2.5"
+val AkkaPersistenceR2dbcVersion = "1.2.6"
 val AkkaProjectionVersion =
   sys.props.getOrElse("akka-projection.version", "1.5.8")
 val AkkaDiagnosticsVersion = "2.1.1"

--- a/samples/grpc/shopping-analytics-service-java/pom.xml
+++ b/samples/grpc/shopping-analytics-service-java/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <akka.version>2.9.6</akka.version>
         <akka-projection.version>1.5.8</akka-projection.version>
-        <akka-persistence-r2dbc.version>1.2.5</akka-persistence-r2dbc.version>
+        <akka-persistence-r2dbc.version>1.2.6</akka-persistence-r2dbc.version>
         <akka-management.version>1.5.1</akka-management.version>
         <akka-diagnostics.version>2.1.0</akka-diagnostics.version>
         <akka-grpc.version>2.4.4</akka-grpc.version>

--- a/samples/grpc/shopping-analytics-service-scala/build.sbt
+++ b/samples/grpc/shopping-analytics-service-scala/build.sbt
@@ -31,7 +31,7 @@ Global / cancelable := false // ctrl-c
 val AkkaVersion = "2.9.6"
 val AkkaHttpVersion = "10.6.3"
 val AkkaManagementVersion = "1.5.1"
-val AkkaPersistenceR2dbcVersion = "1.2.5"
+val AkkaPersistenceR2dbcVersion = "1.2.6"
 val AkkaProjectionVersion =
   sys.props.getOrElse("akka-projection.version", "1.5.8")
 val AkkaDiagnosticsVersion = "2.1.0"

--- a/samples/grpc/shopping-cart-service-java/pom.xml
+++ b/samples/grpc/shopping-cart-service-java/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <akka.version>2.9.6</akka.version>
         <akka-projection.version>1.5.8</akka-projection.version>
-        <akka-persistence-r2dbc.version>1.2.5</akka-persistence-r2dbc.version>
+        <akka-persistence-r2dbc.version>1.2.6</akka-persistence-r2dbc.version>
         <akka-management.version>1.5.1</akka-management.version>
         <akka-diagnostics.version>2.1.0</akka-diagnostics.version>
         <akka-grpc.version>2.4.4</akka-grpc.version>

--- a/samples/grpc/shopping-cart-service-scala/build.sbt
+++ b/samples/grpc/shopping-cart-service-scala/build.sbt
@@ -31,7 +31,7 @@ Global / cancelable := false // ctrl-c
 val AkkaVersion = "2.9.6"
 val AkkaHttpVersion = "10.6.3"
 val AkkaManagementVersion = "1.5.2"
-val AkkaPersistenceR2dbcVersion = "1.2.5"
+val AkkaPersistenceR2dbcVersion = "1.2.6"
 val AkkaProjectionVersion =
   sys.props.getOrElse("akka-projection.version", "1.5.8")
 val AkkaDiagnosticsVersion = "2.1.1"

--- a/samples/replicated/shopping-cart-service-scala/build.sbt
+++ b/samples/replicated/shopping-cart-service-scala/build.sbt
@@ -32,7 +32,7 @@ Global / cancelable := false // ctrl-c
 val AkkaVersion = sys.props.getOrElse("akka.version", "2.9.6")
 val AkkaHttpVersion = "10.6.3"
 val AkkaManagementVersion = "1.5.2"
-val AkkaPersistenceR2dbcVersion = "1.2.5"
+val AkkaPersistenceR2dbcVersion = "1.2.6"
 val AkkaProjectionVersion =
   sys.props.getOrElse("akka-projection.version", "1.5.8")
 val AkkaDiagnosticsVersion = "2.1.1"


### PR DESCRIPTION
Not strictly needed, but some good improvements in https://github.com/akka/akka-persistence-r2dbc/pull/615 that we want to promote