### PR TITLE
fix: DynamoDB replay rejected events

### DIFF
--- a/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
+++ b/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
@@ -904,12 +904,18 @@ class DynamoDBTimestampOffsetProjectionSpec
 
       val sourceProvider =
         createSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
+
       implicit val offsetStore: DynamoDBOffsetStore =
         new DynamoDBOffsetStore(projectionId, Some(sourceProvider), system, settings, client)
 
       val projectionRef = spawn(
-        ProjectionBehavior(DynamoDBProjection
-          .atLeastOnce(projectionId, Some(settings), sourceProvider, handler = () => new ConcatHandler(repository))))
+        ProjectionBehavior(
+          DynamoDBProjection
+            .atLeastOnce(
+              projectionId,
+              Some(settings.withReplayOnRejectedSequenceNumbers(true)),
+              sourceProvider,
+              handler = () => new ConcatHandler(repository))))
 
       eventually {
         projectedValueShouldBe("e1|e2|e3|e4|e5|e6")(pid1)
@@ -960,8 +966,13 @@ class DynamoDBTimestampOffsetProjectionSpec
         new DynamoDBOffsetStore(projectionId, Some(sourceProvider), system, settings, client)
 
       val projectionRef = spawn(
-        ProjectionBehavior(DynamoDBProjection
-          .atLeastOnce(projectionId, Some(settings), sourceProvider, handler = () => new ConcatHandler(repository))))
+        ProjectionBehavior(
+          DynamoDBProjection
+            .atLeastOnce(
+              projectionId,
+              Some(settings.withReplayOnRejectedSequenceNumbers(true)),
+              sourceProvider,
+              handler = () => new ConcatHandler(repository))))
 
       eventually {
         projectedValueShouldBe("e1|e2|e3|e4|e5|e6|e7|e8|e9")(pid1)

--- a/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
+++ b/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
@@ -1246,6 +1246,102 @@ class DynamoDBTimestampOffsetProjectionSpec
       }
       latestOffsetShouldBe(envelopes.last.offset)
     }
+
+    "replay rejected sequence numbers" in {
+      val pid1 = UUID.randomUUID().toString
+      val pid2 = UUID.randomUUID().toString
+      val projectionId = genRandomProjectionId()
+
+      val allEnvelopes = createEnvelopes(pid1, 6) ++ createEnvelopes(pid2, 3)
+      val skipPid1SeqNrs = Set(3L, 4L, 5L)
+      val envelopes = allEnvelopes.filterNot { env =>
+        (env.persistenceId == pid1 && skipPid1SeqNrs(env.sequenceNr)) ||
+        (env.persistenceId == pid2 && (env.sequenceNr == 1))
+      }
+
+      val sourceProvider =
+        createSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
+
+      implicit val offsetStore: DynamoDBOffsetStore =
+        new DynamoDBOffsetStore(projectionId, Some(sourceProvider), system, settings, client)
+
+      val projectionRef = spawn(
+        ProjectionBehavior(
+          DynamoDBProjection
+            .exactlyOnce(
+              projectionId,
+              Some(settings.withReplayOnRejectedSequenceNumbers(true)),
+              sourceProvider,
+              handler = () => new TransactConcatHandler)))
+
+      eventually {
+        projectedTestValueShouldBe("e1|e2|e3|e4|e5|e6")(pid1)
+        projectedTestValueShouldBe("e1|e2|e3")(pid2)
+      }
+
+      eventually {
+        latestOffsetShouldBe(allEnvelopes.last.offset)
+      }
+      projectionRef ! ProjectionBehavior.Stop
+    }
+
+    "replay rejected sequence numbers due to clock skew on event write" in {
+      val pid1 = UUID.randomUUID().toString
+      val pid2 = UUID.randomUUID().toString
+      val projectionId = genRandomProjectionId()
+
+      val start = tick().instant()
+
+      def createEnvelopesFor(
+          pid: Pid,
+          fromSeqNr: Int,
+          toSeqNr: Int,
+          fromTimestamp: Instant): immutable.IndexedSeq[EventEnvelope[String]] = {
+        (fromSeqNr to toSeqNr).map { n =>
+          createEnvelope(pid, n, fromTimestamp.plusSeconds(n - fromSeqNr), s"e$n")
+        }
+      }
+
+      val envelopes1 =
+        createEnvelopesFor(pid1, 1, 2, start) ++
+        createEnvelopesFor(pid1, 3, 4, start.plusSeconds(4)) ++ // gap
+        createEnvelopesFor(pid1, 5, 9, start.plusSeconds(2)) // clock skew, back 2, and then overlapping
+
+      val envelopes2 =
+        createEnvelopesFor(pid2, 1, 3, start.plusSeconds(10)) ++
+        createEnvelopesFor(pid2, 4, 6, start.plusSeconds(1)) ++ // clock skew, back 9
+        createEnvelopesFor(pid2, 7, 9, start.plusSeconds(20)) // and gap
+
+      val allEnvelopes = envelopes1 ++ envelopes2
+
+      val envelopes = allEnvelopes.sortBy(_.timestamp)
+
+      val sourceProvider =
+        createSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
+
+      implicit val offsetStore: DynamoDBOffsetStore =
+        new DynamoDBOffsetStore(projectionId, Some(sourceProvider), system, settings, client)
+
+      val projectionRef = spawn(
+        ProjectionBehavior(
+          DynamoDBProjection
+            .exactlyOnce(
+              projectionId,
+              Some(settings.withReplayOnRejectedSequenceNumbers(true)),
+              sourceProvider,
+              handler = () => new TransactConcatHandler)))
+
+      eventually {
+        projectedTestValueShouldBe("e1|e2|e3|e4|e5|e6|e7|e8|e9")(pid1)
+        projectedTestValueShouldBe("e1|e2|e3|e4|e5|e6|e7|e8|e9")(pid2)
+      }
+
+      eventually {
+        latestOffsetShouldBe(envelopes.last.offset)
+      }
+
+      projectionRef ! ProjectionBehavior.Stop
+    }
   }
 
   "A DynamoDB grouped projection with TimestampOffset" must {

--- a/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
+++ b/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
@@ -1565,6 +1565,126 @@ class DynamoDBTimestampOffsetProjectionSpec
         latestOffsetShouldBe(envelopes.last.offset)
       }
     }
+
+    "replay rejected sequence numbers for at-least-once grouped" in {
+      val pid1 = UUID.randomUUID().toString
+      val pid2 = UUID.randomUUID().toString
+      val projectionId = genRandomProjectionId()
+
+      val allEnvelopes = createEnvelopes(pid1, 6) ++ createEnvelopes(pid2, 3)
+      val envelopes = allEnvelopes.filterNot { env =>
+        (env.persistenceId == pid1 && (env.sequenceNr == 3 || env.sequenceNr == 4 || env.sequenceNr == 5)) ||
+        (env.persistenceId == pid2 && (env.sequenceNr == 1))
+      }
+
+      val sourceProvider =
+        createSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
+
+      implicit val offsetStore: DynamoDBOffsetStore =
+        new DynamoDBOffsetStore(projectionId, Some(sourceProvider), system, settings, client)
+
+      val results = new ConcurrentHashMap[String, String]()
+
+      val handler: Handler[Seq[EventEnvelope[String]]] =
+        (envelopes: Seq[EventEnvelope[String]]) => {
+          Future {
+            envelopes.foreach { envelope =>
+              results.putIfAbsent(envelope.persistenceId, "|")
+              results.computeIfPresent(envelope.persistenceId, (_, value) => value + envelope.event + "|")
+            }
+          }.map(_ => Done)
+        }
+
+      val projection =
+        DynamoDBProjection
+          .atLeastOnceGroupedWithin(
+            projectionId,
+            Some(settings.withReplayOnRejectedSequenceNumbers(true)),
+            sourceProvider,
+            handler = () => handler)
+          .withGroup(2, 3.seconds)
+
+      offsetShouldBeEmpty()
+
+      projectionTestKit.run(projection) {
+        results.get(pid1) shouldBe "|e1|e2|e3|e4|e5|e6|"
+        results.get(pid2) shouldBe "|e1|e2|e3|"
+      }
+
+      eventually {
+        latestOffsetShouldBe(allEnvelopes.last.offset)
+      }
+    }
+
+    "replay rejected sequence numbers due to clock skew on event write for at-least-once grouped" in {
+      val pid1 = UUID.randomUUID().toString
+      val pid2 = UUID.randomUUID().toString
+      val projectionId = genRandomProjectionId()
+
+      val start = tick().instant()
+
+      def createEnvelopesFor(
+          pid: Pid,
+          fromSeqNr: Int,
+          toSeqNr: Int,
+          fromTimestamp: Instant): immutable.IndexedSeq[EventEnvelope[String]] = {
+        (fromSeqNr to toSeqNr).map { n =>
+          createEnvelope(pid, n, fromTimestamp.plusSeconds(n - fromSeqNr), s"e$n")
+        }
+      }
+
+      val envelopes1 =
+        createEnvelopesFor(pid1, 1, 2, start) ++
+        createEnvelopesFor(pid1, 3, 4, start.plusSeconds(4)) ++ // gap
+        createEnvelopesFor(pid1, 5, 9, start.plusSeconds(2)) // clock skew, back 2, and then overlapping
+
+      val envelopes2 =
+        createEnvelopesFor(pid2, 1, 3, start.plusSeconds(10)) ++
+        createEnvelopesFor(pid2, 4, 6, start.plusSeconds(1)) ++ // clock skew, back 9
+        createEnvelopesFor(pid2, 7, 9, start.plusSeconds(20)) // and gap
+
+      val allEnvelopes = envelopes1 ++ envelopes2
+
+      val envelopes = allEnvelopes.sortBy(_.timestamp)
+
+      val sourceProvider =
+        createSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
+
+      implicit val offsetStore: DynamoDBOffsetStore =
+        new DynamoDBOffsetStore(projectionId, Some(sourceProvider), system, settings, client)
+
+      val results = new ConcurrentHashMap[String, String]()
+
+      val handler: Handler[Seq[EventEnvelope[String]]] =
+        (envelopes: Seq[EventEnvelope[String]]) => {
+          Future {
+            envelopes.foreach { envelope =>
+              results.putIfAbsent(envelope.persistenceId, "|")
+              results.computeIfPresent(envelope.persistenceId, (_, value) => value + envelope.event + "|")
+            }
+          }.map(_ => Done)
+        }
+
+      val projection =
+        DynamoDBProjection
+          .atLeastOnceGroupedWithin(
+            projectionId,
+            Some(settings.withReplayOnRejectedSequenceNumbers(true)),
+            sourceProvider,
+            handler = () => handler)
+          .withGroup(2, 3.seconds)
+
+      offsetShouldBeEmpty()
+
+      projectionTestKit.run(projection) {
+        results.get(pid1) shouldBe "|e1|e2|e3|e4|e5|e6|e7|e8|e9|"
+        results.get(pid2) shouldBe "|e1|e2|e3|e4|e5|e6|e7|e8|e9|"
+      }
+
+      eventually {
+        latestOffsetShouldBe(allEnvelopes.last.offset)
+      }
+    }
   }
 
   "A DynamoDB flow projection with TimestampOffset" must {

--- a/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
+++ b/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
@@ -1830,6 +1830,113 @@ class DynamoDBTimestampOffsetProjectionSpec
         latestOffsetShouldBe(envelopes.last.offset)
       }
     }
+
+    "replay rejected sequence numbers for flow projection" in {
+      val pid1 = UUID.randomUUID().toString
+      val pid2 = UUID.randomUUID().toString
+      val projectionId = genRandomProjectionId()
+
+      val allEnvelopes = createEnvelopes(pid1, 6) ++ createEnvelopes(pid2, 3)
+      val envelopes = allEnvelopes.filterNot { env =>
+        (env.persistenceId == pid1 && (env.sequenceNr == 3 || env.sequenceNr == 4 || env.sequenceNr == 5)) ||
+        (env.persistenceId == pid2 && (env.sequenceNr == 1))
+      }
+
+      val sourceProvider =
+        createSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
+
+      implicit val offsetStore: DynamoDBOffsetStore =
+        new DynamoDBOffsetStore(projectionId, Some(sourceProvider), system, settings, client)
+
+      offsetShouldBeEmpty()
+
+      val flowHandler =
+        FlowWithContext[EventEnvelope[String], ProjectionContext]
+          .mapAsync(1) { env =>
+            repository.concatToText(env.persistenceId, env.event)
+          }
+
+      val projection =
+        DynamoDBProjection
+          .atLeastOnceFlow(
+            projectionId,
+            Some(settings.withReplayOnRejectedSequenceNumbers(true)),
+            sourceProvider,
+            handler = flowHandler)
+          .withSaveOffset(1, 1.minute)
+
+      projectionTestKit.run(projection) {
+        projectedValueShouldBe("e1|e2|e3|e4|e5|e6")(pid1)
+        projectedValueShouldBe("e1|e2|e3")(pid2)
+      }
+
+      eventually {
+        latestOffsetShouldBe(allEnvelopes.last.offset)
+      }
+    }
+
+    "replay rejected sequence numbers due to clock skew for flow projection" in {
+      val pid1 = UUID.randomUUID().toString
+      val pid2 = UUID.randomUUID().toString
+      val projectionId = genRandomProjectionId()
+
+      val start = tick().instant()
+
+      def createEnvelopesFor(
+          pid: Pid,
+          fromSeqNr: Int,
+          toSeqNr: Int,
+          fromTimestamp: Instant): immutable.IndexedSeq[EventEnvelope[String]] = {
+        (fromSeqNr to toSeqNr).map { n =>
+          createEnvelope(pid, n, fromTimestamp.plusSeconds(n - fromSeqNr), s"e$n")
+        }
+      }
+
+      val envelopes1 =
+        createEnvelopesFor(pid1, 1, 2, start) ++
+        createEnvelopesFor(pid1, 3, 4, start.plusSeconds(4)) ++ // gap
+        createEnvelopesFor(pid1, 5, 9, start.plusSeconds(2)) // clock skew, back 2, and then overlapping
+
+      val envelopes2 =
+        createEnvelopesFor(pid2, 1, 3, start.plusSeconds(10)) ++
+        createEnvelopesFor(pid2, 4, 6, start.plusSeconds(1)) ++ // clock skew, back 9
+        createEnvelopesFor(pid2, 7, 9, start.plusSeconds(20)) // and gap
+
+      val allEnvelopes = envelopes1 ++ envelopes2
+
+      val envelopes = allEnvelopes.sortBy(_.timestamp)
+      val sourceProvider =
+        createSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
+
+      implicit val offsetStore: DynamoDBOffsetStore =
+        new DynamoDBOffsetStore(projectionId, Some(sourceProvider), system, settings, client)
+
+      offsetShouldBeEmpty()
+
+      val flowHandler =
+        FlowWithContext[EventEnvelope[String], ProjectionContext]
+          .mapAsync(1) { env =>
+            repository.concatToText(env.persistenceId, env.event)
+          }
+
+      val projection =
+        DynamoDBProjection
+          .atLeastOnceFlow(
+            projectionId,
+            Some(settings.withReplayOnRejectedSequenceNumbers(true)),
+            sourceProvider,
+            handler = flowHandler)
+          .withSaveOffset(1, 1.minute)
+
+      projectionTestKit.run(projection) {
+        projectedValueShouldBe("e1|e2|e3|e4|e5|e6|e7|e8|e9")(pid1)
+        projectedValueShouldBe("e1|e2|e3|e4|e5|e6|e7|e8|e9")(pid2)
+      }
+
+      eventually {
+        latestOffsetShouldBe(allEnvelopes.last.offset)
+      }
+    }
   }
 
   // FIXME see more tests in R2dbcTimestampOffsetProjectionSpec

--- a/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
+++ b/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
@@ -1488,6 +1488,107 @@ class DynamoDBTimestampOffsetProjectionSpec
       latestOffsetShouldBe(envelopes.last.offset)
     }
 
+    "replay rejected sequence numbers for exactly-once grouped" in {
+      val pid1 = UUID.randomUUID().toString
+      val pid2 = UUID.randomUUID().toString
+      val projectionId = genRandomProjectionId()
+
+      val allEnvelopes = createEnvelopes(pid1, 10) ++ createEnvelopes(pid2, 3)
+      val skipPid1SeqNrs = Set(3L, 4L, 5L, 7L, 9L)
+      val envelopes = allEnvelopes.filterNot { env =>
+        (env.persistenceId == pid1 && skipPid1SeqNrs(env.sequenceNr)) ||
+        (env.persistenceId == pid2 && (env.sequenceNr == 1))
+      }
+
+      val sourceProvider =
+        createSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
+
+      implicit val offsetStore: DynamoDBOffsetStore =
+        new DynamoDBOffsetStore(projectionId, Some(sourceProvider), system, settings, client)
+
+      val handlerProbe = createTestProbe[String]("calls-to-handler")
+
+      val projectionRef = spawn(
+        ProjectionBehavior(
+          DynamoDBProjection
+            .exactlyOnceGroupedWithin(
+              projectionId,
+              Some(settings.withReplayOnRejectedSequenceNumbers(true)),
+              sourceProvider,
+              handler = () => new TransactGroupedConcatHandler(handlerProbe.ref))
+            .withGroup(8, 3.seconds)))
+
+      eventually {
+        projectedTestValueShouldBe("e1|e2|e3|e4|e5|e6|e7|e8|e9|e10")(pid1)
+        projectedTestValueShouldBe("e1|e2|e3")(pid2)
+      }
+
+      eventually {
+        latestOffsetShouldBe(allEnvelopes.last.offset)
+      }
+      projectionRef ! ProjectionBehavior.Stop
+    }
+
+    "replay rejected sequence numbers due to clock skew on event write for exactly-once grouped" in {
+      val pid1 = UUID.randomUUID().toString
+      val pid2 = UUID.randomUUID().toString
+      val projectionId = genRandomProjectionId()
+
+      val start = tick().instant()
+
+      def createEnvelopesFor(
+          pid: Pid,
+          fromSeqNr: Int,
+          toSeqNr: Int,
+          fromTimestamp: Instant): immutable.IndexedSeq[EventEnvelope[String]] = {
+        (fromSeqNr to toSeqNr).map { n =>
+          createEnvelope(pid, n, fromTimestamp.plusSeconds(n - fromSeqNr), s"e$n")
+        }
+      }
+
+      val envelopes1 =
+        createEnvelopesFor(pid1, 1, 2, start) ++
+        createEnvelopesFor(pid1, 3, 4, start.plusSeconds(4)) ++ // gap
+        createEnvelopesFor(pid1, 5, 9, start.plusSeconds(2)) // clock skew, back 2, and then overlapping
+
+      val envelopes2 =
+        createEnvelopesFor(pid2, 1, 3, start.plusSeconds(10)) ++
+        createEnvelopesFor(pid2, 4, 6, start.plusSeconds(1)) ++ // clock skew, back 9
+        createEnvelopesFor(pid2, 7, 9, start.plusSeconds(20)) // and gap
+
+      val allEnvelopes = envelopes1 ++ envelopes2
+
+      val envelopes = allEnvelopes.sortBy(_.timestamp)
+
+      val sourceProvider =
+        createSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
+
+      implicit val offsetStore: DynamoDBOffsetStore =
+        new DynamoDBOffsetStore(projectionId, Some(sourceProvider), system, settings, client)
+
+      val handlerProbe = createTestProbe[String]("calls-to-handler")
+
+      val projectionRef = spawn(
+        ProjectionBehavior(
+          DynamoDBProjection
+            .exactlyOnceGroupedWithin(
+              projectionId,
+              Some(settings.withReplayOnRejectedSequenceNumbers(true)),
+              sourceProvider,
+              handler = () => new TransactGroupedConcatHandler(handlerProbe.ref))
+            .withGroup(8, 3.seconds)))
+
+      eventually {
+        projectedTestValueShouldBe("e1|e2|e3|e4|e5|e6|e7|e8|e9")(pid1)
+        projectedTestValueShouldBe("e1|e2|e3|e4|e5|e6|e7|e8|e9")(pid2)
+      }
+
+      eventually {
+        latestOffsetShouldBe(allEnvelopes.last.offset)
+      }
+      projectionRef ! ProjectionBehavior.Stop
+    }
+
     "handle at-least-once grouped projection" in {
       val pid1 = UUID.randomUUID().toString
       val pid2 = UUID.randomUUID().toString

--- a/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
+++ b/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
@@ -1571,9 +1571,9 @@ class DynamoDBTimestampOffsetProjectionSpec
       val pid2 = UUID.randomUUID().toString
       val projectionId = genRandomProjectionId()
 
-      val allEnvelopes = createEnvelopes(pid1, 6) ++ createEnvelopes(pid2, 3)
+      val allEnvelopes = createEnvelopes(pid1, 10) ++ createEnvelopes(pid2, 3)
       val envelopes = allEnvelopes.filterNot { env =>
-        (env.persistenceId == pid1 && (env.sequenceNr == 3 || env.sequenceNr == 4 || env.sequenceNr == 5)) ||
+        (env.persistenceId == pid1 && (env.sequenceNr == 3 || env.sequenceNr == 4 || env.sequenceNr == 5 || env.sequenceNr == 7 || env.sequenceNr == 9)) ||
         (env.persistenceId == pid2 && (env.sequenceNr == 1))
       }
 
@@ -1602,12 +1602,12 @@ class DynamoDBTimestampOffsetProjectionSpec
             Some(settings.withReplayOnRejectedSequenceNumbers(true)),
             sourceProvider,
             handler = () => handler)
-          .withGroup(2, 3.seconds)
+          .withGroup(8, 3.seconds)
 
       offsetShouldBeEmpty()
 
       projectionTestKit.run(projection) {
-        results.get(pid1) shouldBe "|e1|e2|e3|e4|e5|e6|"
+        results.get(pid1) shouldBe "|e1|e2|e3|e4|e5|e6|e7|e8|e9|e10|"
         results.get(pid2) shouldBe "|e1|e2|e3|"
       }
 

--- a/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
+++ b/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
@@ -897,8 +897,9 @@ class DynamoDBTimestampOffsetProjectionSpec
       val projectionId = genRandomProjectionId()
 
       val allEnvelopes = createEnvelopes(pid1, 6) ++ createEnvelopes(pid2, 3)
+      val skipPid1SeqNrs = Set(3L, 4L, 5L)
       val envelopes = allEnvelopes.filterNot { env =>
-        (env.persistenceId == pid1 && (env.sequenceNr == 3 || env.sequenceNr == 4 || env.sequenceNr == 5)) ||
+        (env.persistenceId == pid1 && skipPid1SeqNrs(env.sequenceNr)) ||
         (env.persistenceId == pid2 && (env.sequenceNr == 1))
       }
 
@@ -1572,8 +1573,9 @@ class DynamoDBTimestampOffsetProjectionSpec
       val projectionId = genRandomProjectionId()
 
       val allEnvelopes = createEnvelopes(pid1, 10) ++ createEnvelopes(pid2, 3)
+      val skipPid1SeqNrs = Set(3L, 4L, 5L, 7L, 9L)
       val envelopes = allEnvelopes.filterNot { env =>
-        (env.persistenceId == pid1 && (env.sequenceNr == 3 || env.sequenceNr == 4 || env.sequenceNr == 5 || env.sequenceNr == 7 || env.sequenceNr == 9)) ||
+        (env.persistenceId == pid1 && skipPid1SeqNrs(env.sequenceNr)) ||
         (env.persistenceId == pid2 && (env.sequenceNr == 1))
       }
 
@@ -1837,8 +1839,9 @@ class DynamoDBTimestampOffsetProjectionSpec
       val projectionId = genRandomProjectionId()
 
       val allEnvelopes = createEnvelopes(pid1, 6) ++ createEnvelopes(pid2, 3)
+      val skipPid1SeqNrs = Set(3L, 4L, 5L)
       val envelopes = allEnvelopes.filterNot { env =>
-        (env.persistenceId == pid1 && (env.sequenceNr == 3 || env.sequenceNr == 4 || env.sequenceNr == 5)) ||
+        (env.persistenceId == pid1 && skipPid1SeqNrs(env.sequenceNr)) ||
         (env.persistenceId == pid2 && (env.sequenceNr == 1))
       }
 

--- a/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
+++ b/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetProjectionSpec.scala
@@ -1176,6 +1176,7 @@ class DynamoDBTimestampOffsetProjectionSpec
       offsetShouldBeEmpty()
       projectionTestKit.run(projection) {
         projectedTestValueShouldBe("e1|e2|e5")
+        offsetStore.storedSeqNr(pid).futureValue shouldBe 6
       }
       latestOffsetShouldBe(envelopes.last.offset)
     }

--- a/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/TestSourceProviderWithInput.scala
+++ b/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/TestSourceProviderWithInput.scala
@@ -23,15 +23,19 @@ import akka.persistence.query.typed.EventEnvelope
 import akka.persistence.query.typed.scaladsl.EventTimestampQuery
 import akka.persistence.query.typed.scaladsl.LoadEventQuery
 import akka.projection.BySlicesSourceProvider
+import akka.projection.eventsourced.scaladsl.EventSourcedProvider.LoadEventsByPersistenceIdSourceProvider
 import akka.projection.scaladsl.SourceProvider
 import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.Source
 
-class TestSourceProviderWithInput()(implicit val system: ActorSystem[_])
+class TestSourceProviderWithInput(enableCurrentEventsByPersistenceId: Boolean)(implicit val system: ActorSystem[_])
     extends SourceProvider[TimestampOffset, EventEnvelope[String]]
     with BySlicesSourceProvider
     with EventTimestampQuery
-    with LoadEventQuery {
+    with LoadEventQuery
+    with LoadEventsByPersistenceIdSourceProvider[String] {
+
+  def this()(implicit system: ActorSystem[_]) = this(enableCurrentEventsByPersistenceId = false)
 
   private implicit val ec: ExecutionContext = system.executionContext
   private val persistenceExt = Persistence(system)
@@ -95,5 +99,23 @@ class TestSourceProviderWithInput()(implicit val system: ActorSystem[_])
           new NoSuchElementException(
             s"Event with persistenceId [$persistenceId] and sequenceNr [$sequenceNr] not found."))
     }
+  }
+
+  override private[akka] def currentEventsByPersistenceId(
+      persistenceId: String,
+      fromSequenceNr: Long,
+      toSequenceNr: Long): Option[Source[EventEnvelope[String], NotUsed]] = {
+    if (enableCurrentEventsByPersistenceId)
+      Some(
+        Source(
+          envelopes
+            .iterator()
+            .asScala
+            .filter { env =>
+              env.persistenceId == persistenceId && env.sequenceNr >= fromSequenceNr && env.sequenceNr <= toSequenceNr
+            }
+            .toVector))
+    else
+      None
   }
 }

--- a/akka-projection-dynamodb/src/main/mima-filters/1.6.3.backwards.excludes/offset-store.excludes
+++ b/akka-projection-dynamodb/src/main/mima-filters/1.6.3.backwards.excludes/offset-store.excludes
@@ -1,0 +1,2 @@
+# internal
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.dynamodb.internal.DynamoDBOffsetStore#State.evict")

--- a/akka-projection-dynamodb/src/main/resources/reference.conf
+++ b/akka-projection-dynamodb/src/main/resources/reference.conf
@@ -45,7 +45,7 @@ akka.projection.dynamodb {
   }
 
   # Replay missed events for a particular persistence id when a sequence number is rejected by validation.
-  replay-on-rejected-sequence-numbers = off
+  replay-on-rejected-sequence-numbers = on
 
   # By default it shares DynamoDB client with akka-persistence-dynamodb (write side).
   # To use a separate client for projections this can be

--- a/akka-projection-dynamodb/src/main/resources/reference.conf
+++ b/akka-projection-dynamodb/src/main/resources/reference.conf
@@ -44,6 +44,9 @@ akka.projection.dynamodb {
     }
   }
 
+  # Replay missed events for a particular persistence id when a sequence number is rejected by validation.
+  replay-on-rejected-sequence-numbers = off
+
   # By default it shares DynamoDB client with akka-persistence-dynamodb (write side).
   # To use a separate client for projections this can be
   # set to another config path that defines the config based on

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/DynamoDBProjectionSettings.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/DynamoDBProjectionSettings.scala
@@ -48,7 +48,8 @@ object DynamoDBProjectionSettings {
       offsetBatchSize = config.getInt("offset-store.offset-batch-size"),
       offsetSliceReadParallelism = config.getInt("offset-store.offset-slice-read-parallelism"),
       timeToLiveSettings = TimeToLiveSettings(config.getConfig("time-to-live")),
-      retrySettings = RetrySettings(config.getConfig("offset-store.retries")))
+      retrySettings = RetrySettings(config.getConfig("offset-store.retries")),
+      replayOnRejectedSequenceNumbers = config.getBoolean("replay-on-rejected-sequence-numbers"))
   }
 
   /**
@@ -72,7 +73,8 @@ final class DynamoDBProjectionSettings private (
     val offsetBatchSize: Int,
     val offsetSliceReadParallelism: Int,
     val timeToLiveSettings: TimeToLiveSettings,
-    val retrySettings: RetrySettings) {
+    val retrySettings: RetrySettings,
+    val replayOnRejectedSequenceNumbers: Boolean) {
 
   // 25 is a hard limit of batch writes in DynamoDB
   require(offsetBatchSize <= 25, s"offset-batch-size must be <= 25, was [$offsetBatchSize]")
@@ -122,6 +124,9 @@ final class DynamoDBProjectionSettings private (
   def withRetrySettings(retrySettings: RetrySettings): DynamoDBProjectionSettings =
     copy(retrySettings = retrySettings)
 
+  def withReplayOnRejectedSequenceNumbers(replayOnRejectedSequenceNumbers: Boolean): DynamoDBProjectionSettings =
+    copy(replayOnRejectedSequenceNumbers = replayOnRejectedSequenceNumbers)
+
   @nowarn("msg=deprecated")
   private def copy(
       timestampOffsetTable: String = timestampOffsetTable,
@@ -132,7 +137,8 @@ final class DynamoDBProjectionSettings private (
       offsetBatchSize: Int = offsetBatchSize,
       offsetSliceReadParallelism: Int = offsetSliceReadParallelism,
       timeToLiveSettings: TimeToLiveSettings = timeToLiveSettings,
-      retrySettings: RetrySettings = retrySettings) =
+      retrySettings: RetrySettings = retrySettings,
+      replayOnRejectedSequenceNumbers: Boolean = replayOnRejectedSequenceNumbers) =
     new DynamoDBProjectionSettings(
       timestampOffsetTable,
       useClient,
@@ -144,10 +150,24 @@ final class DynamoDBProjectionSettings private (
       offsetBatchSize,
       offsetSliceReadParallelism,
       timeToLiveSettings,
-      retrySettings)
+      retrySettings,
+      replayOnRejectedSequenceNumbers)
 
-  override def toString =
-    s"DynamoDBProjectionSettings($timestampOffsetTable, $useClient, $timeWindow, $backtrackingWindow, $warnAboutFilteredEventsInFlow, $offsetBatchSize)"
+  @nowarn("msg=deprecated")
+  override def toString: String =
+    s"DynamoDBProjectionSettings(" +
+    s"timestampOffsetTable=$timestampOffsetTable, " +
+    s"useClient=$useClient, " +
+    s"timeWindow=$timeWindow, " +
+    s"backtrackingWindow=$backtrackingWindow, " +
+    s"keepNumberOfEntries=$keepNumberOfEntries, " +
+    s"evictInterval=$evictInterval, " +
+    s"warnAboutFilteredEventsInFlow=$warnAboutFilteredEventsInFlow, " +
+    s"offsetBatchSize=$offsetBatchSize, " +
+    s"offsetSliceReadParallelism=$offsetSliceReadParallelism, " +
+    s"timeToLiveSettings=$timeToLiveSettings, " +
+    s"retrySettings=$retrySettings, " +
+    s"replayOnRejectedSequenceNumbers=$replayOnRejectedSequenceNumbers)"
 }
 
 object TimeToLiveSettings {

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -622,7 +622,6 @@ private[projection] class DynamoDBOffsetStore(
           // always accept starting from snapshots when there was no previous event seen
           FutureAccepted
         } else {
-          println(s"# validateEventTimestamp $recordWithOffset") // FIXME
           validateEventTimestamp(currentState, recordWithOffset)
         }
       } else {

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -605,10 +605,14 @@ private[projection] class DynamoDBOffsetStore(
             FutureAccepted
           } else if (!recordWithOffset.fromBacktracking) {
             logUnexpected()
+            // Rejected will trigger replay of missed events, if replay-on-rejected-sequence-numbers is enabled
+            // and SourceProvider supports it.
             FutureRejectedSeqNr
           } else {
             logUnexpected()
-            // This will result in projection restart (with normal configuration)
+            // Rejected will trigger replay of missed events, if replay-on-rejected-sequence-numbers is enabled
+            // and SourceProvider supports it.
+            // Otherwise this will result in projection restart (with normal configuration).
             FutureRejectedBacktrackingSeqNr
           }
         } else if (seqNr == 1) {
@@ -618,6 +622,7 @@ private[projection] class DynamoDBOffsetStore(
           // always accept starting from snapshots when there was no previous event seen
           FutureAccepted
         } else {
+          println(s"# validateEventTimestamp $recordWithOffset") // FIXME
           validateEventTimestamp(currentState, recordWithOffset)
         }
       } else {
@@ -682,6 +687,8 @@ private[projection] class DynamoDBOffsetStore(
             previousTimestamp,
             currentState.startTimestampBySlice(slice),
             settings.backtrackingWindow)
+          // Rejected will trigger replay of missed events, if replay-on-rejected-sequence-numbers is enabled
+          // and SourceProvider supports it.
           RejectedBacktrackingSeqNr
         } else {
           // This may happen rather frequently when using `publish-events`, after reconnecting and such.
@@ -690,6 +697,8 @@ private[projection] class DynamoDBOffsetStore(
             seqNr,
             pid,
             recordWithOffset.offset)
+          // Rejected will trigger replay of missed events, if replay-on-rejected-sequence-numbers is enabled
+          // and SourceProvider supports it.
           // Backtracking will emit missed event again.
           RejectedSeqNr
         }

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -217,7 +217,7 @@ private[projection] class DynamoDBOffsetStore(
   }
 
   private val logger = LoggerFactory.getLogger(this.getClass)
-  private val logPrefix = s"${projectionId.name} [$minSlice-$maxSlice]:"
+  val logPrefix = s"${projectionId.name} [$minSlice-$maxSlice]:"
 
   private val dao = new OffsetStoreDao(system, settings, projectionId, client)
 

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -203,7 +203,7 @@ private[projection] class DynamoDBOffsetStore(
     projectionId: ProjectionId,
     sourceProvider: Option[BySlicesSourceProvider],
     system: ActorSystem[_],
-    settings: DynamoDBProjectionSettings,
+    val settings: DynamoDBProjectionSettings,
     client: DynamoDbAsyncClient,
     clock: Clock = Clock.systemUTC()) {
 

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBProjectionImpl.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBProjectionImpl.scala
@@ -610,7 +610,7 @@ private[projection] object DynamoDBProjectionImpl {
                         } else {
                           // FIXME: filtered envelopes are not passed through, so we can't expect all to be replayed here
                           //        and handler could also filter out envelopes
-                          log.warn(
+                          log.debug(
                             "{} Replay due to rejected envelope found [{}] events, but expected [{}]. PersistenceId [{}] from seqNr [{}] to [{}].",
                             offsetStore.logPrefix,
                             count,

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBProjectionImpl.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBProjectionImpl.scala
@@ -215,6 +215,7 @@ private[projection] object DynamoDBProjectionImpl {
       }
 
       private def replayIfPossible(originalEnvelope: Envelope): Future[Boolean] = {
+        val logPrefix = offsetStore.logPrefix
         originalEnvelope match {
           case originalEventEnvelope: EventEnvelope[Any @unchecked] if originalEventEnvelope.sequenceNr > 1 =>
             sourceProvider match {
@@ -224,7 +225,7 @@ private[projection] object DynamoDBProjectionImpl {
                 offsetStore.storedSeqNr(persistenceId).flatMap { storedSeqNr =>
                   val fromSeqNr = storedSeqNr + 1
                   val toSeqNr = originalEventEnvelope.sequenceNr
-                  logReplayRejected(offsetStore, persistenceId, fromSeqNr, toSeqNr)
+                  logReplayRejected(logPrefix, persistenceId, fromSeqNr, toSeqNr)
                   provider.currentEventsByPersistenceId(persistenceId, fromSeqNr, toSeqNr) match {
                     case Some(querySource) =>
                       querySource
@@ -264,25 +265,12 @@ private[projection] object DynamoDBProjectionImpl {
                             true
                           } else {
                             // it's expected to find all events, otherwise fail the replay attempt
-                            log.warn(
-                              "{} Replay due to rejected envelope found [{}] events, but expected [{}]. PersistenceId [{}] from seqNr [{}] to [{}].",
-                              offsetStore.logPrefix,
-                              count,
-                              expected,
-                              persistenceId,
-                              fromSeqNr,
-                              toSeqNr)
+                            logReplayInvalidCount(logPrefix, persistenceId, fromSeqNr, toSeqNr, count, expected)
                             throwRejectedEnvelopeAfterFailedReplay(sourceProvider, originalEnvelope)
                           }
                         }
                         .recoverWith { exc =>
-                          log.warn(
-                            "{} Replay due to rejected envelope failed. PersistenceId [{}] from seqNr [{}] to [{}].",
-                            offsetStore.logPrefix,
-                            persistenceId,
-                            fromSeqNr,
-                            originalEventEnvelope.sequenceNr,
-                            exc)
+                          logReplayException(logPrefix, persistenceId, fromSeqNr, toSeqNr, exc)
                           Future.failed(exc)
                         }
                     case None => FutureFalse
@@ -338,6 +326,7 @@ private[projection] object DynamoDBProjectionImpl {
       }
 
       private def replayIfPossible(originalEnvelope: Envelope): Future[Boolean] = {
+        val logPrefix = offsetStore.logPrefix
         originalEnvelope match {
           case originalEventEnvelope: EventEnvelope[Any @unchecked] if originalEventEnvelope.sequenceNr > 1 =>
             sourceProvider match {
@@ -347,7 +336,7 @@ private[projection] object DynamoDBProjectionImpl {
                 offsetStore.storedSeqNr(persistenceId).flatMap { storedSeqNr =>
                   val fromSeqNr = storedSeqNr + 1
                   val toSeqNr = originalEventEnvelope.sequenceNr
-                  logReplayRejected(offsetStore, persistenceId, fromSeqNr, toSeqNr)
+                  logReplayRejected(logPrefix, persistenceId, fromSeqNr, toSeqNr)
                   provider.currentEventsByPersistenceId(persistenceId, fromSeqNr, toSeqNr) match {
                     case Some(querySource) =>
                       querySource
@@ -384,25 +373,12 @@ private[projection] object DynamoDBProjectionImpl {
                             true
                           } else {
                             // it's expected to find all events, otherwise fail the replay attempt
-                            log.warn(
-                              "{} Replay due to rejected envelope found [{}] events, but expected [{}]. PersistenceId [{}] from seqNr [{}] to [{}].",
-                              offsetStore.logPrefix,
-                              count,
-                              expected,
-                              persistenceId,
-                              fromSeqNr,
-                              toSeqNr)
+                            logReplayInvalidCount(logPrefix, persistenceId, fromSeqNr, toSeqNr, count, expected)
                             throwRejectedEnvelopeAfterFailedReplay(sourceProvider, originalEnvelope)
                           }
                         }
                         .recoverWith { exc =>
-                          log.warn(
-                            "{} Replay due to rejected envelope failed. PersistenceId [{}] from seqNr [{}] to [{}].",
-                            offsetStore.logPrefix,
-                            persistenceId,
-                            fromSeqNr,
-                            originalEventEnvelope.sequenceNr,
-                            exc)
+                          logReplayException(logPrefix, persistenceId, fromSeqNr, toSeqNr, exc)
                           Future.failed(exc)
                         }
                     case None => FutureFalse
@@ -499,6 +475,7 @@ private[projection] object DynamoDBProjectionImpl {
       }
 
       private def replayIfPossible(originalEnvelope: Envelope): Future[Boolean] = {
+        val logPrefix = offsetStore.logPrefix
         originalEnvelope match {
           case originalEventEnvelope: EventEnvelope[Any @unchecked] if originalEventEnvelope.sequenceNr > 1 =>
             sourceProvider match {
@@ -508,7 +485,7 @@ private[projection] object DynamoDBProjectionImpl {
                 offsetStore.storedSeqNr(persistenceId).flatMap { storedSeqNr =>
                   val fromSeqNr = storedSeqNr + 1
                   val toSeqNr = originalEventEnvelope.sequenceNr
-                  logReplayRejected(offsetStore, persistenceId, fromSeqNr, toSeqNr)
+                  logReplayRejected(logPrefix, persistenceId, fromSeqNr, toSeqNr)
                   provider.currentEventsByPersistenceId(persistenceId, fromSeqNr, toSeqNr) match {
                     case Some(querySource) =>
                       querySource
@@ -547,25 +524,12 @@ private[projection] object DynamoDBProjectionImpl {
                             true
                           } else {
                             // it's expected to find all events, otherwise fail the replay attempt
-                            log.warn(
-                              "{} Replay due to rejected envelope found [{}] events, but expected [{}]. PersistenceId [{}] from seqNr [{}] to [{}].",
-                              offsetStore.logPrefix,
-                              count,
-                              expected,
-                              persistenceId,
-                              fromSeqNr,
-                              toSeqNr)
+                            logReplayInvalidCount(logPrefix, persistenceId, fromSeqNr, toSeqNr, count, expected)
                             throwRejectedEnvelopeAfterFailedReplay(sourceProvider, originalEnvelope)
                           }
                         }
                         .recoverWith { exc =>
-                          log.warn(
-                            "{} Replay due to rejected envelope failed. PersistenceId [{}] from seqNr [{}] to [{}].",
-                            offsetStore.logPrefix,
-                            persistenceId,
-                            fromSeqNr,
-                            originalEventEnvelope.sequenceNr,
-                            exc)
+                          logReplayException(logPrefix, persistenceId, fromSeqNr, toSeqNr, exc)
                           Future.failed(exc)
                         }
                     case None => FutureFalse
@@ -664,6 +628,7 @@ private[projection] object DynamoDBProjectionImpl {
       }
 
       private def replayIfPossible(originalEnvelope: Envelope): Future[Boolean] = {
+        val logPrefix = offsetStore.logPrefix
         originalEnvelope match {
           case originalEventEnvelope: EventEnvelope[Any @unchecked] if originalEventEnvelope.sequenceNr > 1 =>
             sourceProvider match {
@@ -673,7 +638,7 @@ private[projection] object DynamoDBProjectionImpl {
                 offsetStore.storedSeqNr(persistenceId).flatMap { storedSeqNr =>
                   val fromSeqNr = storedSeqNr + 1
                   val toSeqNr = originalEventEnvelope.sequenceNr
-                  logReplayRejected(offsetStore, persistenceId, fromSeqNr, toSeqNr)
+                  logReplayRejected(logPrefix, persistenceId, fromSeqNr, toSeqNr)
                   provider.currentEventsByPersistenceId(persistenceId, fromSeqNr, toSeqNr) match {
                     case Some(querySource) =>
                       querySource
@@ -712,25 +677,12 @@ private[projection] object DynamoDBProjectionImpl {
                             true
                           } else {
                             // it's expected to find all events, otherwise fail the replay attempt
-                            log.warn(
-                              "{} Replay due to rejected envelope found [{}] events, but expected [{}]. PersistenceId [{}] from seqNr [{}] to [{}].",
-                              offsetStore.logPrefix,
-                              count,
-                              expected,
-                              persistenceId,
-                              fromSeqNr,
-                              toSeqNr)
+                            logReplayInvalidCount(logPrefix, persistenceId, fromSeqNr, toSeqNr, count, expected)
                             throwRejectedEnvelopeAfterFailedReplay(sourceProvider, originalEnvelope)
                           }
                         }
                         .recoverWith { exc =>
-                          log.warn(
-                            "{} Replay due to rejected envelope failed. PersistenceId [{}] from seqNr [{}] to [{}].",
-                            offsetStore.logPrefix,
-                            persistenceId,
-                            fromSeqNr,
-                            originalEventEnvelope.sequenceNr,
-                            exc)
+                          logReplayException(logPrefix, persistenceId, fromSeqNr, toSeqNr, exc)
                           Future.failed(exc)
                         }
                     case None => FutureFalse
@@ -758,6 +710,7 @@ private[projection] object DynamoDBProjectionImpl {
     implicit val ec: ExecutionContext = system.executionContext
 
     def replayIfPossible(originalEnvelope: Envelope): Future[Boolean] = {
+      val logPrefix = offsetStore.logPrefix
       originalEnvelope match {
         case originalEventEnvelope: EventEnvelope[Any @unchecked] if originalEventEnvelope.sequenceNr > 1 =>
           sourceProvider match {
@@ -767,7 +720,7 @@ private[projection] object DynamoDBProjectionImpl {
               offsetStore.storedSeqNr(persistenceId).flatMap { storedSeqNr =>
                 val fromSeqNr = storedSeqNr + 1
                 val toSeqNr = originalEventEnvelope.sequenceNr
-                logReplayRejected(offsetStore, persistenceId, fromSeqNr, toSeqNr)
+                logReplayRejected(logPrefix, persistenceId, fromSeqNr, toSeqNr)
                 provider.currentEventsByPersistenceId(persistenceId, fromSeqNr, toSeqNr) match {
                   case Some(querySource) =>
                     querySource
@@ -813,24 +766,17 @@ private[projection] object DynamoDBProjectionImpl {
                           //        and handler could also filter out envelopes
                           log.debug(
                             "{} Replay due to rejected envelope found [{}] events, but expected [{}]. PersistenceId [{}] from seqNr [{}] to [{}].",
-                            offsetStore.logPrefix,
+                            logPrefix,
                             count,
                             expected,
                             persistenceId,
                             fromSeqNr,
                             toSeqNr)
-                          // throwRejectedEnvelopeAfterFailedReplay(source, sourceProvider, originalEnvelope)
                           true
                         }
                       }
                       .recoverWith { exc =>
-                        log.warn(
-                          "{} Replay due to rejected envelope failed. PersistenceId [{}] from seqNr [{}] to [{}].",
-                          offsetStore.logPrefix,
-                          persistenceId,
-                          fromSeqNr,
-                          originalEventEnvelope.sequenceNr,
-                          exc)
+                        logReplayException(logPrefix, persistenceId, fromSeqNr, toSeqNr, exc)
                         Future.failed(exc)
                       }
                   case None => FutureFalse
@@ -876,18 +822,46 @@ private[projection] object DynamoDBProjectionImpl {
       .via(handler)
   }
 
-  private def logReplayRejected(
-      offsetStore: DynamoDBOffsetStore,
-      persistenceId: String,
-      fromSeqNr: Long,
-      toSeqNr: Long): Unit = {
+  private def logReplayRejected(logPrefix: String, persistenceId: String, fromSeqNr: Long, toSeqNr: Long): Unit = {
     val msg =
       "{} Replaying events after rejected sequence number. PersistenceId [{}], replaying from seqNr [{}] to [{}]. Replay count [{}]."
     val c = replayRejectedCounter.incrementAndGet()
     if (c == 1 || c % 1000 == 0)
-      log.warn(msg, offsetStore.logPrefix, persistenceId, fromSeqNr, toSeqNr, c)
+      log.warn(msg, logPrefix, persistenceId, fromSeqNr, toSeqNr, c)
     else
-      log.debug(msg, offsetStore.logPrefix, persistenceId, fromSeqNr, toSeqNr, c)
+      log.debug(msg, logPrefix, persistenceId, fromSeqNr, toSeqNr, c)
+  }
+
+  private def logReplayInvalidCount(
+      logPrefix: String,
+      persistenceId: String,
+      fromSeqNr: Long,
+      toSeqNr: Long,
+      count: Int,
+      expected: Long): Unit = {
+    log.warn(
+      "{} Replay due to rejected envelope found [{}] events, but expected [{}]. PersistenceId [{}] from seqNr [{}] to [{}].",
+      logPrefix,
+      count,
+      expected,
+      persistenceId,
+      fromSeqNr,
+      toSeqNr)
+  }
+
+  private def logReplayException(
+      logPrefix: String,
+      persistenceId: String,
+      fromSeqNr: Long,
+      toSeqNr: Long,
+      exc: Throwable): Unit = {
+    log.warn(
+      "{} Replay due to rejected envelope failed. PersistenceId [{}] from seqNr [{}] to [{}].",
+      logPrefix,
+      persistenceId,
+      fromSeqNr,
+      toSeqNr,
+      exc)
   }
 
   /**

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBProjectionImpl.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBProjectionImpl.scala
@@ -212,9 +212,7 @@ private[projection] object DynamoDBProjectionImpl {
           }
       }
 
-      private def replayIfPossible(source: String, originalEnvelope: Envelope)(
-          implicit ec: ExecutionContext,
-          system: ActorSystem[_]): Future[Boolean] = {
+      private def replayIfPossible(source: String, originalEnvelope: Envelope): Future[Boolean] = {
         originalEnvelope match {
           case originalEventEnvelope: EventEnvelope[Any @unchecked] if originalEventEnvelope.sequenceNr > 1 =>
             sourceProvider match {
@@ -448,9 +446,7 @@ private[projection] object DynamoDBProjectionImpl {
         }
       }
 
-      private def replayIfPossible(source: String, originalEnvelope: Envelope)(
-          implicit ec: ExecutionContext,
-          system: ActorSystem[_]): Future[Boolean] = {
+      private def replayIfPossible(source: String, originalEnvelope: Envelope): Future[Boolean] = {
         originalEnvelope match {
           case originalEventEnvelope: EventEnvelope[Any @unchecked] if originalEventEnvelope.sequenceNr > 1 =>
             sourceProvider match {

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBProjectionImpl.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBProjectionImpl.scala
@@ -217,8 +217,8 @@ private[projection] object DynamoDBProjectionImpl {
         originalEnvelope match {
           case originalEventEnvelope: EventEnvelope[Any @unchecked] if originalEventEnvelope.sequenceNr > 1 =>
             sourceProvider match {
-              // FIXME config to make this case opt in
-              case provider: LoadEventsByPersistenceIdSourceProvider[Any @unchecked] =>
+              case provider: LoadEventsByPersistenceIdSourceProvider[Any @unchecked]
+                  if offsetStore.settings.replayOnRejectedSequenceNumbers =>
                 val persistenceId = originalEventEnvelope.persistenceId
                 offsetStore.storedSeqNr(persistenceId).flatMap { storedSeqNr =>
                   val fromSeqNr = storedSeqNr + 1

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBProjectionImpl.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBProjectionImpl.scala
@@ -207,7 +207,7 @@ private[projection] object DynamoDBProjectionImpl {
             case RejectedBacktrackingSeqNr =>
               replayIfPossible("backtracking", envelope).map {
                 case true  => Done
-                case false => throwRejectedEnvelopeAfterFailedReplay("backtracking", sourceProvider, envelope)
+                case false => throwRejectedEnvelope(sourceProvider, envelope)
               }(ExecutionContext.parasitic)
           }
       }
@@ -224,6 +224,12 @@ private[projection] object DynamoDBProjectionImpl {
                 offsetStore.storedSeqNr(persistenceId).flatMap { storedSeqNr =>
                   val fromSeqNr = storedSeqNr + 1
                   val toSeqNr = originalEventEnvelope.sequenceNr
+                  log.debug(
+                    s"{} Replaying events after rejected sequence number. PersistenceId [{}], replaying from seqNr [{}] to [{}].",
+                    offsetStore.logPrefix,
+                    persistenceId,
+                    fromSeqNr,
+                    toSeqNr)
                   provider.currentEventsByPersistenceId(persistenceId, fromSeqNr, toSeqNr) match {
                     case Some(querySource) =>
                       querySource
@@ -406,9 +412,9 @@ private[projection] object DynamoDBProjectionImpl {
           val replayDone =
             Future.sequence(isAcceptedEnvelopes.map {
               case (env, RejectedSeqNr) =>
-                triggerReplayIfPossible(sourceProvider, offsetStore, env).map(_ => Done)(ExecutionContext.parasitic)
+                replayIfPossible("query", env).map(_ => Done)(ExecutionContext.parasitic)
               case (env, RejectedBacktrackingSeqNr) =>
-                triggerReplayIfPossible(sourceProvider, offsetStore, env).map {
+                replayIfPossible("backtracking", env).map {
                   case true  => Done
                   case false => throwRejectedEnvelope(sourceProvider, env)
                 }
@@ -439,6 +445,99 @@ private[projection] object DynamoDBProjectionImpl {
               }
             }
           }
+        }
+      }
+
+      private def replayIfPossible(source: String, originalEnvelope: Envelope)(
+          implicit ec: ExecutionContext,
+          system: ActorSystem[_]): Future[Boolean] = {
+        originalEnvelope match {
+          case originalEventEnvelope: EventEnvelope[Any @unchecked] if originalEventEnvelope.sequenceNr > 1 =>
+            sourceProvider match {
+              case provider: LoadEventsByPersistenceIdSourceProvider[Any @unchecked]
+                  if offsetStore.settings.replayOnRejectedSequenceNumbers =>
+                val persistenceId = originalEventEnvelope.persistenceId
+                offsetStore.storedSeqNr(persistenceId).flatMap { storedSeqNr =>
+                  val fromSeqNr = storedSeqNr + 1
+                  val toSeqNr = originalEventEnvelope.sequenceNr
+                  log.debug(
+                    s"{} Replaying events after rejected sequence number. PersistenceId [{}], replaying from seqNr [{}] to [{}].",
+                    offsetStore.logPrefix,
+                    persistenceId,
+                    fromSeqNr,
+                    toSeqNr)
+                  provider.currentEventsByPersistenceId(persistenceId, fromSeqNr, toSeqNr) match {
+                    case Some(querySource) =>
+                      querySource
+                        .mapAsync(1) { envelope =>
+                          import DynamoDBOffsetStore.Validation._
+                          offsetStore
+                            .validate(envelope)
+                            .flatMap {
+                              case Accepted =>
+                                // FIXME: should we be grouping the replayed envelopes? based on what?
+                                loadEnvelope(envelope.asInstanceOf[Envelope], sourceProvider).flatMap {
+                                  loadedEnvelope =>
+                                    val offset = extractOffsetPidSeqNr(sourceProvider, loadedEnvelope)
+                                    if (isFilteredEvent(loadedEnvelope)) {
+                                      offsetStore.saveOffset(offset)
+                                    } else {
+                                      delegate
+                                        .process(Seq(loadedEnvelope))
+                                        .flatMap { _ =>
+                                          offsetStore.saveOffset(offset)
+                                        }
+                                    }
+                                }
+                              case Duplicate =>
+                                FutureDone
+                              case RejectedSeqNr =>
+                                // this shouldn't happen
+                                throw new RejectedEnvelope(
+                                  s"Replay due to rejected envelope was rejected. PersistenceId [$persistenceId] seqNr [${envelope.sequenceNr}].")
+                              case RejectedBacktrackingSeqNr =>
+                                // this shouldn't happen
+                                throw new RejectedEnvelope(
+                                  s"Replay due to rejected envelope was rejected. Should not be from backtracking. PersistenceId [$persistenceId] seqNr [${envelope.sequenceNr}].")
+                            }
+                        }
+                        .runFold(0) { case (acc, _) => acc + 1 }
+                        .map { count =>
+                          val expected = toSeqNr - fromSeqNr + 1
+                          if (count == expected) {
+                            true
+                          } else {
+                            // it's expected to find all events, otherwise fail the replay attempt
+                            log.warn(
+                              "{} Replay due to rejected envelope found [{}] events, but expected [{}]. PersistenceId [{}] from seqNr [{}] to [{}].",
+                              offsetStore.logPrefix,
+                              count,
+                              expected,
+                              persistenceId,
+                              fromSeqNr,
+                              toSeqNr)
+                            throwRejectedEnvelopeAfterFailedReplay(source, sourceProvider, originalEnvelope)
+                          }
+                        }
+                        .recoverWith { exc =>
+                          log.warn(
+                            "{} Replay due to rejected envelope failed. PersistenceId [{}] from seqNr [{}] to [{}].",
+                            offsetStore.logPrefix,
+                            persistenceId,
+                            fromSeqNr,
+                            originalEventEnvelope.sequenceNr,
+                            exc)
+                          Future.failed(exc)
+                        }
+                    case None => FutureFalse
+                  }
+                }
+
+              case _ =>
+                triggerReplayIfPossible(sourceProvider, offsetStore, originalEnvelope)
+            }
+          case _ =>
+            FutureFalse // no replay support for non typed envelopes
         }
       }
     }

--- a/akka-projection-eventsourced/src/main/scala/akka/projection/eventsourced/javadsl/EventSourcedProvider.scala
+++ b/akka-projection-eventsourced/src/main/scala/akka/projection/eventsourced/javadsl/EventSourcedProvider.scala
@@ -22,12 +22,14 @@ import akka.persistence.query.Offset
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.query.javadsl.EventsByTagQuery
 import akka.persistence.query.javadsl.ReadJournal
+import akka.persistence.query.typed.javadsl.CurrentEventsByPersistenceIdTypedQuery
 import akka.persistence.query.typed.javadsl.EventTimestampQuery
 import akka.persistence.query.typed.javadsl.EventsBySliceQuery
 import akka.persistence.query.typed.javadsl.EventsBySliceStartingFromSnapshotsQuery
 import akka.persistence.query.typed.javadsl.LoadEventQuery
 import akka.projection.BySlicesSourceProvider
 import akka.projection.eventsourced.EventEnvelope
+import akka.projection.eventsourced.scaladsl.EventSourcedProvider.LoadEventsByPersistenceIdSourceProvider
 import akka.projection.internal.CanTriggerReplay
 import akka.projection.javadsl
 import akka.projection.javadsl.SourceProvider
@@ -277,7 +279,8 @@ object EventSourcedProvider {
       extends SourceProvider[Offset, akka.persistence.query.typed.EventEnvelope[Event]]
       with BySlicesSourceProvider
       with EventTimestampQuerySourceProvider
-      with LoadEventQuerySourceProvider {
+      with LoadEventQuerySourceProvider
+      with LoadEventsByPersistenceIdSourceProvider[Event] {
 
     override def readJournal: ReadJournal = eventsBySlicesQuery
 
@@ -296,6 +299,20 @@ object EventSourcedProvider {
     override def extractCreationTime(envelope: akka.persistence.query.typed.EventEnvelope[Event]): Long =
       envelope.timestamp
 
+    /**
+     * INTERNAL API
+     */
+    @InternalApi override private[akka] def currentEventsByPersistenceId(
+        persistenceId: String,
+        fromSequenceNr: Long,
+        toSequenceNr: Long)
+        : Option[akka.stream.scaladsl.Source[akka.persistence.query.typed.EventEnvelope[Event], NotUsed]] = {
+      eventsBySlicesQuery match {
+        case q: CurrentEventsByPersistenceIdTypedQuery =>
+          Some(q.currentEventsByPersistenceIdTyped[Event](persistenceId, fromSequenceNr, toSequenceNr).asScala)
+        case _ => None // not supported by this query
+      }
+    }
   }
 
   /**

--- a/akka-projection-eventsourced/src/main/scala/akka/projection/eventsourced/scaladsl/EventSourcedProvider.scala
+++ b/akka-projection-eventsourced/src/main/scala/akka/projection/eventsourced/scaladsl/EventSourcedProvider.scala
@@ -12,11 +12,13 @@ import scala.concurrent.Future
 
 import akka.NotUsed
 import akka.actor.typed.ActorSystem
+import akka.annotation.InternalApi
 import akka.persistence.query.NoOffset
 import akka.persistence.query.Offset
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.query.scaladsl.EventsByTagQuery
 import akka.persistence.query.scaladsl.ReadJournal
+import akka.persistence.query.typed.scaladsl.CurrentEventsByPersistenceIdTypedQuery
 import akka.persistence.query.typed.scaladsl.EventTimestampQuery
 import akka.persistence.query.typed.scaladsl.EventsBySliceQuery
 import akka.persistence.query.typed.scaladsl.EventsBySliceStartingFromSnapshotsQuery
@@ -251,7 +253,8 @@ object EventSourcedProvider {
       extends SourceProvider[Offset, akka.persistence.query.typed.EventEnvelope[Event]]
       with BySlicesSourceProvider
       with EventTimestampQuerySourceProvider
-      with LoadEventQuerySourceProvider {
+      with LoadEventQuerySourceProvider
+      with LoadEventsByPersistenceIdSourceProvider[Event] {
     implicit val executionContext: ExecutionContext = system.executionContext
 
     override def readJournal: ReadJournal = eventsBySlicesQuery
@@ -271,6 +274,19 @@ object EventSourcedProvider {
     override def extractCreationTime(envelope: akka.persistence.query.typed.EventEnvelope[Event]): Long =
       envelope.timestamp
 
+    /**
+     * INTERNAL API
+     */
+    @InternalApi override private[akka] def currentEventsByPersistenceId(
+        persistenceId: String,
+        fromSequenceNr: Long,
+        toSequenceNr: Long): Option[Source[akka.persistence.query.typed.EventEnvelope[Event], NotUsed]] = {
+      eventsBySlicesQuery match {
+        case q: CurrentEventsByPersistenceIdTypedQuery =>
+          Some(q.currentEventsByPersistenceIdTyped[Event](persistenceId, fromSequenceNr, toSequenceNr))
+        case _ => None // not supported by this query
+      }
+    }
   }
 
   private class EventsBySlicesStartingFromSnapshotsSourceProvider[Snapshot, Event](
@@ -339,6 +355,20 @@ object EventSourcedProvider {
             new IllegalStateException(
               s"[${readJournal.getClass.getName}] must implement [${classOf[LoadEventQuery].getName}]"))
       }
+  }
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] trait LoadEventsByPersistenceIdSourceProvider[Event] {
+
+    /**
+     * INTERNAL API
+     */
+    @InternalApi private[akka] def currentEventsByPersistenceId(
+        persistenceId: String,
+        fromSequenceNr: Long,
+        toSequenceNr: Long): Option[Source[akka.persistence.query.typed.EventEnvelope[Event], NotUsed]]
   }
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -180,8 +180,6 @@ lazy val dynamodb =
     .settings(Dependencies.dynamodb)
     .dependsOn(core, eventsourced)
     .disablePlugins(CiReleasePlugin)
-    // FIXME: No previous artifact, disable MiMa until first release
-    .settings(mimaPreviousArtifacts := Set.empty)
 
 lazy val dynamodbIntegration =
   Project(id = "akka-projection-dynamodb-integration", base = file("akka-projection-dynamodb-integration"))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,7 @@ object Dependencies {
       case Seq(major, minor, _*) => s"$major.$minor"
     }
 
-    val AkkaPersistenceDynamodb = "2.0.1"
+    val AkkaPersistenceDynamodb = "2.0.3"
     val AkkaPersistenceDynamodbVersionInDocs = VersionNumber(AkkaPersistenceDynamodb).numbers match {
       case Seq(major, minor, _*) => s"$major.$minor"
     }


### PR DESCRIPTION
To handle unforeseen cases of rejection it will replay missing events via CurrentEventsByPersistenceIdTypedQuery

Also bumps akka-persistence-dynamodb to 2.0.3, since CurrentEventsByPersistenceIdTypedQuery is implemented in that version.

Refs https://github.com/akka/akka-projection/issues/1276