### PR TITLE
fix: DynamoDB - Avoid dropping sequence number progress

### DIFF
--- a/akka-projection-dynamodb/src/main/resources/reference.conf
+++ b/akka-projection-dynamodb/src/main/resources/reference.conf
@@ -27,6 +27,13 @@ akka.projection.dynamodb {
     # reducing this may result in fewer restarts of the projection due to failure to query
     # starting offsets.
     offset-slice-read-parallelism = 64
+
+	# Batch writes are not automatically retried by the underlying SDK, so these settings govern those retries
+    retries {
+      max-retries = 3
+	  min-backoff = 200ms
+	  max-backoff = 2s
+	}
   }
 
   # By default it shares DynamoDB client with akka-persistence-dynamodb (write side).

--- a/akka-projection-dynamodb/src/main/resources/reference.conf
+++ b/akka-projection-dynamodb/src/main/resources/reference.conf
@@ -28,12 +28,13 @@ akka.projection.dynamodb {
     # starting offsets.
     offset-slice-read-parallelism = 64
 
-	# Batch writes are not automatically retried by the underlying SDK, so these settings govern those retries
+    # Batch writes are not automatically retried by the underlying SDK, so these settings govern those retries
     retries {
       max-retries = 3
-	  min-backoff = 200ms
-	  max-backoff = 2s
-	}
+      min-backoff = 200ms
+      max-backoff = 2s
+      random-factor = 0.3
+    }
   }
 
   # By default it shares DynamoDB client with akka-persistence-dynamodb (write side).

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -391,8 +391,9 @@ private[projection] class DynamoDBOffsetStore(
           records
             .groupBy(_.pid)
             .valuesIterator
-            .map(_.maxBy(_.seqNr))
-            .filterNot(oldState.isDuplicate _)
+            .collect {
+              case recordsByPid if !oldState.isDuplicate(recordsByPid.last) => recordsByPid.last
+            }
             .toVector
         }
       }

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -391,9 +391,8 @@ private[projection] class DynamoDBOffsetStore(
           records
             .groupBy(_.pid)
             .valuesIterator
-            .collect {
-              case recordsByPid if !oldState.isDuplicate(recordsByPid.last) => recordsByPid.last
-            }
+            .map(_.maxBy(_.seqNr))
+            .filterNot(oldState.isDuplicate _)
             .toVector
         }
       }

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/OffsetStoreDao.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/OffsetStoreDao.scala
@@ -200,7 +200,7 @@ import akka.projection.dynamodb.internal.DynamoDBOffsetStore.FutureDone
       result
         .flatMap { responses =>
           val lastResponse = responses.last
-          if (lastResponse.hasUnprocessedItems) {
+          if (lastResponse.hasUnprocessedItems && !lastResponse.unprocessedItems.isEmpty) {
             val unprocessedSliceItems =
               lastResponse.unprocessedItems.get(settings.timestampOffsetTable).asScala.toVector
             val unprocessedSlices = unprocessedSliceItems.map(_.putRequest.item.get(NameSlice).s)
@@ -271,7 +271,7 @@ import akka.projection.dynamodb.internal.DynamoDBOffsetStore.FutureDone
 
       result.flatMap { responses =>
         val lastResponse = responses.last
-        if (lastResponse.hasUnprocessedItems) {
+        if (lastResponse.hasUnprocessedItems && !lastResponse.unprocessedItems.isEmpty) {
           val unprocessedSeqNrItems =
             lastResponse.unprocessedItems.get(settings.timestampOffsetTable).asScala.toVector.map(_.putRequest.item)
           val unprocessedSeqNrs = unprocessedSeqNrItems.map { item =>
@@ -474,7 +474,7 @@ import akka.projection.dynamodb.internal.DynamoDBOffsetStore.FutureDone
       result
         .flatMap { responses =>
           val lastResponse = responses.last
-          if (lastResponse.hasUnprocessedItems) {
+          if (lastResponse.hasUnprocessedItems && !lastResponse.unprocessedItems.isEmpty) {
             val unprocessedStateItems =
               lastResponse.unprocessedItems.get(settings.timestampOffsetTable).asScala.toVector.map(_.putRequest.item)
             val unprocessedStates = unprocessedStateItems.map { item =>

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/OffsetStoreDao.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/OffsetStoreDao.scala
@@ -236,7 +236,7 @@ import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse
               unprocessedSlices.size,
               unprocessedSlices.mkString(", "))
 
-            failed.asInstanceOf[Future[Done]] // safe, actually contains Nothing
+            Future.failed(failed)
 
           case c: CompletionException =>
             Future.failed(c.getCause)
@@ -315,7 +315,7 @@ import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse
               unprocessedSeqNrs.size,
               unprocessedSeqNrs.mkString(", "))
 
-            failed.asInstanceOf[Future[Done]]
+            Future.failed(failed)
 
           case c: CompletionException =>
             Future.failed(c.getCause)
@@ -526,7 +526,7 @@ import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse
               unprocessedStates.size,
               unprocessedStates.mkString(", "))
 
-            failed.asInstanceOf[Future[Done]]
+            Future.failed(failed)
 
           case c: CompletionException =>
             Future.failed(c.getCause)


### PR DESCRIPTION
The major fix here is retrying unprocessed batch-write items in the OffsetStoreDao: while the individual writes are atomic, the batch is not and reports partial success as a successful CompletionStage: it's on the caller to check that all items succeeded and retry ones that didn't.