### PR TITLE
fix: DynamoDB Timestamp validation of previous seqNr

### DIFF
--- a/akka-projection-dynamodb/src/main/resources/reference.conf
+++ b/akka-projection-dynamodb/src/main/resources/reference.conf
@@ -12,6 +12,12 @@ akka.projection.dynamodb {
     # within this time window from latest offset.
     time-window = 5 minutes
 
+    # Backtracking window of the source (query). Should be equal to
+    # the akka.persistence.dynamodb.query.backtracking.window that is used for the
+    # SourceProvider.
+    # It should not be larger than the akka.projection.dynamodb.offset-store.time-window.
+    backtracking-window = ${akka.persistence.dynamodb.query.backtracking.window}
+
     # Trying to batch insert offsets in batches of this size.
     offset-batch-size = 20
 

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/DynamoDBProjectionSettings.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/DynamoDBProjectionSettings.scala
@@ -41,6 +41,7 @@ object DynamoDBProjectionSettings {
       timestampOffsetTable = config.getString("offset-store.timestamp-offset-table"),
       useClient = config.getString("use-client"),
       timeWindow = config.getDuration("offset-store.time-window"),
+      backtrackingWindow = config.getDuration("offset-store.backtracking-window"),
       keepNumberOfEntries = 0,
       evictInterval = JDuration.ZERO,
       warnAboutFilteredEventsInFlow = config.getBoolean("warn-about-filtered-events-in-flow"),
@@ -61,6 +62,7 @@ final class DynamoDBProjectionSettings private (
     val timestampOffsetTable: String,
     val useClient: String,
     val timeWindow: JDuration,
+    val backtrackingWindow: JDuration,
     @deprecated("Not used, evict is only based on time window", "1.6.2")
     val keepNumberOfEntries: Int,
     @deprecated("Not used, evict is not periodic", "1.6.2")
@@ -81,6 +83,12 @@ final class DynamoDBProjectionSettings private (
 
   def withTimeWindow(timeWindow: JDuration): DynamoDBProjectionSettings =
     copy(timeWindow = timeWindow)
+
+  def withBacktrackingWindow(backtrackingWindow: FiniteDuration): DynamoDBProjectionSettings =
+    copy(backtrackingWindow = backtrackingWindow.toJava)
+
+  def withBacktrackingWindow(backtrackingWindow: JDuration): DynamoDBProjectionSettings =
+    copy(backtrackingWindow = backtrackingWindow)
 
   @deprecated("Not used, evict is only based on time window", "1.6.2")
   def withKeepNumberOfEntries(keepNumberOfEntries: Int): DynamoDBProjectionSettings =
@@ -111,6 +119,7 @@ final class DynamoDBProjectionSettings private (
       timestampOffsetTable: String = timestampOffsetTable,
       useClient: String = useClient,
       timeWindow: JDuration = timeWindow,
+      backtrackingWindow: JDuration = backtrackingWindow,
       warnAboutFilteredEventsInFlow: Boolean = warnAboutFilteredEventsInFlow,
       offsetBatchSize: Int = offsetBatchSize,
       offsetSliceReadParallelism: Int = offsetSliceReadParallelism,
@@ -119,6 +128,7 @@ final class DynamoDBProjectionSettings private (
       timestampOffsetTable,
       useClient,
       timeWindow,
+      backtrackingWindow,
       keepNumberOfEntries,
       evictInterval,
       warnAboutFilteredEventsInFlow,
@@ -127,7 +137,7 @@ final class DynamoDBProjectionSettings private (
       timeToLiveSettings)
 
   override def toString =
-    s"DynamoDBProjectionSettings($timestampOffsetTable, $useClient, $timeWindow, $warnAboutFilteredEventsInFlow, $offsetBatchSize)"
+    s"DynamoDBProjectionSettings($timestampOffsetTable, $useClient, $timeWindow, $backtrackingWindow, $warnAboutFilteredEventsInFlow, $offsetBatchSize)"
 }
 
 object TimeToLiveSettings {


### PR DESCRIPTION
* base the validaiton time window for the previous sequence number
  on start timestamp and backtracking window

Corresponding to https://github.com/akka/akka-projection/pull/1246