### PR TITLE
fix: [DynamoDB] Ensure that inflight persistence IDs are not evicted

### DIFF
--- a/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBOffsetStoreStateSpec.scala
+++ b/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBOffsetStoreStateSpec.scala
@@ -175,15 +175,23 @@ class DynamoDBOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Match
 
     "evict old but only those allowed to be evicted" in {
       val t0 = TestClock.nowMillis().instant()
-      val state1 = State.empty.add(Vector(createRecord("p92", 2, t0.plusMillis(1)), createRecord("p108", 3, t0.plusMillis(20)), createRecord("p229", 4, t0.plusMillis(30))))
+      val state1 = State.empty.add(
+        Vector(
+          createRecord("p92", 2, t0.plusMillis(1)),
+          createRecord("p108", 3, t0.plusMillis(20)),
+          createRecord("p229", 4, t0.plusMillis(30))))
 
       val slices = state1.bySliceSorted.keySet
       slices.size shouldBe 1
 
-      state1.evict(slices.head, JDuration.ofMillis(1), allowAll).byPid
-        .map { case (pid, r) => pid -> r.seqNr } shouldBe Map("p229" -> 4)    // p92 and p108 evicted
+      state1
+        .evict(slices.head, JDuration.ofMillis(1), allowAll)
+        .byPid
+        .map { case (pid, r) => pid -> r.seqNr } shouldBe Map("p229" -> 4) // p92 and p108 evicted
 
-      state1.evict(slices.head, JDuration.ofMillis(1), _.pid == "p108").byPid  // allow only p108 to be evicted
+      state1
+        .evict(slices.head, JDuration.ofMillis(1), _.pid == "p108")
+        .byPid // allow only p108 to be evicted
         .map { case (pid, r) => pid -> r.seqNr } shouldBe Map("p92" -> 2, "p229" -> 4)
     }
 

--- a/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBOffsetStoreStateSpec.scala
+++ b/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBOffsetStoreStateSpec.scala
@@ -85,6 +85,8 @@ class DynamoDBOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Match
       state6.offsetBySlice(slice("p10084")) shouldBe TimestampOffset(t0.plusMillis(3), Map("p3" -> 10L, "p10084" -> 9))
     }
 
+    val allowAll: Any => Boolean = _ => true
+
     "evict old" in {
       val p1 = "p500" // slice 645
       val p2 = "p621" // slice 645
@@ -107,17 +109,17 @@ class DynamoDBOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Match
         .map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p1 -> 1L, p2 -> 2L, p3 -> 3L, p4 -> 4L, p6 -> 6L)
 
       // keep all
-      state1.evict(slice = 645, timeWindow = JDuration.ofMillis(1000)) shouldBe state1
+      state1.evict(slice = 645, timeWindow = JDuration.ofMillis(1000), allowAll) shouldBe state1
 
       // evict older than time window
-      val state2 = state1.evict(slice = 645, timeWindow = JDuration.ofMillis(2))
+      val state2 = state1.evict(slice = 645, timeWindow = JDuration.ofMillis(2), allowAll)
       state2.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p2 -> 2L, p3 -> 3L, p4 -> 4L, p6 -> 6L)
 
       val state3 = state1.add(Vector(createRecord(p5, 5, t0.plusMillis(100)), createRecord(p7, 7, t0.plusMillis(10))))
-      val state4 = state3.evict(slice = 645, timeWindow = JDuration.ofMillis(2))
+      val state4 = state3.evict(slice = 645, timeWindow = JDuration.ofMillis(2), allowAll)
       state4.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map(p5 -> 5L, p6 -> 6L, p7 -> 7L)
 
-      val state5 = state3.evict(slice = 905, timeWindow = JDuration.ofMillis(2))
+      val state5 = state3.evict(slice = 905, timeWindow = JDuration.ofMillis(2), allowAll)
       state5.byPid.map { case (pid, r) => pid -> r.seqNr } shouldBe Map(
         p1 -> 1L,
         p2 -> 2L,
@@ -156,7 +158,7 @@ class DynamoDBOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Match
       val timeWindow = JDuration.ofMillis(1)
 
       val state2 = slices.foldLeft(state1) {
-        case (acc, slice) => acc.evict(slice, timeWindow)
+        case (acc, slice) => acc.evict(slice, timeWindow, allowAll)
       }
       // note that p92 is evicted because it has same slice as p108
       // p1 is kept because keeping one for each slice
@@ -164,11 +166,25 @@ class DynamoDBOffsetStoreStateSpec extends AnyWordSpec with TestSuite with Match
         .map { case (pid, r) => pid -> r.seqNr } shouldBe Map("p1" -> 1L, "p108" -> 3L, "p4" -> 4L, "p5" -> 5L)
 
       val state3 = slices.foldLeft(state2) {
-        case (acc, slice) => acc.evict(slice, timeWindow)
+        case (acc, slice) => acc.evict(slice, timeWindow, allowAll)
       }
       // still keeping one for each slice
       state3.byPid
         .map { case (pid, r) => pid -> r.seqNr } shouldBe Map("p1" -> 1L, "p108" -> 3L, "p4" -> 4L, "p5" -> 5L)
+    }
+
+    "evict old but only those allowed to be evicted" in {
+      val t0 = TestClock.nowMillis().instant()
+      val state1 = State.empty.add(Vector(createRecord("p92", 2, t0.plusMillis(1)), createRecord("p108", 3, t0.plusMillis(20)), createRecord("p229", 4, t0.plusMillis(30))))
+
+      val slices = state1.bySliceSorted.keySet
+      slices.size shouldBe 1
+
+      state1.evict(slices.head, JDuration.ofMillis(1), allowAll).byPid
+        .map { case (pid, r) => pid -> r.seqNr } shouldBe Map("p229" -> 4)    // p92 and p108 evicted
+
+      state1.evict(slices.head, JDuration.ofMillis(1), _.pid == "p108").byPid  // allow only p108 to be evicted
+        .map { case (pid, r) => pid -> r.seqNr } shouldBe Map("p92" -> 2, "p229" -> 4)
     }
 
     "find duplicate" in {

--- a/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetStoreSpec.scala
+++ b/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetStoreSpec.scala
@@ -848,8 +848,6 @@ abstract class DynamoDBTimestampOffsetStoreBaseSpec(config: Config)
         .futureValue
       offsetStore.getState().size shouldBe 6
 
-      offsetStore.getInflight().size shouldBe 0
-
       offsetStore
         .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(timeWindow.minusSeconds(10)), Map(p7 -> 1L)), p7, 1L))
         .futureValue

--- a/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetStoreSpec.scala
+++ b/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetStoreSpec.scala
@@ -848,6 +848,8 @@ abstract class DynamoDBTimestampOffsetStoreBaseSpec(config: Config)
         .futureValue
       offsetStore.getState().size shouldBe 6
 
+      offsetStore.getInflight().size shouldBe 0
+
       offsetStore
         .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plus(timeWindow.minusSeconds(10)), Map(p7 -> 1L)), p7, 1L))
         .futureValue

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -52,7 +52,7 @@ private[projection] object DynamoDBOffsetStore {
           Integer.compare(slice, that.slice) match {
             case 0 =>
               pid.compareTo(that.pid) match {
-                case 0 => java.lang.Long.compare(seqNr, that.seqNr)
+                case 0      => java.lang.Long.compare(seqNr, that.seqNr)
                 case result => result
               }
             case result => result

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -154,8 +154,8 @@ private[projection] object DynamoDBOffsetStore {
           // Records comparing < this record by recordOrdering are subject to eviction
           // Slice will be equal, and pid will compare lexicographically less than any valid pid
           val untilRecord = Record(slice, "", 0, until)
-          val newerRecords = recordsSortedByTimestamp.rangeImpl(Some(untilRecord), None) // inclusive of until
-          val olderRecords = recordsSortedByTimestamp.rangeImpl(None, Some(untilRecord)) // exclusive of until
+          val newerRecords = recordsSortedByTimestamp.rangeFrom(untilRecord) // inclusive of until
+          val olderRecords = recordsSortedByTimestamp.rangeUntil(untilRecord) // exclusive of until
           val filteredOlder = olderRecords.filterNot(ableToEvictRecord)
 
           if (filteredOlder.size == olderRecords.size) recordsSortedByTimestamp

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -408,12 +408,15 @@ private[projection] class DynamoDBOffsetStore(
           records.filterNot(oldState.isDuplicate)
         else {
           // use last record for each pid
-          records
-            .groupBy(_.pid)
-            .valuesIterator
-            .map(_.maxBy(_.seqNr))
-            .filterNot(oldState.isDuplicate)
-            .toVector
+          val grouped = records.groupBy(_.pid)
+
+          if (grouped.size == records.size)
+            records.filterNot(oldState.isDuplicate)
+          else
+            grouped.valuesIterator
+              .map(_.maxBy(_.seqNr))
+              .filterNot(oldState.isDuplicate)
+              .toVector
         }
       }
       if (filteredRecords.isEmpty) {

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -159,7 +159,7 @@ private[projection] object DynamoDBOffsetStore {
           val filteredOlder = olderRecords.filterNot(ableToEvictRecord)
 
           if (filteredOlder.size == olderRecords.size) recordsSortedByTimestamp
-          else newerRecords.union(olderRecords)
+          else newerRecords.union(filteredOlder)
         }
 
         // adding back filtered is linear in the size of filtered, but so is checking if we're able to evict

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -409,7 +409,8 @@ private[projection] class DynamoDBOffsetStore(
         else {
           // Can assume (given other projection guarantees) that records for the same pid
           // have montonically increasing sequence numbers
-          records.groupBy(_.pid)
+          records
+            .groupBy(_.pid)
             .valuesIterator
             .collect {
               case recordsByPid if !oldState.isDuplicate(recordsByPid.last) => recordsByPid.last


### PR DESCRIPTION
If, when recovering a backlog in an at-least-once projection, the range of event timestamps from a slice in a given batch of records to have offsets saved exceeds the offset store's `time-window`, the older events will be immediately evicted; since the inflight records are cleaned based on the state after evicting, this implies that the records for those older events will continue to be considered inflight.

If there are no further events for a persistence ID that was immediately evicted, this means a leak in inflight (if there are enough of these situations, the hard limit of 10k records inflight will get breached) eventually resulting in projection failure.

Note that sequence numbers are saved based on the incoming records, so this eviction will not prevent seen sequence numbers from being updated.