### PR TITLE
perf: Try to load previous seqNr if missing, in validation (backport 1.5)

### DIFF
--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/OffsetStoreDao.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/OffsetStoreDao.scala
@@ -24,6 +24,8 @@ private[projection] trait OffsetStoreDao {
 
   def readTimestampOffset(): Future[immutable.IndexedSeq[R2dbcOffsetStore.RecordWithProjectionKey]]
 
+  def readTimestampOffset(slice: Int, pid: String): Future[Option[R2dbcOffsetStore.Record]]
+
   def readPrimitiveOffset(): Future[immutable.IndexedSeq[OffsetSerialization.SingleOffset]]
 
   def insertTimestampOffsetInTx(

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/PostgresOffsetStoreDao.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/PostgresOffsetStoreDao.scala
@@ -70,6 +70,15 @@ private[projection] class PostgresOffsetStoreDao(
     SELECT projection_key, slice, persistence_id, seq_nr, timestamp_offset
     FROM $timestampOffsetTable WHERE slice BETWEEN ? AND ? AND projection_name = ?"""
 
+  protected def createSelectOneTimestampOffsetSql: String =
+    sql"""
+    SELECT seq_nr, timestamp_offset
+    FROM $timestampOffsetTable WHERE slice = ? AND projection_name = ? AND persistence_id = ?
+    ORDER BY seq_nr DESC
+    LIMIT 1"""
+
+  private val selectOneTimestampOffsetSql: String = createSelectOneTimestampOffsetSql
+
   private val insertTimestampOffsetSql: String =
     sql"""
     INSERT INTO $timestampOffsetTable
@@ -219,6 +228,23 @@ private[projection] class PostgresOffsetStoreDao(
         val seqNr = row.get("seq_nr", classOf[java.lang.Long])
         val timestamp = row.getTimestamp("timestamp_offset")
         R2dbcOffsetStore.RecordWithProjectionKey(R2dbcOffsetStore.Record(slice, pid, seqNr, timestamp), projectionKey)
+      })
+  }
+
+  def readTimestampOffset(slice: Int, pid: String): Future[Option[R2dbcOffsetStore.Record]] = {
+    r2dbcExecutor.selectOne("read one timestamp offset")(
+      conn => {
+        logger.trace("reading one timestamp offset for [{}] pid [{}]", projectionId, pid)
+        conn
+          .createStatement(selectOneTimestampOffsetSql)
+          .bind(0, slice)
+          .bind(1, projectionId.name)
+          .bind(2, pid)
+      },
+      row => {
+        val seqNr = row.get("seq_nr", classOf[java.lang.Long])
+        val timestamp = row.getTimestamp("timestamp_offset")
+        R2dbcOffsetStore.Record(slice, pid, seqNr, timestamp)
       })
   }
 

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/SqlServerOffsetStoreDao.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/SqlServerOffsetStoreDao.scala
@@ -39,6 +39,12 @@ private[projection] class SqlServerOffsetStoreDao(
 
   override protected implicit def timestampCodec: TimestampCodec = SqlServerTimestampCodec
 
+  override protected def createSelectOneTimestampOffsetSql: String =
+    sql"""
+    SELECT TOP(1) seq_nr, timestamp_offset
+    FROM $timestampOffsetTable WHERE slice = ? AND projection_name = ? AND persistence_id = ?
+    ORDER BY seq_nr DESC"""
+
   override protected def createUpsertOffsetSql() =
     sql"""
             UPDATE $offsetTable SET


### PR DESCRIPTION
Backport of https://github.com/akka/akka-projection/pull/1197

* perf: Try to load previous seqNr if missing, in validation

* makes it more safe to evict from memory, but keep more in database
* a step towards lazy loading of offsets, but full lazy loading would require many more changes due to the concurrency model used in the R2dbcOffsetStore
* otherwise it will use timestampOf, which are be more costly for gRPC projections
* it still falls back to timestampOf as last resort

* different sql for SqlServer

(cherry picked from commit e956248d81634c8d6b234bf4a3600e2889ffbd94)
