### PR TITLE
fix: DynamoDB evict offsets per slice

### DIFF
--- a/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBOffsetStoreStateSpec.scala
+++ b/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBOffsetStoreStateSpec.scala
@@ -4,6 +4,7 @@
 
 package akka.projection.dynamodb
 
+import java.time.{ Duration => JDuration }
 import java.time.Instant
 
 import akka.persistence.query.TimestampOffset
@@ -35,7 +36,6 @@ class DynamoDBOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Match
       state1.byPid("p1").seqNr shouldBe 3L
       state1.offsetBySlice(slice("p1")) shouldBe TimestampOffset(t0.plusMillis(2), Map("p1" -> 3L))
       state1.latestTimestamp shouldBe t0.plusMillis(2)
-      state1.oldestTimestamp shouldBe t0
 
       val state2 = state1.add(Vector(createRecord("p2", 2, t0.plusMillis(1))))
       state2.byPid("p1").seqNr shouldBe 3L
@@ -44,7 +44,6 @@ class DynamoDBOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Match
       state2.offsetBySlice(slice("p2")) shouldBe TimestampOffset(t0.plusMillis(1), Map("p2" -> 2L))
       // latest not updated because timestamp of p2 was before latest
       state2.latestTimestamp shouldBe t0.plusMillis(2)
-      state2.oldestTimestamp shouldBe t0
 
       val state3 = state2.add(Vector(createRecord("p3", 10, t0.plusMillis(3))))
       state3.byPid("p1").seqNr shouldBe 3L
@@ -54,7 +53,6 @@ class DynamoDBOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Match
       slice("p3") should not be slice("p2")
       state3.offsetBySlice(slice("p3")) shouldBe TimestampOffset(t0.plusMillis(3), Map("p3" -> 10L))
       state3.latestTimestamp shouldBe t0.plusMillis(3)
-      state3.oldestTimestamp shouldBe t0
 
       // same slice and same timestamp, keep both in seen
       slice("p10084") shouldBe slice("p3")
@@ -63,37 +61,45 @@ class DynamoDBOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Match
     }
 
     "evict old" in {
-      // these pids have the same slice 645, otherwise it will keep one for each slice
-      val p1 = "p500"
-      val p2 = "p621"
-      val p3 = "p742"
-      val p4 = "p863"
-      val p5 = "p984"
+      val p1 = "p500" // slice 645
+      val p2 = "p621" // slice 645
+      val p3 = "p742" // slice 645
+      val p4 = "p863" // slice 645
+      val p5 = "p984" // slice 645
+      val p6 = "p92" // slice 905
+      val p7 = "p108" // slice 905
 
       val t0 = TestClock.nowMillis().instant()
       val state1 = State.empty
         .add(
           Vector(
-            createRecord(p1, 1, t0),
-            createRecord(p2, 2, t0.plusMillis(1)),
-            createRecord(p3, 3, t0.plusMillis(2)),
-            createRecord(p4, 4, t0.plusMillis(3)),
-            createRecord(p5, 5, t0.plusMillis(4))))
-      state1.oldestTimestamp shouldBe t0
+            createRecord(p1, 1, t0.plusMillis(1)),
+            createRecord(p2, 2, t0.plusMillis(2)),
+            createRecord(p3, 3, t0.plusMillis(3)),
+            createRecord(p4, 4, t0.plusMillis(4)),
+            createRecord(p6, 6, t0.plusMillis(6))))
       state1.byPid
-        .map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p1 -> 1L, p2 -> 2L, p3 -> 3L, p4 -> 4L, p5 -> 5L)
-
-      val state2 = state1.evict(t0.plusMillis(2), keepNumberOfEntries = 1)
-      state2.oldestTimestamp shouldBe t0.plusMillis(2)
-      state2.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p3 -> 3L, p4 -> 4L, p5 -> 5L)
+        .map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p1 -> 1L, p2 -> 2L, p3 -> 3L, p4 -> 4L, p6 -> 6L)
 
       // keep all
-      state1.evict(t0.plusMillis(2), keepNumberOfEntries = 100) shouldBe state1
+      state1.evict(slice = 645, timeWindow = JDuration.ofMillis(1000)) shouldBe state1
 
-      // keep 4
-      val state3 = state1.evict(t0.plusMillis(2), keepNumberOfEntries = 4)
-      state3.oldestTimestamp shouldBe t0.plusMillis(1)
-      state3.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p2 -> 2L, p3 -> 3L, p4 -> 4L, p5 -> 5L)
+      // evict older than time window
+      val state2 = state1.evict(slice = 645, timeWindow = JDuration.ofMillis(2))
+      state2.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p2 -> 2L, p3 -> 3L, p4 -> 4L, p6 -> 6L)
+
+      val state3 = state1.add(Vector(createRecord(p5, 5, t0.plusMillis(100)), createRecord(p7, 7, t0.plusMillis(10))))
+      val state4 = state3.evict(slice = 645, timeWindow = JDuration.ofMillis(2))
+      state4.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p5 -> 5L, p6 -> 6L, p7 -> 7L)
+
+      val state5 = state3.evict(slice = 905, timeWindow = JDuration.ofMillis(2))
+      state5.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map(
+        p1 -> 1L,
+        p2 -> 2L,
+        p3 -> 3L,
+        p4 -> 4L,
+        p5 -> 5L,
+        p7 -> 7L)
     }
 
     "find duplicate" in {

--- a/akka-projection-dynamodb/src/main/resources/reference.conf
+++ b/akka-projection-dynamodb/src/main/resources/reference.conf
@@ -12,14 +12,6 @@ akka.projection.dynamodb {
     # within this time window from latest offset.
     time-window = 5 minutes
 
-    # Keep this number of entries. Don't evict old entries until this threshold
-    # has been reached.
-    keep-number-of-entries = 10000
-
-    # Remove old entries outside the time-window from the offset store memory
-    # with this frequency.
-    evict-interval = 10 seconds
-
     # Trying to batch insert offsets in batches of this size.
     offset-batch-size = 20
 

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/DynamoDBProjectionSettings.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/DynamoDBProjectionSettings.scala
@@ -6,6 +6,7 @@ package akka.projection.dynamodb
 
 import java.time.{ Duration => JDuration }
 
+import scala.annotation.nowarn
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.jdk.DurationConverters._
@@ -40,8 +41,8 @@ object DynamoDBProjectionSettings {
       timestampOffsetTable = config.getString("offset-store.timestamp-offset-table"),
       useClient = config.getString("use-client"),
       timeWindow = config.getDuration("offset-store.time-window"),
-      keepNumberOfEntries = config.getInt("offset-store.keep-number-of-entries"),
-      evictInterval = config.getDuration("offset-store.evict-interval"),
+      keepNumberOfEntries = 0,
+      evictInterval = JDuration.ZERO,
       warnAboutFilteredEventsInFlow = config.getBoolean("warn-about-filtered-events-in-flow"),
       offsetBatchSize = config.getInt("offset-store.offset-batch-size"),
       offsetSliceReadParallelism = config.getInt("offset-store.offset-slice-read-parallelism"),
@@ -60,7 +61,9 @@ final class DynamoDBProjectionSettings private (
     val timestampOffsetTable: String,
     val useClient: String,
     val timeWindow: JDuration,
+    @deprecated("Not used, evict is only based on time window", "1.6.2")
     val keepNumberOfEntries: Int,
+    @deprecated("Not used, evict is not periodic", "1.6.2")
     val evictInterval: JDuration,
     val warnAboutFilteredEventsInFlow: Boolean,
     val offsetBatchSize: Int,
@@ -79,14 +82,17 @@ final class DynamoDBProjectionSettings private (
   def withTimeWindow(timeWindow: JDuration): DynamoDBProjectionSettings =
     copy(timeWindow = timeWindow)
 
+  @deprecated("Not used, evict is only based on time window", "1.6.2")
   def withKeepNumberOfEntries(keepNumberOfEntries: Int): DynamoDBProjectionSettings =
-    copy(keepNumberOfEntries = keepNumberOfEntries)
+    this
 
+  @deprecated("Not used, evict is not periodic", "1.6.2")
   def withEvictInterval(evictInterval: FiniteDuration): DynamoDBProjectionSettings =
-    copy(evictInterval = evictInterval.toJava)
+    this
 
+  @deprecated("Not used, evict is not periodic", "1.6.2")
   def withEvictInterval(evictInterval: JDuration): DynamoDBProjectionSettings =
-    copy(evictInterval = evictInterval)
+    this
 
   def withWarnAboutFilteredEventsInFlow(warnAboutFilteredEventsInFlow: Boolean): DynamoDBProjectionSettings =
     copy(warnAboutFilteredEventsInFlow = warnAboutFilteredEventsInFlow)
@@ -100,12 +106,11 @@ final class DynamoDBProjectionSettings private (
   def withTimeToLiveSettings(timeToLiveSettings: TimeToLiveSettings): DynamoDBProjectionSettings =
     copy(timeToLiveSettings = timeToLiveSettings)
 
+  @nowarn("msg=deprecated")
   private def copy(
       timestampOffsetTable: String = timestampOffsetTable,
       useClient: String = useClient,
       timeWindow: JDuration = timeWindow,
-      keepNumberOfEntries: Int = keepNumberOfEntries,
-      evictInterval: JDuration = evictInterval,
       warnAboutFilteredEventsInFlow: Boolean = warnAboutFilteredEventsInFlow,
       offsetBatchSize: Int = offsetBatchSize,
       offsetSliceReadParallelism: Int = offsetSliceReadParallelism,
@@ -122,7 +127,7 @@ final class DynamoDBProjectionSettings private (
       timeToLiveSettings)
 
   override def toString =
-    s"DynamoDBProjectionSettings($timestampOffsetTable, $useClient, $timeWindow, $keepNumberOfEntries, $evictInterval, $warnAboutFilteredEventsInFlow, $offsetBatchSize)"
+    s"DynamoDBProjectionSettings($timestampOffsetTable, $useClient, $timeWindow, $warnAboutFilteredEventsInFlow, $offsetBatchSize)"
 }
 
 object TimeToLiveSettings {


### PR DESCRIPTION
* don't use evicted state when saving changed timestamp per slice
* evict time window for each slice
* remove keep-number-of-entries and evict-interval
