### PR TITLE
fix(r2dbc): avoid unnecessary rejection given deleted offsets

### DIFF
--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -650,7 +650,7 @@ private[projection] class DynamoDBOffsetStore(
     val seqNr = recordWithOffset.record.seqNr
     val slice = recordWithOffset.record.slice
 
-    // Haven't see seen this pid within the time window. Since events can be missed
+    // Haven't seen this pid within the time window. Since events can be missed
     // when read at the tail we will only accept it if the event with previous seqNr has timestamp
     // before the startTimestamp minus backtracking window
     timestampOf(pid, seqNr - 1).map {

--- a/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
+++ b/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
@@ -460,11 +460,6 @@ class R2dbcTimestampOffsetStoreSpec
       val p5 = "p-08192" // slice 101 (same as p1)
       val p6 = "p-08076" // slice 106
 
-      // some validation require the startTimestamp, which is set from readOffset
-      offsetStore.getState().startTimestamp shouldBe Instant.EPOCH
-      offsetStore.readOffset().futureValue
-      offsetStore.getState().startTimestamp shouldBe clock.instant()
-
       val startTime = TestClock.nowMicros().instant()
       val offset1 = TimestampOffset(startTime, Map(p1 -> 3L, p2 -> 1L, p3 -> 5L))
       offsetStore.saveOffset(OffsetPidSeqNr(offset1, p1, 3L)).futureValue
@@ -1589,7 +1584,6 @@ class R2dbcTimestampOffsetStoreSpec
       // scaled up to 4 projections, testing 512-767
       val startOffset2 = TimestampOffset.toTimestampOffset(offsetStore2.readOffset().futureValue.get)
       startOffset2.timestamp shouldBe time(2)
-      offsetStore2.getState().startTimestamp shouldBe time(2)
       val latestTime = time(10)
       offsetStore2.saveOffset(OffsetPidSeqNr(TimestampOffset(latestTime, Map(p1 -> 2L)), p1, 2L)).futureValue
       offsetStore2.getState().latestTimestamp shouldBe latestTime

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcOffsetStore.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcOffsetStore.scala
@@ -4,7 +4,23 @@
 
 package akka.projection.r2dbc.internal
 
+import java.lang.Boolean.FALSE
+import java.lang.Boolean.TRUE
+import java.time.Clock
+import java.time.Instant
+import java.time.{ Duration => JDuration }
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.annotation.tailrec
+import scala.collection.immutable
+import scala.collection.immutable.TreeSet
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
 import akka.Done
+import akka.actor.Cancellable
 import akka.actor.typed.ActorSystem
 import akka.annotation.InternalApi
 import akka.persistence.Persistence
@@ -24,26 +40,10 @@ import akka.projection.internal.ManagementState
 import akka.projection.internal.OffsetSerialization
 import akka.projection.internal.OffsetSerialization.MultipleOffsets
 import akka.projection.r2dbc.R2dbcProjectionSettings
-import io.r2dbc.spi.Connection
-import org.slf4j.LoggerFactory
-import java.time.Clock
-import java.time.Instant
-import java.time.{ Duration => JDuration }
-import java.util.UUID
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicReference
-import java.lang.Boolean.FALSE
-import java.lang.Boolean.TRUE
-
-import scala.annotation.tailrec
-import scala.collection.immutable
-import scala.collection.immutable.TreeSet
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-
-import akka.actor.Cancellable
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
+import io.r2dbc.spi.Connection
+import org.slf4j.LoggerFactory
 
 /**
  * INTERNAL API
@@ -848,24 +848,25 @@ private[projection] class R2dbcOffsetStore(
     import Validation._
     val pid = recordWithOffset.record.pid
     val seqNr = recordWithOffset.record.seqNr
+    val slice = recordWithOffset.record.slice
 
-    // Haven't see seen this pid within the time window. Since events can be missed
-    // when read at the tail we will only accept it if the event with previous seqNr has timestamp
-    // before the startTimestamp minus backtracking window
+    // Haven't seen this pid in the time window (or lazy loaded from the database).
+    // Only accept it if the event with previous seqNr is outside the deletion window (for tracked slices).
     timestampOf(pid, seqNr - 1).map {
       case Some(previousTimestamp) =>
-        val acceptBefore = currentState.startTimestamp.minus(settings.backtrackingWindow)
+        val acceptBefore = currentState.bySliceSorted.get(slice).map { bySliceSorted =>
+          bySliceSorted.last.timestamp.minus(settings.deleteAfter)
+        }
 
-        if (previousTimestamp.isBefore(acceptBefore)) {
+        if (acceptBefore.exists(timestamp => previousTimestamp.isBefore(timestamp))) {
           logger.debug(
             "{} Accepting envelope with pid [{}], seqNr [{}], where previous event timestamp [{}] " +
-            "is before start timestamp [{}] minus backtracking window [{}].",
+            "is before deletion window timestamp [{}].",
             logPrefix,
             pid,
             seqNr,
             previousTimestamp,
-            currentState.startTimestamp,
-            settings.backtrackingWindow)
+            acceptBefore.get)
           Accepted
         } else if (recordWithOffset.fromPubSub) {
           // Rejected will trigger replay of missed events, if replay-on-rejected-sequence-numbers is enabled


### PR DESCRIPTION
We've been seeing unnecessary rejection (and replay) of events. There can be a large enough gap between events, so that all older offsets for a pid have been deleted, while the previous timestamp is after the start timestamp (minus the backtracking window, the current accept before time). Then any later events for that pid will be rejected.

Deletion is now per slice, offsets are lazy loaded when not in-memory, and the offset table should have at least the latest offset for each slice. So we can instead accept seq numbers if the previous offset could have been deleted (it's before the delete-until timestamp for its slice).

At first, because of other tests failing when a slice was untracked, I had it fallback to the previous accept-before timestamp (start minus backtracking). But given that any slice which has been seen by a projection will have at least the latest offset for that slice, then if the slice is not tracked (no deletion window can be defined) then we should always reject. Have updated other tests for this behaviour.

This only updates for R2DBC. We can make a similar change for DynamoDB, but based on TTL settings.