### PR TITLE
fix: Wrong VersionVector when migrated from non-replicated

### DIFF
--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/EventProducerServiceSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/EventProducerServiceSpec.scala
@@ -258,13 +258,15 @@ class EventProducerServiceSpec
       .withReplicatedEventMetadataTransformation(
         env =>
           if (env.eventMetadata.isDefined) None
-          else
+          else {
+            // migrated from non-replicated, fill in metadata
             Some(
               ReplicatedEventMetadata(
                 originReplica = ReplicaId.empty,
                 originSequenceNr = env.sequenceNr,
-                version = VersionVector(env.persistenceId, env.sequenceNr),
-                concurrent = false))))
+                version = VersionVector(ReplicaId.empty.id, env.sequenceNr),
+                concurrent = false))
+          }))
 
   private val eventProducerService =
     new EventProducerServiceImpl(

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/EventProducerServiceSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/EventProducerServiceSpec.scala
@@ -613,14 +613,14 @@ class EventProducerServiceSpec
       protoAnySerialization.deserialize(out1.getEvent.metadata.get) shouldBe ReplicatedEventMetadata(
         originReplica = ReplicaId.empty,
         originSequenceNr = env1.sequenceNr,
-        version = VersionVector(env1.persistenceId, env1.sequenceNr),
+        version = VersionVector(ReplicaId.empty.id, env1.sequenceNr),
         concurrent = false)
 
       val out2 = probe.expectNext()
       protoAnySerialization.deserialize(out2.getEvent.metadata.get) shouldBe ReplicatedEventMetadata(
         originReplica = ReplicaId.empty,
         originSequenceNr = env2.sequenceNr,
-        version = VersionVector(env2.persistenceId, env2.sequenceNr),
+        version = VersionVector(ReplicaId.empty.id, env2.sequenceNr),
         concurrent = false)
     }
 

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/replication/internal/ReplicationImpl.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/replication/internal/ReplicationImpl.scala
@@ -110,7 +110,7 @@ private[akka] object ReplicationImpl {
             ReplicatedEventMetadata(
               originReplica = settings.selfReplicaId,
               originSequenceNr = env.sequenceNr,
-              version = VersionVector(env.persistenceId, env.sequenceNr),
+              version = VersionVector(settings.selfReplicaId.id, env.sequenceNr),
               concurrent = false))
         })
 
@@ -367,7 +367,7 @@ private[akka] object ReplicationImpl {
             ReplicatedEventMetadata(
               originReplica = settings.selfReplicaId,
               originSequenceNr = env.sequenceNr,
-              version = VersionVector(env.persistenceId, env.sequenceNr),
+              version = VersionVector(settings.selfReplicaId.id, env.sequenceNr),
               concurrent = false))
         })
 


### PR DESCRIPTION
* it should be replicaId and not persistenceId
