### PR TITLE
test: Harden DynamoDBTimestampOffsetProjectionSpec

### DIFF
--- a/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
+++ b/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
@@ -921,6 +921,7 @@ class DynamoDBTimestampOffsetProjectionSpec
       offsetShouldBeEmpty()
       projectionTestKit.run(projectionFailing) {
         projectedTestValueShouldBe("e1|e2|e3|e4|e5")
+        bogusEventHandler.attempts shouldBe 1
       }
       eventually {
         latestOffsetShouldBe(envelopes.last.offset)

--- a/akka-projection-jdbc-integration/src/test/scala/akka/projection/jdbc/JdbcProjectionSpec.scala
+++ b/akka-projection-jdbc-integration/src/test/scala/akka/projection/jdbc/JdbcProjectionSpec.scala
@@ -360,6 +360,7 @@ class JdbcProjectionSpec
       offsetShouldBeEmpty()
       projectionTestKit.run(projectionFailing) {
         projectedValueShouldBe("e1|e2|e3|e4|e5")
+        bogusEventHandler.attempts shouldBe 1
       }
       eventually {
         offsetShouldBe(6L)

--- a/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcProjectionSpec.scala
+++ b/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcProjectionSpec.scala
@@ -363,6 +363,7 @@ class R2dbcProjectionSpec
       offsetShouldBeEmpty()
       projectionTestKit.run(projectionFailing) {
         projectedValueShouldBe("e1|e2|e3|e4|e5")
+        bogusEventHandler.attempts shouldBe 1
       }
       eventually {
         offsetShouldBe(6L)

--- a/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetProjectionSpec.scala
+++ b/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetProjectionSpec.scala
@@ -418,6 +418,7 @@ class R2dbcTimestampOffsetProjectionSpec
       offsetShouldBeEmpty()
       projectionTestKit.run(projectionFailing) {
         projectedValueShouldBe("e1|e2|e3|e4|e5")
+        bogusEventHandler.attempts shouldBe 1
       }
       eventually {
         offsetShouldBe(envelopes.last.offset)


### PR DESCRIPTION
* failing test: "store offset for failing events when using RecoveryStrategy.skip"
* projection might have been stopped before the error occured
