### PR TITLE
feat: Configuration to accept when previous is old

### DIFF
--- a/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
+++ b/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
@@ -602,6 +602,9 @@ class R2dbcTimestampOffsetStoreSpec
         eventTimestampQueryClock = eventTimestampQueryClock,
         customSettings = settings.withAcceptWhenPreviousTimestampBefore(startTime.minusSeconds(3600)))
 
+      val startOffset = offsetStore.readOffset[TimestampOffset]().futureValue
+      startOffset.get.timestamp shouldBe startTime.minusSeconds(3600)
+
       // these pids have the same slice 645
       val p1 = "p500" // slice 645
       val p2 = "p621" // same slice 645

--- a/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
+++ b/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
@@ -591,6 +591,36 @@ class R2dbcTimestampOffsetStoreSpec
       offsetStore.validate(createEnvelope(pid1, 6L, startTime, "e1-6")).futureValue shouldBe Duplicate
     }
 
+    "accept when previous timestamp is before configured accept-when-previous-timestamp-before" in {
+      import R2dbcOffsetStore.Validation._
+      val projectionId = genRandomProjectionId()
+      val eventTimestampQueryClock = TestClock.nowMicros()
+      val startTime = TestClock.nowMicros().instant()
+
+      val offsetStore = createOffsetStore(
+        projectionId,
+        eventTimestampQueryClock = eventTimestampQueryClock,
+        customSettings = settings.withAcceptWhenPreviousTimestampBefore(startTime.minusSeconds(3600)))
+
+      // these pids have the same slice 645
+      val p1 = "p500" // slice 645
+      val p2 = "p621" // same slice 645
+      // reject unknown
+      val offset1 = TimestampOffset(startTime.plusMillis(8), Map(p1 -> 7L))
+      val env1 = createEnvelope(p1, 7L, offset1.timestamp, "e1-7")
+      offsetStore.validate(env1).futureValue shouldBe RejectedSeqNr
+      offsetStore.validate(backtrackingEnvelope(env1)).futureValue shouldBe RejectedBacktrackingSeqNr
+      // but accepted if timestamp of previous sequence number is before accept-when-previous-timestamp-before,
+      // even when there are no previously stored offsets
+      eventTimestampQueryClock.setInstant(startTime.minusSeconds(3600).minusMillis(1))
+      offsetStore.validate(env1).futureValue shouldBe Accepted
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p1", 3L)).futureValue
+
+      // and same for another pid of same slice even though there is a stored offset
+      val env2 = createEnvelope(p2, 3L, startTime.plusMillis(9), "e2-3")
+      offsetStore.validate(env2).futureValue shouldBe Accepted
+    }
+
     "update inflight on error and re-accept element" in {
       import R2dbcOffsetStore.Validation._
       val projectionId = genRandomProjectionId()

--- a/akka-projection-r2dbc/src/main/resources/reference.conf
+++ b/akka-projection-r2dbc/src/main/resources/reference.conf
@@ -48,6 +48,13 @@ akka.projection.r2dbc {
     # Number of offsets to retrieve per slice when the projection is started.
     # Other offsets will be loaded on demand.
     offset-slice-read-limit = 100
+
+    # Accept an event even if the offset for previous sequence number is unknown
+    # when the timestamp of the previous event is before this configured timestamp.
+    # This is useful when migrating events from JDBC without migrating
+    # the offsets, which are stored in a different way for JDBC.
+    # Example timestamp format 2025-01-26T13:00:00.00Z.
+    accept-when-previous-timestamp-before = ""
   }
 
   # Replay missed events for a particular persistence id when a sequence number is rejected by validation.

--- a/akka-projection-r2dbc/src/main/resources/reference.conf
+++ b/akka-projection-r2dbc/src/main/resources/reference.conf
@@ -49,11 +49,13 @@ akka.projection.r2dbc {
     # Other offsets will be loaded on demand.
     offset-slice-read-limit = 100
 
-    # Accept an event even if the offset for previous sequence number is unknown
-    # when the timestamp of the previous event is before this configured timestamp.
     # This is useful when migrating events from JDBC without migrating
     # the offsets, which are stored in a different way for JDBC.
+    # Accept an event even if the offset for previous sequence number is unknown
+    # when the timestamp of the previous event is before this configured timestamp.
     # Example timestamp format 2025-01-26T13:00:00.00Z.
+    # When this is defined the start offset will correspond to this timestamp if there
+    # are no other offsets stored.
     accept-when-previous-timestamp-before = ""
   }
 

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcOffsetStore.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcOffsetStore.scala
@@ -381,7 +381,11 @@ private[projection] class R2dbcOffsetStore(
       case Some(_) =>
         readTimestampOffset().flatMap {
           case Some(t) => Future.successful(Some(t.asInstanceOf[Offset]))
-          case None    => readPrimitiveOffset()
+          case None =>
+            settings.acceptWhenPreviousTimestampBefore match {
+              case Some(t) => Future.successful(Some(TimestampOffset(t, Map.empty).asInstanceOf[Offset]))
+              case None    => readPrimitiveOffset()
+            }
         }
       case None =>
         readPrimitiveOffset()


### PR DESCRIPTION
* use case is when migrating (from jdbc) and there are no previously stored offsets and the projections start from a specific time
