### PR TITLE
docs: note for running projections using management api

### DIFF
--- a/docs/src/main/paradox/management.md
+++ b/docs/src/main/paradox/management.md
@@ -4,6 +4,12 @@
 
 With the @apidoc[ProjectionManagement] API you can manage the offset of a projection.
 
+@@@ note
+
+This management API is only usable with a running projection within the same system.
+
+@@@
+
 To retrieve latest stored offset:
 
 Scala


### PR DESCRIPTION
The management API can only be used against running projections. It will fail if tried outside.