### PR TITLE
fix(dynamodb): avoid unnecessary rejection given expired offsets

### DIFF
--- a/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/TestClock.scala
+++ b/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/TestClock.scala
@@ -40,6 +40,14 @@ object TestClock {
   def setInstant(newInstant: Instant): Unit =
     _instant = newInstant.truncatedTo(resolution)
 
+  def withInstant[T](instant: Instant)(block: => T): T = {
+    val restore = _instant
+    try {
+      setInstant(instant)
+      block
+    } finally setInstant(restore)
+  }
+
   /**
    * Increase the clock with this duration (truncated to the resolution)
    */

--- a/akka-projection-dynamodb/src/main/mima-filters/1.6.5.backwards.excludes/dynamodb-offset-store.excludes
+++ b/akka-projection-dynamodb/src/main/mima-filters/1.6.5.backwards.excludes/dynamodb-offset-store.excludes
@@ -1,0 +1,2 @@
+# internal
+ProblemFilters.exclude[Problem]("akka.projection.dynamodb.internal.DynamoDBOffsetStore#State*")

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/OffsetStoreDao.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/OffsetStoreDao.scala
@@ -127,10 +127,6 @@ import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse
   def storeTimestampOffsets(offsetsBySlice: Map[Int, TimestampOffset]): Future[Done] = {
     import OffsetStoreDao.OffsetStoreAttributes._
 
-    val expiry = timeToLiveSettings.offsetTimeToLive.map { timeToLive =>
-      Instant.now().plusSeconds(timeToLive.toSeconds)
-    }
-
     def writeBatch(offsetsBatch: IndexedSeq[(Int, TimestampOffset)]): Future[Done] = {
       val writeItems =
         offsetsBatch.map {
@@ -154,10 +150,6 @@ import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse
               }
             }
             attributes.put(Seen, AttributeValue.fromM(seen))
-
-            expiry.foreach { timestamp =>
-              attributes.put(Expiry, AttributeValue.fromN(timestamp.getEpochSecond.toString))
-            }
 
             WriteRequest.builder
               .putRequest(


### PR DESCRIPTION
Similar changes as #1293 for DynamoDB, but using TTL expiry.

While for R2DBC, we're managing the offset deletion, and basing this on the event timestamps, for DynamoDB it's just a simple TTL expiry set when the offset is written. So we use an accept before time that's just based on now minus the expiry.

When looking at this, noticed the expiry set on the separate latest-by-slice offsets. To keep things safer, have removed this expiry, so we always keep this for restarting a projection, while the per-pid offsets will be expired.