### PR TITLE
feat (dynamodb): Configurable parallelism in initial offset store query

### DIFF
--- a/akka-projection-dynamodb/src/main/resources/reference.conf
+++ b/akka-projection-dynamodb/src/main/resources/reference.conf
@@ -22,6 +22,12 @@ akka.projection.dynamodb {
 
     # Trying to batch insert offsets in batches of this size.
     offset-batch-size = 20
+
+	# Number of slices to read offsets simultaneously for.  The underlying Dynamo
+	# client must be able to handle (`http.max-concurrency` plus `http.max-pending-connection-acquires`)
+	# at least this number of concurrent requests.  Defaults to 1024 (all slices simultaneously),
+	# but may be reduced.
+	offset-slice-read-parallelism = 1024
   }
 
   # By default it shares DynamoDB client with akka-persistence-dynamodb (write side).

--- a/akka-projection-dynamodb/src/main/resources/reference.conf
+++ b/akka-projection-dynamodb/src/main/resources/reference.conf
@@ -23,11 +23,18 @@ akka.projection.dynamodb {
     # Trying to batch insert offsets in batches of this size.
     offset-batch-size = 20
 
-	# Number of slices to read offsets simultaneously for.  The underlying Dynamo
-	# client must be able to handle (`http.max-concurrency` plus `http.max-pending-connection-acquires`)
-	# at least this number of concurrent requests.  Defaults to 1024 (all slices simultaneously),
-	# but may be reduced.
-	offset-slice-read-parallelism = 1024
+    # Number of slices (within a given projection's slice range) which will be queried for
+    # offsets simultaneously.  The underlying Dynamo client must be able to handle
+    # (`http.max-concurrency` plus `http.max-pending-connection-acquires`) at least this number
+    # of concurrent requests.
+    #
+    # Set to 1024 to always query for all slices simultaneously.  The minimum allowed value
+    # is 1.  If there are more than 64 slices in a range (e.g. fewer than 16 projections
+    # consuming events), then increasing this may result in slightly faster projection starts;
+    # conversely, if there are many slices being projected using a given Dynamo client,
+    # reducing this may result in fewer restarts of the projection due to failure to query
+    # starting offsets.
+	offset-slice-read-parallelism = 64
   }
 
   # By default it shares DynamoDB client with akka-persistence-dynamodb (write side).

--- a/akka-projection-dynamodb/src/main/resources/reference.conf
+++ b/akka-projection-dynamodb/src/main/resources/reference.conf
@@ -34,7 +34,7 @@ akka.projection.dynamodb {
     # conversely, if there are many slices being projected using a given Dynamo client,
     # reducing this may result in fewer restarts of the projection due to failure to query
     # starting offsets.
-	offset-slice-read-parallelism = 64
+    offset-slice-read-parallelism = 64
   }
 
   # By default it shares DynamoDB client with akka-persistence-dynamodb (write side).

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/DynamoDBProjectionSettings.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/DynamoDBProjectionSettings.scala
@@ -44,6 +44,7 @@ object DynamoDBProjectionSettings {
       evictInterval = config.getDuration("offset-store.evict-interval"),
       warnAboutFilteredEventsInFlow = config.getBoolean("warn-about-filtered-events-in-flow"),
       offsetBatchSize = config.getInt("offset-store.offset-batch-size"),
+      offsetSliceReadParallelism = config.getInt("offset-store.offset-slice-read-parallelism"),
       timeToLiveSettings = TimeToLiveSettings(config.getConfig("time-to-live")))
   }
 
@@ -63,6 +64,7 @@ final class DynamoDBProjectionSettings private (
     val evictInterval: JDuration,
     val warnAboutFilteredEventsInFlow: Boolean,
     val offsetBatchSize: Int,
+    val offsetSliceReadParallelism: Int,
     val timeToLiveSettings: TimeToLiveSettings) {
 
   def withTimestampOffsetTable(timestampOffsetTable: String): DynamoDBProjectionSettings =
@@ -92,6 +94,9 @@ final class DynamoDBProjectionSettings private (
   def withOffsetBatchSize(offsetBatchSize: Int): DynamoDBProjectionSettings =
     copy(offsetBatchSize = offsetBatchSize)
 
+  def withOffsetSliceReadParallelism(offsetSliceReadParallelism: Int): DynamoDBProjectionSettings =
+    copy(offsetSliceReadParallelism = offsetSliceReadParallelism)
+
   def withTimeToLiveSettings(timeToLiveSettings: TimeToLiveSettings): DynamoDBProjectionSettings =
     copy(timeToLiveSettings = timeToLiveSettings)
 
@@ -103,6 +108,7 @@ final class DynamoDBProjectionSettings private (
       evictInterval: JDuration = evictInterval,
       warnAboutFilteredEventsInFlow: Boolean = warnAboutFilteredEventsInFlow,
       offsetBatchSize: Int = offsetBatchSize,
+      offsetSliceReadParallelism: Int = offsetSliceReadParallelism,
       timeToLiveSettings: TimeToLiveSettings = timeToLiveSettings) =
     new DynamoDBProjectionSettings(
       timestampOffsetTable,
@@ -112,6 +118,7 @@ final class DynamoDBProjectionSettings private (
       evictInterval,
       warnAboutFilteredEventsInFlow,
       offsetBatchSize,
+      offsetSliceReadParallelism,
       timeToLiveSettings)
 
   override def toString =

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -28,6 +28,9 @@ import akka.projection.BySlicesSourceProvider
 import akka.projection.ProjectionId
 import akka.projection.dynamodb.DynamoDBProjectionSettings
 import akka.projection.internal.ManagementState
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import akka.stream.Materializer.matFromSystem
 import org.slf4j.LoggerFactory
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem
@@ -248,9 +251,20 @@ private[projection] class DynamoDBOffsetStore(
   private def readTimestampOffset(): Future[TimestampOffsetBySlice] = {
     val oldState = state.get()
     // retrieve latest timestamp for each slice, and use the earliest
-    val futTimestamps =
-      (minSlice to maxSlice).map(slice => dao.loadTimestampOffset(slice).map(optTimestamp => slice -> optTimestamp))
-    val offsetBySliceFut = Future.sequence(futTimestamps).map(_.collect { case (slice, Some(ts)) => slice -> ts }.toMap)
+    val offsetBySliceFut =
+      Source(minSlice to maxSlice)
+        .mapAsyncUnordered(settings.offsetSliceReadParallelism) { slice =>
+          dao
+            .loadTimestampOffset(slice)
+            .map { optTimestampOffset =>
+              optTimestampOffset.map { timestampOffset => slice -> timestampOffset }
+            }(ExecutionContext.parasitic)
+        }
+        .mapConcat(identity)
+        .runWith(Sink.fold(Map.empty[Int, TimestampOffset]) { (offsetMap, sliceAndOffset: (Int, TimestampOffset)) =>
+          offsetMap + sliceAndOffset
+        })(matFromSystem(system))
+
     offsetBySliceFut.map { offsetBySlice =>
       val newState = State(offsetBySlice)
       logger.debug(

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -249,6 +249,7 @@ private[projection] class DynamoDBOffsetStore(
   }
 
   private def readTimestampOffset(): Future[TimestampOffsetBySlice] = {
+    implicit val sys = system   // for implicit stream materializer
     val oldState = state.get()
     // retrieve latest timestamp for each slice, and use the earliest
     val offsetBySliceFut =
@@ -263,7 +264,7 @@ private[projection] class DynamoDBOffsetStore(
         .mapConcat(identity)
         .runWith(Sink.fold(Map.empty[Int, TimestampOffset]) { (offsetMap, sliceAndOffset: (Int, TimestampOffset)) =>
           offsetMap + sliceAndOffset
-        })(matFromSystem(system))
+        })
 
     offsetBySliceFut.map { offsetBySlice =>
       val newState = State(offsetBySlice)

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -249,7 +249,7 @@ private[projection] class DynamoDBOffsetStore(
   }
 
   private def readTimestampOffset(): Future[TimestampOffsetBySlice] = {
-    implicit val sys = system   // for implicit stream materializer
+    implicit val sys = system // for implicit stream materializer
     val oldState = state.get()
     // retrieve latest timestamp for each slice, and use the earliest
     val offsetBySliceFut =


### PR DESCRIPTION
References https://github.com/akka/akka-projection/pull/1222#discussion_r1813297496

The offset retrieval query performs a query for each slice in its range (up to 1024 in the case of a single-instance projection, which might be used if the projection is for an entity with an expected-to-be-low rate of events); these queries are performed simultaneously and all in a given invocation must succeed.  The default number of HTTP connections to dynamo is likely to be less than the number of queries, so these queries will be queued (by dynamo) with other persistence operations (in the case where projections are started early in the application's lifecycle, there may likewise be a surge of persistence operations as shards are rebalanced to the application instance), which may have undesirable effects on write-side latency, or in extreme cases (if `max-pending-connection-acquires` is limited) prevent the projection from running.

Using separate Dynamo clients for write-side and projections isolates them, though at the cost of extra HTTP connections in the respective pools as well as threads to manage said connections; this is especially exacerbated in the case of entities with low rates of event traffic.

This change allows the parallelism of the offset query to be bounded.
