### PR TITLE
fix: R2dbcOffsetStore evict and delete per slice

### DIFF
--- a/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreStateSpec.scala
+++ b/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreStateSpec.scala
@@ -94,6 +94,8 @@ class R2dbcOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Matchers
       state.latestOffset.get.seen shouldBe Map("p1" -> 3L, "p2" -> 2L, "p3" -> 5L, "p4" -> 9L)
     }
 
+    val allowAll: Any => Boolean = _ => true
+
     "evict old" in {
       val p1 = "p500" // slice 645
       val p2 = "p621" // slice 645
@@ -116,17 +118,17 @@ class R2dbcOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Matchers
         .map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p1 -> 1L, p2 -> 2L, p3 -> 3L, p4 -> 4L, p6 -> 6L)
 
       // keep all
-      state1.evict(slice = 645, timeWindow = JDuration.ofMillis(1000)) shouldBe state1
+      state1.evict(slice = 645, timeWindow = JDuration.ofMillis(1000), allowAll) shouldBe state1
 
       // evict older than time window
-      val state2 = state1.evict(slice = 645, timeWindow = JDuration.ofMillis(2))
+      val state2 = state1.evict(slice = 645, timeWindow = JDuration.ofMillis(2), allowAll)
       state2.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p2 -> 2L, p3 -> 3L, p4 -> 4L, p6 -> 6L)
 
       val state3 = state1.add(Vector(createRecord(p5, 5, t0.plusMillis(100)), createRecord(p7, 7, t0.plusMillis(10))))
-      val state4 = state3.evict(slice = 645, timeWindow = JDuration.ofMillis(2))
+      val state4 = state3.evict(slice = 645, timeWindow = JDuration.ofMillis(2), allowAll)
       state4.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p5 -> 5L, p6 -> 6L, p7 -> 7L)
 
-      val state5 = state3.evict(slice = 905, timeWindow = JDuration.ofMillis(2))
+      val state5 = state3.evict(slice = 905, timeWindow = JDuration.ofMillis(2), allowAll)
       state5.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map(
         p1 -> 1L,
         p2 -> 2L,
@@ -166,7 +168,7 @@ class R2dbcOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Matchers
       val timeWindow = JDuration.ofMillis(1)
 
       val state2 = slices.foldLeft(state1) {
-        case (acc, slice) => acc.evict(slice, timeWindow)
+        case (acc, slice) => acc.evict(slice, timeWindow, allowAll)
       }
       // note that p92 is evicted because it has same slice as p108
       // p1 is kept because keeping one for each slice
@@ -175,11 +177,33 @@ class R2dbcOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Matchers
       state2.latestOffset.get.seen shouldBe Map("p5" -> 5L)
 
       val state3 = slices.foldLeft(state2) {
-        case (acc, slice) => acc.evict(slice, timeWindow)
+        case (acc, slice) => acc.evict(slice, timeWindow, allowAll)
       }
       // still keeping one for each slice
       state3.byPid
         .map { case (pid, r) => pid -> r.seqNr } shouldBe Map("p1" -> 1L, "p108" -> 3L, "p4" -> 4L, "p5" -> 5L)
+    }
+
+    "evict old but only those allowed to be evicted" in {
+      val t0 = TestClock.nowMillis().instant()
+      val state1 = State.empty.add(
+        Vector(
+          createRecord("p92", 2, t0.plusMillis(1)),
+          createRecord("p108", 3, t0.plusMillis(20)),
+          createRecord("p229", 4, t0.plusMillis(30))))
+
+      val slices = state1.bySliceSorted.keySet
+      slices.size shouldBe 1
+
+      state1
+        .evict(slices.head, JDuration.ofMillis(1), allowAll)
+        .byPid
+        .map { case (pid, r) => pid -> r.seqNr } shouldBe Map("p229" -> 4) // p92 and p108 evicted
+
+      state1
+        .evict(slices.head, JDuration.ofMillis(1), _.pid == "p108")
+        .byPid // allow only p108 to be evicted
+        .map { case (pid, r) => pid -> r.seqNr } shouldBe Map("p92" -> 2, "p229" -> 4)
     }
 
     "find duplicate" in {

--- a/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreStateSpec.scala
+++ b/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreStateSpec.scala
@@ -4,6 +4,7 @@
 
 package akka.projection.r2dbc
 
+import java.time.{ Duration => JDuration }
 import java.time.Instant
 
 import akka.projection.r2dbc.internal.R2dbcOffsetStore.Pid
@@ -16,9 +17,10 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class R2dbcOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Matchers {
 
+  def slice(pid: Pid): Int = math.abs(pid.hashCode % 1024)
+
   def createRecord(pid: Pid, seqNr: SeqNr, timestamp: Instant): Record = {
-    val slice = math.abs(pid.hashCode % 1024)
-    Record(slice, pid, seqNr, timestamp)
+    Record(slice(pid), pid, seqNr, timestamp)
   }
 
   "R2dbcOffsetStore.State" should {
@@ -31,6 +33,10 @@ class R2dbcOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Matchers
             createRecord("p1", 2, t0.plusMillis(1)),
             createRecord("p1", 3, t0.plusMillis(2))))
       state1.byPid("p1").seqNr shouldBe 3L
+      state1.bySliceSorted.size shouldBe 1
+      state1.bySliceSorted(slice("p1")).size shouldBe 3
+      state1.bySliceSorted(slice("p1")).head.seqNr shouldBe 1
+      state1.bySliceSorted(slice("p1")).last.seqNr shouldBe 3
       state1.latestTimestamp shouldBe t0.plusMillis(2)
       state1.latestOffset.get.seen shouldBe Map("p1" -> 3L)
       state1.oldestTimestamp shouldBe t0
@@ -47,6 +53,8 @@ class R2dbcOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Matchers
       state3.byPid("p1").seqNr shouldBe 3L
       state3.byPid("p2").seqNr shouldBe 2L
       state3.byPid("p3").seqNr shouldBe 10L
+      state3.bySliceSorted(slice("p3")).last.pid shouldBe "p3"
+      state3.bySliceSorted(slice("p3")).last.seqNr shouldBe 10
       state3.latestTimestamp shouldBe t0.plusMillis(3)
       state3.latestOffset.get.seen shouldBe Map("p3" -> 10L)
       state3.oldestTimestamp shouldBe t0
@@ -69,40 +77,45 @@ class R2dbcOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Matchers
     }
 
     "evict old" in {
-      // these pids have the same slice 645, otherwise it will keep one for each slice
-      val p1 = "p500"
-      val p2 = "p621"
-      val p3 = "p742"
-      val p4 = "p863"
-      val p5 = "p984"
+      val p1 = "p500" // slice 645
+      val p2 = "p621" // slice 645
+      val p3 = "p742" // slice 645
+      val p4 = "p863" // slice 645
+      val p5 = "p984" // slice 645
+      val p6 = "p92" // slice 905
+      val p7 = "p108" // slice 905
 
       val t0 = TestClock.nowMillis().instant()
       val state1 = State.empty
         .add(
           Vector(
-            createRecord(p1, 1, t0),
-            createRecord(p2, 2, t0.plusMillis(1)),
-            createRecord(p3, 3, t0.plusMillis(2)),
-            createRecord(p4, 4, t0.plusMillis(3)),
-            createRecord(p5, 5, t0.plusMillis(4))))
-      state1.latestOffset.get.seen shouldBe Map(p5 -> 5L)
-      state1.oldestTimestamp shouldBe t0
+            createRecord(p1, 1, t0.plusMillis(1)),
+            createRecord(p2, 2, t0.plusMillis(2)),
+            createRecord(p3, 3, t0.plusMillis(3)),
+            createRecord(p4, 4, t0.plusMillis(4)),
+            createRecord(p6, 6, t0.plusMillis(6))))
       state1.byPid
-        .map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p1 -> 1L, p2 -> 2L, p3 -> 3L, p4 -> 4L, p5 -> 5L)
-
-      val state2 = state1.evict(t0.plusMillis(2), keepNumberOfEntries = 1)
-      state2.latestOffset.get.seen shouldBe Map(p5 -> 5L)
-      state2.oldestTimestamp shouldBe t0.plusMillis(2)
-      state2.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p3 -> 3L, p4 -> 4L, p5 -> 5L)
+        .map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p1 -> 1L, p2 -> 2L, p3 -> 3L, p4 -> 4L, p6 -> 6L)
 
       // keep all
-      state1.evict(t0.plusMillis(2), keepNumberOfEntries = 100) shouldBe state1
+      state1.evict(slice = 645, timeWindow = JDuration.ofMillis(1000)) shouldBe state1
 
-      // keep 4
-      val state3 = state1.evict(t0.plusMillis(2), keepNumberOfEntries = 4)
-      state3.latestOffset.get.seen shouldBe Map(p5 -> 5L)
-      state3.oldestTimestamp shouldBe t0.plusMillis(1)
-      state3.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p2 -> 2L, p3 -> 3L, p4 -> 4L, p5 -> 5L)
+      // evict older than time window
+      val state2 = state1.evict(slice = 645, timeWindow = JDuration.ofMillis(2))
+      state2.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p2 -> 2L, p3 -> 3L, p4 -> 4L, p6 -> 6L)
+
+      val state3 = state1.add(Vector(createRecord(p5, 5, t0.plusMillis(100)), createRecord(p7, 7, t0.plusMillis(10))))
+      val state4 = state3.evict(slice = 645, timeWindow = JDuration.ofMillis(2))
+      state4.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p5 -> 5L, p6 -> 6L, p7 -> 7L)
+
+      val state5 = state3.evict(slice = 905, timeWindow = JDuration.ofMillis(2))
+      state5.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map(
+        p1 -> 1L,
+        p2 -> 2L,
+        p3 -> 3L,
+        p4 -> 4L,
+        p5 -> 5L,
+        p7 -> 7L)
     }
 
     "evict old but keep latest for each slice" in {
@@ -112,15 +125,17 @@ class R2dbcOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Matchers
           Vector(
             createRecord("p1", 1, t0),
             createRecord("p92", 2, t0.plusMillis(1)),
-            createRecord("p108", 3, t0.plusMillis(2)),
-            createRecord("p4", 4, t0.plusMillis(3)),
-            createRecord("p5", 5, t0.plusMillis(4))))
+            createRecord("p108", 3, t0.plusMillis(20)),
+            createRecord("p4", 4, t0.plusMillis(30)),
+            createRecord("p5", 5, t0.plusMillis(40))))
 
       state1.byPid("p1").slice shouldBe 449
       state1.byPid("p92").slice shouldBe 905
       state1.byPid("p108").slice shouldBe 905 // same slice as p92
       state1.byPid("p4").slice shouldBe 452
       state1.byPid("p5").slice shouldBe 453
+
+      val slices = state1.bySliceSorted.keySet
 
       state1.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map(
         "p1" -> 1L,
@@ -131,7 +146,11 @@ class R2dbcOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Matchers
       state1.latestOffset.get.seen shouldBe Map("p5" -> 5L)
       state1.oldestTimestamp shouldBe t0
 
-      val state2 = state1.evict(t0.plusMillis(2), keepNumberOfEntries = 1)
+      val timeWindow = JDuration.ofMillis(1)
+
+      val state2 = slices.foldLeft(state1) {
+        case (acc, slice) => acc.evict(slice, timeWindow)
+      }
       // note that p92 is evicted because it has same slice as p108
       // p1 is kept because keeping one for each slice
       state2.byPid
@@ -139,7 +158,9 @@ class R2dbcOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Matchers
       state2.latestOffset.get.seen shouldBe Map("p5" -> 5L)
       state2.oldestTimestamp shouldBe t0
 
-      val state3 = state1.evict(t0.plusMillis(10), keepNumberOfEntries = 1)
+      val state3 = slices.foldLeft(state2) {
+        case (acc, slice) => acc.evict(slice, timeWindow)
+      }
       // still keeping one for each slice
       state3.byPid
         .map { case (pid, r) => pid -> r.seqNr } shouldBe Map("p1" -> 1L, "p108" -> 3L, "p4" -> 4L, "p5" -> 5L)

--- a/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
+++ b/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
@@ -29,7 +29,6 @@ import akka.projection.r2dbc.internal.OffsetPidSeqNr
 import akka.projection.r2dbc.internal.R2dbcOffsetStore
 import akka.projection.r2dbc.internal.R2dbcOffsetStore.Pid
 import akka.projection.r2dbc.internal.R2dbcOffsetStore.SeqNr
-import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.slf4j.LoggerFactory
 
@@ -48,13 +47,7 @@ object R2dbcTimestampOffsetStoreSpec {
 }
 
 class R2dbcTimestampOffsetStoreSpec
-    extends ScalaTestWithActorTestKit(
-      ConfigFactory
-        .parseString("""
-    # to be able to test eviction
-    akka.projection.r2dbc.offset-store.keep-number-of-entries = 0
-    """)
-        .withFallback(TestConfig.config))
+    extends ScalaTestWithActorTestKit(TestConfig.config)
     with AnyWordSpecLike
     with TestDbLifecycle
     with TestData
@@ -133,6 +126,9 @@ class R2dbcTimestampOffsetStoreSpec
       state,
       TimestampOffset(timestamp, timestamp.plusMillis(1000), Map(pid -> revision)),
       timestamp.toEpochMilli)
+
+  def slice(pid: String): Int =
+    persistenceExt.sliceForPersistenceId(pid)
 
   s"The R2dbcOffsetStore for TimestampOffset (dialect ${r2dbcSettings.dialectName})" must {
 
@@ -738,16 +734,16 @@ class R2dbcTimestampOffsetStoreSpec
       offsetStore.getInflight() shouldBe Map("p1" -> 4L, "p3" -> 20L)
     }
 
-    "evict old records" in {
+    "evict old records from same slice" in {
       val projectionId = genRandomProjectionId()
-      val evictSettings = settings.withTimeWindow(JDuration.ofSeconds(100)).withEvictInterval(JDuration.ofSeconds(10))
+      val evictSettings = settings.withTimeWindow(JDuration.ofSeconds(100))
       import evictSettings._
       val offsetStore = createOffsetStore(projectionId, evictSettings)
 
       val startTime = TestClock.nowMicros().instant()
       log.debug("Start time [{}]", startTime)
 
-      // these pids have the same slice 645, otherwise it will keep one for each slice
+      // these pids have the same slice 645
       val p1 = "p500"
       val p2 = "p621"
       val p3 = "p742"
@@ -759,34 +755,22 @@ class R2dbcTimestampOffsetStoreSpec
 
       offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(startTime, Map(p1 -> 1L)), p1, 1L)).futureValue
       offsetStore
-        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(JDuration.ofSeconds(1)), Map(p2 -> 1L)), p2, 1L))
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusSeconds(1), Map(p2 -> 1L)), p2, 1L))
         .futureValue
       offsetStore
-        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(JDuration.ofSeconds(2)), Map(p3 -> 1L)), p3, 1L))
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusSeconds(2), Map(p3 -> 1L)), p3, 1L))
         .futureValue
       offsetStore
-        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(evictInterval), Map(p4 -> 1L)), p4, 1L))
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusSeconds(3), Map(p4 -> 1L)), p4, 1L))
         .futureValue
       offsetStore
-        .saveOffset(
-          OffsetPidSeqNr(
-            TimestampOffset(startTime.plus(evictInterval).plus(JDuration.ofSeconds(1)), Map(p4 -> 1L)),
-            p4,
-            1L))
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusSeconds(4), Map(p4 -> 1L)), p4, 1L))
         .futureValue
       offsetStore
-        .saveOffset(
-          OffsetPidSeqNr(
-            TimestampOffset(startTime.plus(evictInterval).plus(JDuration.ofSeconds(2)), Map(p5 -> 1L)),
-            p5,
-            1L))
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusSeconds(5), Map(p5 -> 1L)), p5, 1L))
         .futureValue
       offsetStore
-        .saveOffset(
-          OffsetPidSeqNr(
-            TimestampOffset(startTime.plus(evictInterval).plus(JDuration.ofSeconds(3)), Map(p6 -> 1L)),
-            p6,
-            3L))
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusSeconds(4), Map(p6 -> 1L)), p6, 3L))
         .futureValue
       offsetStore.getState().size shouldBe 6
 
@@ -796,81 +780,59 @@ class R2dbcTimestampOffsetStoreSpec
       offsetStore.getState().size shouldBe 7 // nothing evicted yet
 
       offsetStore
-        .saveOffset(
-          OffsetPidSeqNr(
-            TimestampOffset(startTime.plus(timeWindow.plus(evictInterval).minusSeconds(3)), Map(p8 -> 1L)),
-            p8,
-            1L))
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(timeWindow.minusSeconds(1)), Map(p8 -> 1L)), p8, 1L))
         .futureValue
       offsetStore.getState().size shouldBe 8 // still nothing evicted yet
 
       offsetStore
-        .saveOffset(
-          OffsetPidSeqNr(
-            TimestampOffset(startTime.plus(timeWindow.plus(evictInterval).plusSeconds(1)), Map(p8 -> 2L)),
-            p8,
-            2L))
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(timeWindow.plusSeconds(4)), Map(p8 -> 2L)), p8, 2L))
         .futureValue
       offsetStore.getState().byPid.keySet shouldBe Set(p5, p6, p7, p8)
 
       offsetStore
-        .saveOffset(
-          OffsetPidSeqNr(
-            TimestampOffset(startTime.plus(timeWindow.plus(evictInterval).plusSeconds(20)), Map(p8 -> 3L)),
-            p8,
-            3L))
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(timeWindow.plusSeconds(20)), Map(p8 -> 3L)), p8, 3L))
         .futureValue
       offsetStore.getState().byPid.keySet shouldBe Set(p7, p8)
     }
 
-    "evict old records but keep latest for each slice" in {
+    "evict old records from different slices" in {
       val projectionId = genRandomProjectionId()
-      val evictSettings = settings.withTimeWindow(JDuration.ofSeconds(100)).withEvictInterval(JDuration.ofSeconds(10))
+      val evictSettings = settings.withTimeWindow(JDuration.ofSeconds(100))
       import evictSettings._
       val offsetStore = createOffsetStore(projectionId, evictSettings)
 
       val startTime = TestClock.nowMicros().instant()
       log.debug("Start time [{}]", startTime)
 
-      val p1 = "p500" // slice 645
-      val p2 = "p92" // slice 905
-      val p3 = "p108" // slice 905
-      val p4 = "p863" // slice 645
-      val p5 = "p984" // slice 645
-      val p6 = "p3080" // slice 645
-      val p7 = "p4290" // slice 645
-      val p8 = "p20180" // slice 645
+      // these pids have the same slice 645
+      val p1 = "p500"
+      val p2 = "p621"
+      val p3 = "p742"
+      val p4 = "p863"
+      val p5 = "p984"
+      val p6 = "p3080"
+      val p7 = "p4290"
+      val p8 = "p20180"
+      val p9 = "p-0960" // slice 576
 
       offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(startTime, Map(p1 -> 1L)), p1, 1L)).futureValue
       offsetStore
-        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(JDuration.ofSeconds(1)), Map(p2 -> 1L)), p2, 1L))
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusSeconds(1), Map(p2 -> 1L)), p2, 1L))
         .futureValue
       offsetStore
-        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(JDuration.ofSeconds(2)), Map(p3 -> 1L)), p3, 1L))
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusSeconds(2), Map(p3 -> 1L)), p3, 1L))
         .futureValue
       offsetStore
-        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(evictInterval), Map(p4 -> 1L)), p4, 1L))
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusSeconds(3), Map(p4 -> 1L)), p4, 1L))
         .futureValue
       offsetStore
-        .saveOffset(
-          OffsetPidSeqNr(
-            TimestampOffset(startTime.plus(evictInterval).plus(JDuration.ofSeconds(1)), Map(p4 -> 1L)),
-            p4,
-            1L))
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusSeconds(4), Map(p4 -> 1L)), p4, 1L))
         .futureValue
       offsetStore
-        .saveOffset(
-          OffsetPidSeqNr(
-            TimestampOffset(startTime.plus(evictInterval).plus(JDuration.ofSeconds(2)), Map(p5 -> 1L)),
-            p5,
-            1L))
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusSeconds(5), Map(p5 -> 1L)), p5, 1L))
         .futureValue
       offsetStore
-        .saveOffset(
-          OffsetPidSeqNr(
-            TimestampOffset(startTime.plus(evictInterval).plus(JDuration.ofSeconds(3)), Map(p6 -> 1L)),
-            p6,
-            1L))
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusSeconds(4), Map(p6 -> 1L)), p6, 3L))
         .futureValue
       offsetStore.getState().size shouldBe 6
 
@@ -880,32 +842,42 @@ class R2dbcTimestampOffsetStoreSpec
       offsetStore.getState().size shouldBe 7 // nothing evicted yet
 
       offsetStore
-        .saveOffset(
-          OffsetPidSeqNr(
-            TimestampOffset(startTime.plus(timeWindow.plus(evictInterval).minusSeconds(3)), Map(p8 -> 1L)),
-            p8,
-            1L))
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(timeWindow.minusSeconds(1)), Map(p8 -> 1L)), p8, 1L))
         .futureValue
       offsetStore.getState().size shouldBe 8 // still nothing evicted yet
 
       offsetStore
-        .saveOffset(
-          OffsetPidSeqNr(
-            TimestampOffset(startTime.plus(timeWindow.plus(evictInterval).plusSeconds(1)), Map(p8 -> 2L)),
-            p8,
-            2L))
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(timeWindow.plusSeconds(4)), Map(p8 -> 2L)), p8, 2L))
         .futureValue
-      // also keeping p3 ("p108") for slice 905
-      offsetStore.getState().byPid.keySet shouldBe Set(p3, p5, p6, p7, p8)
+      offsetStore.getState().byPid.keySet shouldBe Set(p5, p6, p7, p8)
 
       offsetStore
-        .saveOffset(
-          OffsetPidSeqNr(
-            TimestampOffset(startTime.plus(timeWindow.plus(evictInterval).plusSeconds(20)), Map(p8 -> 3L)),
-            p8,
-            3L))
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(timeWindow.plusSeconds(20)), Map(p8 -> 3L)), p8, 3L))
         .futureValue
-      offsetStore.getState().byPid.keySet shouldBe Set(p3, p7, p8)
+      offsetStore.getState().byPid.keySet shouldBe Set(p7, p8)
+
+      // save same slice, but behind
+      offsetStore
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusMillis(1001), Map(p2 -> 2L)), p2, 2L))
+        .futureValue
+      // it's evicted immediately
+      offsetStore.getState().byPid.keySet shouldBe Set(p7, p8)
+      val dao = offsetStore.dao
+      // but still saved
+      dao.readTimestampOffset(slice(p2), p2).futureValue.get.seqNr shouldBe 2
+
+      // save another slice that hasn't been used before
+      offsetStore
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusMillis(1002), Map(p9 -> 1L)), p9, 1L))
+        .futureValue
+      offsetStore.getState().byPid.keySet shouldBe Set(p9, p7, p8)
+      dao.readTimestampOffset(slice(p9), p9).futureValue.get.seqNr shouldBe 1
+      // and one more of that same slice
+      offsetStore
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusMillis(1003), Map(p9 -> 2L)), p9, 2L))
+        .futureValue
+      offsetStore.getState().byPid.keySet shouldBe Set(p9, p7, p8)
+      dao.readTimestampOffset(slice(p9), p9).futureValue.get.seqNr shouldBe 2
     }
 
     "delete old records" in {
@@ -1012,7 +984,11 @@ class R2dbcTimestampOffsetStoreSpec
       offsetStore
         .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(timeWindow.plusSeconds(3)), Map(p8 -> 1L)), p8, 1L))
         .futureValue
-      offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 2
+      offsetStore
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(timeWindow.plusSeconds(3)), Map(p3 -> 2L)), p3, 2L))
+        .futureValue
+      offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 3
+      offsetStore.getState().byPid.keySet shouldBe Set(p3, p4, p5, p6, p7, p8)
       offsetStore.readOffset().futureValue // this will load from database
       // p3 is kept for slice 905
       offsetStore.getState().byPid.keySet shouldBe Set(p3, p4, p5, p6, p7, p8)
@@ -1026,7 +1002,6 @@ class R2dbcTimestampOffsetStoreSpec
       val projectionId = genRandomProjectionId()
       val deleteSettings = settings
         .withTimeWindow(JDuration.ofSeconds(windowSeconds))
-        .withKeepNumberOfEntries(2000)
         .withDeleteInterval(JDuration.ofHours(1)) // don't run the scheduled deletes
       val offsetStore = createOffsetStore(projectionId, deleteSettings)
 
@@ -1092,15 +1067,13 @@ class R2dbcTimestampOffsetStoreSpec
       }
     }
 
-    "delete old records triggered by time window, while still within entries limit" in {
+    "delete old records from different slices" in {
       val projectionId = genRandomProjectionId()
       val evictSettings = settings
-        .withKeepNumberOfEntries(10)
         .withTimeWindow(JDuration.ofSeconds(100))
-        .withEvictInterval(JDuration.ofSeconds(10))
       val offsetStore = createOffsetStore(projectionId, evictSettings)
 
-      import evictSettings.{ evictInterval, timeWindow }
+      import evictSettings.timeWindow
 
       val t0 = TestClock.nowMicros().instant()
       log.debug("Start time [{}]", t0)
@@ -1123,13 +1096,13 @@ class R2dbcTimestampOffsetStoreSpec
       val t3 = t0.plusSeconds(3)
       offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(t3, Map(p3 -> 1L)), p3, 1L)).futureValue
 
-      val t4 = t0.plus(evictInterval).plusSeconds(1)
+      val t4 = t0.plusSeconds(11)
       offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(t4, Map(p4 -> 1L)), p4, 1L)).futureValue
 
-      val t5 = t0.plus(evictInterval).plusSeconds(2)
+      val t5 = t0.plusSeconds(12)
       offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(t5, Map(p5 -> 1L)), p5, 1L)).futureValue
 
-      val t6 = t0.plus(evictInterval).plusSeconds(3)
+      val t6 = t0.plusSeconds(13)
       offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(t6, Map(p6 -> 1L)), p6, 1L)).futureValue
 
       offsetStore.getState().size shouldBe 6
@@ -1140,32 +1113,30 @@ class R2dbcTimestampOffsetStoreSpec
       offsetStore.getState().size shouldBe 7 // no eviction
       offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 0 // no deletion (within time window)
 
-      val t8 = t0.plus(timeWindow.plus(evictInterval).minusSeconds(3))
+      val t8 = t0.plus(timeWindow.plusSeconds(7))
       offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(t8, Map(p8 -> 1L)), p8, 1L)).futureValue
 
-      offsetStore.getState().size shouldBe 8 // no eviction
-      offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 2 // deleted p1@t1 and p2@t2, kept p3@t3 (latest)
+      offsetStore.getState().byPid.keySet shouldBe Set(p2, p3, p4, p5, p6, p7, p8) // eviction slice 645
+      offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 1 // deleted p1@t1
 
-      val t9 = t0.plus(timeWindow.plus(evictInterval).plusSeconds(3))
+      val t9 = t0.plus(timeWindow.plusSeconds(13))
       offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(t9, Map(p8 -> 2L)), p8, 2L)).futureValue
 
-      offsetStore.getState().size shouldBe 8 // no eviction (outside eviction window, but within keep-number-of-entries)
-      offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 2 // deleted p4@t4 and p5@t5, kept p3@t3 (latest)
+      offsetStore.getState().byPid.keySet shouldBe Set(p2, p3, p6, p7, p8) // eviction slice 645
+      offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 2 // deleted p4@t4 and p5@t5
 
-      offsetStore.getState().byPid.keySet shouldBe Set(p1, p2, p3, p4, p5, p6, p7, p8)
+      offsetStore.getState().byPid.keySet shouldBe Set(p2, p3, p6, p7, p8)
       offsetStore.readOffset().futureValue // reload from database
-      offsetStore.getState().byPid.keySet shouldBe Set(p3, p6, p7, p8)
+      offsetStore.getState().byPid.keySet shouldBe Set(p2, p3, p6, p7, p8)
     }
 
-    "delete old records triggered after eviction" in {
+    "delete old records for same slice" in {
       val projectionId = genRandomProjectionId()
       val evictSettings = settings
-        .withKeepNumberOfEntries(5)
         .withTimeWindow(JDuration.ofSeconds(100))
-        .withEvictInterval(JDuration.ofSeconds(10))
       val offsetStore = createOffsetStore(projectionId, evictSettings)
 
-      import evictSettings.{ evictInterval, timeWindow }
+      import evictSettings.timeWindow
 
       val t0 = TestClock.nowMicros().instant()
       log.debug("Start time [{}]", t0)
@@ -1193,69 +1164,69 @@ class R2dbcTimestampOffsetStoreSpec
       val t3 = t0.plusSeconds(3)
       offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(t3, Map(p3 -> 1L)), p3, 1L)).futureValue
 
-      val t4 = t0.plus(evictInterval).plusSeconds(7)
+      val t4 = t0.plusSeconds(17)
       offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(t4, Map(p4 -> 1L)), p4, 1L)).futureValue
 
-      val t5 = t0.plus(evictInterval).plusSeconds(8)
+      val t5 = t0.plusSeconds(18)
       offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(t5, Map(p5 -> 1L)), p5, 1L)).futureValue
 
-      val t6 = t0.plus(evictInterval).plusSeconds(9)
+      val t6 = t0.plusSeconds(19)
       offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(t6, Map(p6 -> 1L)), p6, 1L)).futureValue
 
       offsetStore.getState().size shouldBe 6 // no eviction
       offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 0 // no deletion
 
-      val t7 = t0.plus(timeWindow.minus(evictInterval))
+      val t7 = t0.plus(timeWindow.minusSeconds(10))
       offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(t7, Map(p7 -> 1L)), p7, 1L)).futureValue
 
       offsetStore.getState().size shouldBe 7 // no eviction
       offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 0 // no deletion (within time window)
 
-      val t8 = t0.plus(timeWindow.plus(evictInterval).plusSeconds(3))
+      val t8 = t0.plus(timeWindow.plusSeconds(13))
       offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(t8, Map(p8 -> 1L)), p8, 1L)).futureValue
 
       offsetStore.getState().byPid.keySet shouldBe Set(p4, p5, p6, p7, p8) // evicted p1@t1, p2@t2, and p3@t3
       offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 3 // deletion triggered by eviction
 
-      val t9 = t0.plus(timeWindow.plus(evictInterval.multipliedBy(2)).plusSeconds(10))
+      val t9 = t0.plus(timeWindow.plusSeconds(30))
       offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(t9, Map(p8 -> 2L)), p8, 2L)).futureValue
 
-      offsetStore.getState().size shouldBe 5 // no eviction (outside time window, but still within limit)
+      offsetStore.getState().byPid.keySet shouldBe Set(p7, p8) // evicted
       offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 3 // deleted p4@t4, p5@t5, p6@t6 (outside window)
 
-      val t10 = t0.plus(timeWindow.plus(evictInterval.multipliedBy(2)).plusSeconds(11))
+      val t10 = t0.plus(timeWindow.plusSeconds(31))
       offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(t10, Map(p9 -> 1L)), p9, 1L)).futureValue
 
-      offsetStore.getState().byPid.keySet shouldBe Set(p5, p6, p7, p8, p9) // evicted p4@t4
-      offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 0 // deletion triggered, but nothing to delete
+      offsetStore.getState().byPid.keySet shouldBe Set(p7, p8, p9) // nothing evicted
+      offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 0 // but if deletion triggered nothing to delete
 
-      val t11 = t0.plus(timeWindow.plus(evictInterval.multipliedBy(2)).plusSeconds(12))
+      val t11 = t0.plus(timeWindow.plusSeconds(32))
       offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(t11, Map(p10 -> 1L)), p10, 1L)).futureValue
 
-      offsetStore.getState().byPid.keySet shouldBe Set(p6, p7, p8, p9, p10) // evicted p5@t5
-      offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 0 // deletion triggered, but nothing to delete
+      offsetStore.getState().byPid.keySet shouldBe Set(p7, p8, p9, p10) // nothing evicted
+      offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 0 // but if deletion triggered nothing to delete
 
-      val t12 = t0.plus(timeWindow.plus(evictInterval.multipliedBy(2)).plusSeconds(13))
+      val t12 = t0.plus(timeWindow.plusSeconds(33))
       offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(t12, Map(p11 -> 1L)), p11, 1L)).futureValue
 
-      offsetStore.getState().byPid.keySet shouldBe Set(p7, p8, p9, p10, p11) // evicted p6@t6
-      offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 0 // deletion triggered, but nothing to delete
+      offsetStore.getState().byPid.keySet shouldBe Set(p7, p8, p9, p10, p11) // nothing evicted
+      offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 0 // but if deletion triggered nothing to delete
 
-      val t13 = t0.plus(timeWindow.plus(evictInterval.multipliedBy(2)).plusSeconds(14))
+      val t13 = t0.plus(timeWindow.plusSeconds(34))
       offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(t13, Map(p12 -> 1L)), p12, 1L)).futureValue
 
-      offsetStore.getState().byPid.keySet shouldBe Set(p7, p8, p9, p10, p11, p12) // no eviction (within time window)
-      offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 0 // no deletion
+      offsetStore.getState().byPid.keySet shouldBe Set(p7, p8, p9, p10, p11, p12) // nothing evicted
+      offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 0 // but if deletion triggered nothing to delete
 
-      val t14 = t0.plus(timeWindow.multipliedBy(2).plus(evictInterval.multipliedBy(3)).plusSeconds(1))
+      val t14 = t7.plus(timeWindow.plusSeconds(1))
       offsetStore.saveOffset(OffsetPidSeqNr(TimestampOffset(t14, Map(p12 -> 2L)), p12, 2L)).futureValue
 
       offsetStore.getState().byPid.keySet shouldBe Set(p8, p9, p10, p11, p12) // evicted p7@t7
-      offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 3 // triggered by evict, deleted p7@t7, p8@t8, p8@t9
+      offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 1 // triggered by evict, deleted p7@t7
 
       offsetStore.getState().byPid.keySet shouldBe Set(p8, p9, p10, p11, p12)
       offsetStore.readOffset().futureValue // reload from database
-      offsetStore.getState().byPid.keySet shouldBe Set(p9, p10, p11, p12)
+      offsetStore.getState().byPid.keySet shouldBe Set(p8, p9, p10, p11, p12)
     }
 
     "set offset" in {
@@ -1429,7 +1400,7 @@ class R2dbcTimestampOffsetStoreSpec
 
       val state1 = offsetStore3.getState()
       state1.size shouldBe 4
-      state1.latestBySlice.size shouldBe 4
+      state1.bySliceSorted.size shouldBe 4
 
       offsetStore3.getForeignOffsets().size shouldBe 4 // all latest are from other projection keys
       offsetStore3.getLatestSeen() shouldBe Instant.EPOCH // latest seen is reset on reload
@@ -1448,7 +1419,7 @@ class R2dbcTimestampOffsetStoreSpec
 
       val state2 = offsetStore3.getState()
       state2.size shouldBe 4
-      state2.latestBySlice.size shouldBe 4
+      state2.bySliceSorted.size shouldBe 4
 
       offsetStore3.getForeignOffsets().size shouldBe 2 // latest by slice still from other projection keys (768-1023)
       offsetStore3.getLatestSeen() shouldBe Instant.EPOCH // latest seen is reset on reload
@@ -1486,7 +1457,7 @@ class R2dbcTimestampOffsetStoreSpec
 
       val state3 = offsetStore3.getState()
       state3.size shouldBe 4
-      state3.latestBySlice.size shouldBe 4
+      state3.bySliceSorted.size shouldBe 4
 
       offsetStore3.getForeignOffsets().size shouldBe 1 // latest by slice still from 768-1023
       offsetStore3.getLatestSeen() shouldBe Instant.EPOCH // latest seen is reset on reload
@@ -1520,7 +1491,7 @@ class R2dbcTimestampOffsetStoreSpec
 
       val state4 = offsetStore3.getState()
       state4.size shouldBe 4
-      state4.latestBySlice.size shouldBe 4
+      state4.bySliceSorted.size shouldBe 4
 
       offsetStore3.getForeignOffsets().size shouldBe 1 // latest by slice still from 768-1023
       offsetStore3.getLatestSeen() shouldBe Instant.EPOCH // latest seen is reset on reload
@@ -1556,14 +1527,17 @@ class R2dbcTimestampOffsetStoreSpec
 
       val state5 = offsetStore3.getState()
       state5.size shouldBe 4
-      state5.latestBySlice.size shouldBe 4
+      state5.bySliceSorted.size shouldBe 4
 
       offsetStore3.getForeignOffsets() shouldBe empty
       offsetStore3.getLatestSeen() shouldBe Instant.EPOCH
 
       // outdated offsets, included those for 768-1023, will eventually be deleted
       offsetStore3.saveOffset(OffsetPidSeqNr(TimestampOffset(time(100), Map(p1 -> 4L)), p1, 4L)).futureValue
-      offsetStore3.deleteOldTimestampOffsets().futureValue shouldBe 17
+      offsetStore3.saveOffset(OffsetPidSeqNr(TimestampOffset(time(100), Map(p2 -> 8L)), p2, 8L)).futureValue
+      offsetStore3.saveOffset(OffsetPidSeqNr(TimestampOffset(time(100), Map(p3 -> 8L)), p3, 8L)).futureValue
+      offsetStore3.saveOffset(OffsetPidSeqNr(TimestampOffset(time(100), Map(p4 -> 10L)), p4, 10L)).futureValue
+      offsetStore3.deleteOldTimestampOffsets().futureValue shouldBe 20
     }
 
     "validate timestamp of previous sequence number" in {

--- a/akka-projection-r2dbc/src/main/mima-filters/1.6.5.backwards.excludes/r2dbc-offset-store.excludes
+++ b/akka-projection-r2dbc/src/main/mima-filters/1.6.5.backwards.excludes/r2dbc-offset-store.excludes
@@ -1,0 +1,2 @@
+# internal
+ProblemFilters.exclude[Problem]("akka.projection.r2dbc.internal.R2dbcOffsetStore#State*")

--- a/akka-projection-r2dbc/src/main/resources/reference.conf
+++ b/akka-projection-r2dbc/src/main/resources/reference.conf
@@ -40,6 +40,14 @@ akka.projection.r2dbc {
 
     # Trying to batch insert offsets in batches of this size.
     offset-batch-size = 20
+
+    # Number of slices (within a given projection's slice range) which will be queried for
+    # offsets simultaneously when the projection is started.
+    offset-slice-read-parallelism = 10
+
+    # Number of offsets to retrieve per slice when the projection is started.
+    # Other offsets will be loaded on demand.
+    offset-slice-read-limit = 100
   }
 
   # By default it shares connection-factory with akka-persistence-r2dbc (write side),

--- a/akka-projection-r2dbc/src/main/resources/reference.conf
+++ b/akka-projection-r2dbc/src/main/resources/reference.conf
@@ -27,9 +27,12 @@ akka.projection.r2dbc {
     # It should not be larger than the akka.projection.r2dbc.offset-store.time-window.
     backtracking-window = ${akka.persistence.r2dbc.query.backtracking.window}
 
-    # Remove old entries outside the time-window from the offset store database
+    # Remove old entries when older than this duration from the offset store database.
+    delete-after = 1 day
+
+    # Remove old entries when older than delete-after from the offset store database
     # with this frequency. Can be disabled with `off`.
-    delete-interval = 1 minute
+    delete-interval = 10 minutes
 
     # Adopt latest-by-slice entries from other projection keys with this frequency.
     # Can be disabled with `off`.

--- a/akka-projection-r2dbc/src/main/resources/reference.conf
+++ b/akka-projection-r2dbc/src/main/resources/reference.conf
@@ -27,14 +27,6 @@ akka.projection.r2dbc {
     # It should not be larger than the akka.projection.r2dbc.offset-store.time-window.
     backtracking-window = ${akka.persistence.r2dbc.query.backtracking.window}
 
-    # Keep this number of entries. Don't evict old entries until this threshold
-    # has been reached.
-    keep-number-of-entries = 10000
-
-    # Remove old entries outside the time-window from the offset store memory
-    # with this frequency.
-    evict-interval = 10 seconds
-
     # Remove old entries outside the time-window from the offset store database
     # with this frequency. Can be disabled with `off`.
     delete-interval = 1 minute

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/R2dbcProjectionSettings.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/R2dbcProjectionSettings.scala
@@ -103,9 +103,9 @@ final class R2dbcProjectionSettings private (
     val timeWindow: JDuration,
     val backtrackingWindow: JDuration,
     val deleteAfter: JDuration,
-    @deprecated("Not used, evict is only based on time window", "1.6.3")
+    @deprecated("Not used, evict is only based on time window", "1.6.6")
     val keepNumberOfEntries: Int,
-    @deprecated("Not used, evict is not periodic", "1.6.2")
+    @deprecated("Not used, evict is not periodic", "1.6.6")
     val evictInterval: JDuration,
     val deleteInterval: JDuration,
     val adoptInterval: JDuration,
@@ -153,15 +153,15 @@ final class R2dbcProjectionSettings private (
   def withDeleteAfter(deleteAfter: JDuration): R2dbcProjectionSettings =
     copy(deleteAfter = deleteAfter)
 
-  @deprecated("Not used, evict is only based on time window", "1.6.2")
+  @deprecated("Not used, evict is only based on time window", "1.6.6")
   def withKeepNumberOfEntries(keepNumberOfEntries: Int): R2dbcProjectionSettings =
     this
 
-  @deprecated("Not used, evict is not periodic", "1.6.2")
+  @deprecated("Not used, evict is not periodic", "1.6.6")
   def withEvictInterval(evictInterval: FiniteDuration): R2dbcProjectionSettings =
     this
 
-  @deprecated("Not used, evict is not periodic", "1.6.2")
+  @deprecated("Not used, evict is not periodic", "1.6.6")
   def withEvictInterval(evictInterval: JDuration): R2dbcProjectionSettings =
     this
 

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/R2dbcProjectionSettings.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/R2dbcProjectionSettings.scala
@@ -7,6 +7,7 @@ package akka.projection.r2dbc
 import java.time.{ Duration => JDuration }
 import java.util.Locale
 
+import scala.annotation.nowarn
 import scala.concurrent.duration._
 import scala.jdk.DurationConverters._
 
@@ -58,8 +59,8 @@ object R2dbcProjectionSettings {
       useConnectionFactory = config.getString("use-connection-factory"),
       timeWindow = config.getDuration("offset-store.time-window"),
       backtrackingWindow = config.getDuration("offset-store.backtracking-window"),
-      keepNumberOfEntries = config.getInt("offset-store.keep-number-of-entries"),
-      evictInterval = config.getDuration("offset-store.evict-interval"),
+      keepNumberOfEntries = 0,
+      evictInterval = JDuration.ZERO,
       deleteInterval,
       adoptInterval,
       logDbCallsExceeding,
@@ -84,7 +85,9 @@ final class R2dbcProjectionSettings private (
     val useConnectionFactory: String,
     val timeWindow: JDuration,
     val backtrackingWindow: JDuration,
+    @deprecated("Not used, evict is only based on time window", "1.6.3")
     val keepNumberOfEntries: Int,
+    @deprecated("Not used, evict is not periodic", "1.6.2")
     val evictInterval: JDuration,
     val deleteInterval: JDuration,
     val adoptInterval: JDuration,
@@ -124,14 +127,17 @@ final class R2dbcProjectionSettings private (
   def withBacktrackingWindow(backtrackingWindow: JDuration): R2dbcProjectionSettings =
     copy(backtrackingWindow = backtrackingWindow)
 
+  @deprecated("Not used, evict is only based on time window", "1.6.2")
   def withKeepNumberOfEntries(keepNumberOfEntries: Int): R2dbcProjectionSettings =
-    copy(keepNumberOfEntries = keepNumberOfEntries)
+    this
 
+  @deprecated("Not used, evict is not periodic", "1.6.2")
   def withEvictInterval(evictInterval: FiniteDuration): R2dbcProjectionSettings =
-    copy(evictInterval = evictInterval.toJava)
+    this
 
+  @deprecated("Not used, evict is not periodic", "1.6.2")
   def withEvictInterval(evictInterval: JDuration): R2dbcProjectionSettings =
-    copy(evictInterval = evictInterval)
+    this
 
   def withDeleteInterval(deleteInterval: FiniteDuration): R2dbcProjectionSettings =
     copy(deleteInterval = deleteInterval.toJava)
@@ -160,6 +166,7 @@ final class R2dbcProjectionSettings private (
   def withCustomConnectionFactory(customConnectionFactory: ConnectionFactory): R2dbcProjectionSettings =
     copy(customConnectionFactory = Some(customConnectionFactory))
 
+  @nowarn("msg=deprecated")
   private def copy(
       schema: Option[String] = schema,
       offsetTable: String = offsetTable,
@@ -168,8 +175,6 @@ final class R2dbcProjectionSettings private (
       useConnectionFactory: String = useConnectionFactory,
       timeWindow: JDuration = timeWindow,
       backtrackingWindow: JDuration = backtrackingWindow,
-      keepNumberOfEntries: Int = keepNumberOfEntries,
-      evictInterval: JDuration = evictInterval,
       deleteInterval: JDuration = deleteInterval,
       adoptInterval: JDuration = adoptInterval,
       logDbCallsExceeding: FiniteDuration = logDbCallsExceeding,
@@ -194,5 +199,5 @@ final class R2dbcProjectionSettings private (
       customConnectionFactory)
 
   override def toString =
-    s"R2dbcProjectionSettings($schema, $offsetTable, $timestampOffsetTable, $managementTable, $useConnectionFactory, $timeWindow, $keepNumberOfEntries, $evictInterval, $deleteInterval, $logDbCallsExceeding, $warnAboutFilteredEventsInFlow, $offsetBatchSize, $customConnectionFactory)"
+    s"R2dbcProjectionSettings($schema, $offsetTable, $timestampOffsetTable, $managementTable, $useConnectionFactory, $timeWindow, $deleteInterval, $logDbCallsExceeding, $warnAboutFilteredEventsInFlow, $offsetBatchSize, $customConnectionFactory)"
 }

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/R2dbcProjectionSettings.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/R2dbcProjectionSettings.scala
@@ -81,7 +81,9 @@ object R2dbcProjectionSettings {
       logDbCallsExceeding,
       warnAboutFilteredEventsInFlow = config.getBoolean("warn-about-filtered-events-in-flow"),
       offsetBatchSize = config.getInt("offset-store.offset-batch-size"),
-      customConnectionFactory = None)
+      customConnectionFactory = None,
+      offsetSliceReadParallelism = config.getInt("offset-store.offset-slice-read-parallelism"),
+      offsetSliceReadLimit = config.getInt("offset-store.offset-slice-read-limit"))
   }
 
   /**
@@ -110,7 +112,9 @@ final class R2dbcProjectionSettings private (
     val logDbCallsExceeding: FiniteDuration,
     val warnAboutFilteredEventsInFlow: Boolean,
     val offsetBatchSize: Int,
-    val customConnectionFactory: Option[ConnectionFactory]) {
+    val customConnectionFactory: Option[ConnectionFactory],
+    val offsetSliceReadParallelism: Int,
+    val offsetSliceReadLimit: Int) {
 
   val offsetTableWithSchema: String = schema.map(_ + ".").getOrElse("") + offsetTable
   val timestampOffsetTableWithSchema: String = schema.map(_ + ".").getOrElse("") + timestampOffsetTable
@@ -188,6 +192,12 @@ final class R2dbcProjectionSettings private (
   def withCustomConnectionFactory(customConnectionFactory: ConnectionFactory): R2dbcProjectionSettings =
     copy(customConnectionFactory = Some(customConnectionFactory))
 
+  def withOffsetSliceReadParallelism(offsetSliceReadParallelism: Int): R2dbcProjectionSettings =
+    copy(offsetSliceReadParallelism = offsetSliceReadParallelism)
+
+  def withOffsetSliceReadLimit(offsetSliceReadLimit: Int): R2dbcProjectionSettings =
+    copy(offsetSliceReadLimit = offsetSliceReadLimit)
+
   @nowarn("msg=deprecated")
   private def copy(
       schema: Option[String] = schema,
@@ -203,7 +213,9 @@ final class R2dbcProjectionSettings private (
       logDbCallsExceeding: FiniteDuration = logDbCallsExceeding,
       warnAboutFilteredEventsInFlow: Boolean = warnAboutFilteredEventsInFlow,
       offsetBatchSize: Int = offsetBatchSize,
-      customConnectionFactory: Option[ConnectionFactory] = customConnectionFactory) =
+      customConnectionFactory: Option[ConnectionFactory] = customConnectionFactory,
+      offsetSliceReadParallelism: Int = offsetSliceReadParallelism,
+      offsetSliceReadLimit: Int = offsetSliceReadLimit) =
     new R2dbcProjectionSettings(
       schema,
       offsetTable,
@@ -220,7 +232,9 @@ final class R2dbcProjectionSettings private (
       logDbCallsExceeding,
       warnAboutFilteredEventsInFlow,
       offsetBatchSize,
-      customConnectionFactory)
+      customConnectionFactory,
+      offsetSliceReadParallelism,
+      offsetSliceReadLimit)
 
   override def toString =
     s"R2dbcProjectionSettings($schema, $offsetTable, $timestampOffsetTable, $managementTable, $useConnectionFactory, $timeWindow, $deleteInterval, $logDbCallsExceeding, $warnAboutFilteredEventsInFlow, $offsetBatchSize, $customConnectionFactory)"

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/OffsetStoreDao.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/OffsetStoreDao.scala
@@ -22,7 +22,7 @@ import akka.projection.r2dbc.internal.R2dbcOffsetStore.LatestBySlice
 @InternalApi
 private[projection] trait OffsetStoreDao {
 
-  def readTimestampOffset(): Future[immutable.IndexedSeq[R2dbcOffsetStore.RecordWithProjectionKey]]
+  def readTimestampOffset(slice: Int): Future[immutable.IndexedSeq[R2dbcOffsetStore.RecordWithProjectionKey]]
 
   def readTimestampOffset(slice: Int, pid: String): Future[Option[R2dbcOffsetStore.Record]]
 

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/OffsetStoreDao.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/OffsetStoreDao.scala
@@ -37,7 +37,7 @@ private[projection] trait OffsetStoreDao {
       timestamp: Instant,
       storageRepresentation: OffsetSerialization.StorageRepresentation): Future[Done]
 
-  def deleteOldTimestampOffset(until: Instant, notInLatestBySlice: Seq[LatestBySlice]): Future[Long]
+  def deleteOldTimestampOffset(slice: Int, until: Instant): Future[Long]
 
   def deleteNewTimestampOffsetsInTx(connection: Connection, timestamp: Instant): Future[Long]
 

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/PostgresOffsetStoreDao.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/PostgresOffsetStoreDao.scala
@@ -197,12 +197,11 @@ private[projection] class PostgresOffsetStoreDao(
     r2dbcExecutor.select("read timestamp offset")(
       conn => {
         logger.trace("reading timestamp offset for [{}]", projectionId)
-        val limit = 1000 // FIXME config
         conn
           .createStatement(selectTimestampOffsetSql)
           .bind(0, slice)
           .bind(1, projectionId.name)
-          .bind(2, limit)
+          .bind(2, settings.offsetSliceReadLimit)
       },
       row => {
         val projectionKey = row.get("projection_key", classOf[String])

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcOffsetStore.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcOffsetStore.scala
@@ -102,10 +102,9 @@ private[projection] object R2dbcOffsetStore {
         None
       } else {
         val t = latestTimestamp
-        // FIXME optimize this collection juggling?
         val latest =
           bySliceSorted.valuesIterator.flatMap { records =>
-            if (records.last.timestamp == t)
+            if (records.nonEmpty && records.last.timestamp == t)
               records.toVector.reverseIterator.takeWhile(_.timestamp == t).toVector
             else
               Vector.empty

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcOffsetStore.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcOffsetStore.scala
@@ -900,7 +900,7 @@ private[projection] class R2dbcOffsetStore(
     val currentState = getState()
     if ((triggerDeletion == null || triggerDeletion == TRUE) && currentState.bySliceSorted.contains(slice)) {
       val latest = currentState.bySliceSorted(slice).last
-      val until = latest.timestamp.minus(settings.timeWindow)
+      val until = latest.timestamp.minus(settings.deleteAfter)
 
       // note that deleteOldTimestampOffsetSql already has `AND timestamp_offset < ?`,
       // which means that the latest for this slice will not be deleted

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcOffsetStore.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcOffsetStore.scala
@@ -167,8 +167,8 @@ private[projection] object R2dbcOffsetStore {
           // Slice will be equal, and pid will compare lexicographically less than any valid pid
           val untilRecord = Record(slice, "", 0, until)
           // this will always keep at least one, latest per slice
-          val newerRecords = recordsSortedByTimestamp.rangeImpl(Some(untilRecord), None) // inclusive of until
-          val olderRecords = recordsSortedByTimestamp.rangeImpl(None, Some(untilRecord)) // exclusive of until
+          val newerRecords = recordsSortedByTimestamp.rangeFrom(untilRecord) // inclusive of until
+          val olderRecords = recordsSortedByTimestamp.rangeUntil(untilRecord) // exclusive of until
           val filteredOlder = olderRecords.filterNot(ableToEvictRecord)
 
           if (filteredOlder.size == olderRecords.size) recordsSortedByTimestamp


### PR DESCRIPTION
* evict time window for each slice
* remove keep-number-of-entries and evict-interval
* lazy loading of offsets
* delete detached from time window, separate delete-after config
