### PR TITLE
fix: handler observability for r2dbc and dynamodb

### DIFF
--- a/akka-projection-core/src/main/scala/akka/projection/StatusObserver.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/StatusObserver.scala
@@ -31,7 +31,7 @@ abstract class StatusObserver[-Envelope] {
   def stopped(projectionId: ProjectionId): Unit
 
   /**
-   * Called as soon as an envelop is ready to be processed. The envelope processing may
+   * Called as soon as an envelope is ready to be processed. The envelope processing may
    * not start immediately if grouping or batching are enabled.
    */
   def beforeProcess(projectionId: ProjectionId, envelope: Envelope): Unit

--- a/akka-projection-core/src/main/scala/akka/projection/internal/ObservableHandler.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/ObservableHandler.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2020-2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.internal
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import akka.Done
+import akka.NotUsed
+import akka.annotation.InternalApi
+import akka.projection.ProjectionContext
+import akka.projection.ProjectionId
+import akka.projection.StatusObserver
+import akka.projection.scaladsl.Handler
+import akka.stream.scaladsl.Flow
+
+/** INTERNAL API */
+@InternalApi
+private[projection] trait HandlerObserver[-Envelope] {
+  def beforeProcess(envelope: Envelope): AnyRef
+  def afterProcess(envelope: Envelope, context: AnyRef): Unit
+}
+
+/** INTERNAL API */
+@InternalApi
+private[projection] object NoopHandlerObserver extends HandlerObserver[Any] {
+  def beforeProcess(envelope: Any): AnyRef = null
+  def afterProcess(envelope: Any, context: AnyRef): Unit = ()
+}
+
+/** INTERNAL API */
+@InternalApi
+private[projection] final class SingleHandlerObserver[Envelope](
+    projectionId: ProjectionId,
+    statusObserver: StatusObserver[Envelope],
+    telemetry: Telemetry,
+    extractCreationTime: Envelope => Long)
+    extends HandlerObserver[Envelope] {
+
+  override def beforeProcess(envelope: Envelope): AnyRef = {
+    statusObserver.beforeProcess(projectionId, envelope)
+    telemetry.beforeProcess(envelope, extractCreationTime(envelope))
+  }
+
+  override def afterProcess(envelope: Envelope, context: AnyRef): Unit = {
+    statusObserver.afterProcess(projectionId, envelope)
+    telemetry.afterProcess(context)
+  }
+}
+
+/** INTERNAL API */
+@InternalApi
+private[projection] final case class GroupedContexts(contexts: Seq[AnyRef])
+
+/** INTERNAL API */
+@InternalApi
+private[projection] final class GroupedHandlerObserver[Envelope](
+    projectionId: ProjectionId,
+    statusObserver: StatusObserver[Envelope],
+    telemetry: Telemetry,
+    extractCreationTime: Envelope => Long)
+    extends HandlerObserver[Seq[Envelope]] {
+
+  override def beforeProcess(envelopes: Seq[Envelope]): AnyRef = {
+    val contexts = envelopes.map { envelope =>
+      statusObserver.beforeProcess(projectionId, envelope)
+      telemetry.beforeProcess(envelope, extractCreationTime(envelope))
+    }
+    GroupedContexts(contexts)
+  }
+
+  override def afterProcess(envelopes: Seq[Envelope], groupedContexts: AnyRef): Unit = {
+    envelopes.foreach(envelope => statusObserver.afterProcess(projectionId, envelope))
+    groupedContexts match {
+      case GroupedContexts(contexts) => contexts.foreach(context => telemetry.afterProcess(context))
+      case _                         =>
+    }
+  }
+}
+
+/** INTERNAL API */
+@InternalApi
+private[projection] object ObservableHandler {
+  def observeProcess[Envelope, Result](
+      observer: HandlerObserver[Envelope],
+      envelope: Envelope,
+      process: Envelope => Future[Result]): Future[Result] = {
+    val context = observer.beforeProcess(envelope)
+    process(envelope)
+      .map { result =>
+        observer.afterProcess(envelope, context)
+        result
+      }(ExecutionContext.parasitic)
+  }
+}
+
+/** INTERNAL API */
+@InternalApi
+private[projection] final class ObservableHandler[Envelope](
+    handler: Handler[Envelope],
+    observer: HandlerObserver[Envelope])
+    extends Handler[Envelope] {
+
+  override def start(): Future[Done] = handler.start()
+
+  override def stop(): Future[Done] = handler.stop()
+
+  override def process(envelope: Envelope): Future[Done] = {
+    ObservableHandler.observeProcess(observer, envelope, handler.process)
+  }
+}
+
+/** INTERNAL API */
+@InternalApi
+private[projection] object ObservableFlowHandler {
+  def apply[Offset, Envelope](
+      flow: Flow[(Envelope, ProjectionContext), (Done, ProjectionContext), _],
+      observer: HandlerObserver[Envelope])
+      : Flow[ProjectionContextImpl[Offset, Envelope], ProjectionContextImpl[Offset, Envelope], NotUsed] = {
+    Flow[ProjectionContextImpl[Offset, Envelope]]
+      .map { projectionContext =>
+        val envelope = projectionContext.envelope
+        val context = observer.beforeProcess(envelope)
+        envelope -> projectionContext.withObserver(observer).withExternalContext(context)
+      }
+      .via(flow)
+      .map {
+        case (_, context) =>
+          val projectionContext = context.asInstanceOf[ProjectionContextImpl[Offset, Envelope]]
+          observer.afterProcess(projectionContext.envelope, projectionContext.externalContext)
+          projectionContext
+      }
+  }
+}

--- a/akka-projection-core/src/main/scala/akka/projection/internal/ProjectionContextImpl.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/ProjectionContextImpl.scala
@@ -12,26 +12,30 @@ import akka.projection.ProjectionContext
  * @param groupSize is used only in GroupHandlerStrategies so a single context instance
  *                  can report that multiple envelopes were processed.
  */
-@InternalApi private[projection] case class ProjectionContextImpl[Offset, Envelope] private (
+@InternalApi private[projection] final case class ProjectionContextImpl[Offset, Envelope] private (
     offset: Offset,
     envelope: Envelope,
+    observer: HandlerObserver[Envelope],
     externalContext: AnyRef,
     groupSize: Int)
     extends ProjectionContext {
 
+  def withObserver(observer: HandlerObserver[Envelope]): ProjectionContextImpl[Offset, Envelope] =
+    copy(observer = observer)
+
+  def withExternalContext(externalContext: AnyRef): ProjectionContextImpl[Offset, Envelope] =
+    copy(externalContext = externalContext)
+
   /**
    * scala3 makes `copy` private
    */
-  def withGroupSize(groupSize: Int) = copy(groupSize = groupSize)
+  def withGroupSize(groupSize: Int): ProjectionContextImpl[Offset, Envelope] = copy(groupSize = groupSize)
 }
 
 /**
  * INTERNAL API
  */
 @InternalApi private[projection] object ProjectionContextImpl {
-  def apply[Offset, Envelope](
-      offset: Offset,
-      envelope: Envelope,
-      externalContext: AnyRef): ProjectionContextImpl[Offset, Envelope] =
-    new ProjectionContextImpl(offset, envelope, externalContext, groupSize = 1)
+  def apply[Offset, Envelope](offset: Offset, envelope: Envelope): ProjectionContextImpl[Offset, Envelope] =
+    new ProjectionContextImpl(offset, envelope, observer = NoopHandlerObserver, externalContext = null, groupSize = 1)
 }

--- a/akka-projection-core/src/main/scala/akka/projection/scaladsl/Handler.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/scaladsl/Handler.scala
@@ -9,6 +9,8 @@ import scala.util.control.NonFatal
 
 import akka.Done
 import akka.annotation.InternalApi
+import akka.projection.internal.HandlerObserver
+import akka.projection.internal.ObservableHandler
 
 object Handler {
 
@@ -43,6 +45,10 @@ trait Handler[Envelope] extends HandlerLifecycle {
    */
   def process(envelope: Envelope): Future[Done]
 
+  /** INTERNAL API */
+  @InternalApi
+  private[projection] def observable(observer: HandlerObserver[Envelope]): Handler[Envelope] =
+    new ObservableHandler[Envelope](this, observer)
 }
 
 trait HandlerLifecycle {

--- a/akka-projection-dynamodb/src/main/mima-filters/1.6.8.backwards.excludes/adapted-handlers.excludes
+++ b/akka-projection-dynamodb/src/main/mima-filters/1.6.8.backwards.excludes/adapted-handlers.excludes
@@ -1,0 +1,3 @@
+# internal
+ProblemFilters.exclude[Problem]("akka.projection.dynamodb.internal.DynamoDBProjectionImpl#AdaptedHandler.*")
+ProblemFilters.exclude[Problem]("akka.projection.dynamodb.internal.DynamoDBProjectionImpl#AdaptedDynamoDBTransactHandler.*")

--- a/akka-projection-r2dbc/src/main/mima-filters/1.6.8.backwards.excludes/adapted-handlers.excludes
+++ b/akka-projection-r2dbc/src/main/mima-filters/1.6.8.backwards.excludes/adapted-handlers.excludes
@@ -1,0 +1,3 @@
+# internal
+ProblemFilters.exclude[Problem]("akka.projection.r2dbc.internal.R2dbcProjectionImpl#AdaptedHandler.*")
+ProblemFilters.exclude[Problem]("akka.projection.r2dbc.internal.R2dbcProjectionImpl#AdaptedR2dbcHandler.*")


### PR DESCRIPTION
Projection telemetry has been on the outermost handler. For R2DBC and DynamoDB this means that it sees all envelope sources (from pubsub, query, and backtracking), including envelopes that will be deduplicated and not actually processed. When metrics like consumer lag are aggregated across all of these, and with backtracking up to 1 minute behind on average it skews the metric creating confusion. While metrics can be separated across envelope sources, there's no way to know which are actually being processed or deduplicated.

Fix this by only calling telemetry (and status observer) for actual processing of envelopes. Because of the way the telemetry SPI is set up (no started hook, creation of the telemetry object indicates projection start), it's not possible to simply move the telemetry creation up and make it available to handlers and keep this behaviour. So instead have handlers converted to an observable handler, and make it possible for the R2DBC and DynamoDB adapted handlers to override this, so that only the delegate handler is instrumented when it's called.

Telemetry SPI has not changed and implementations don't need to be updated at all — they'll now start recording only the actual envelope processing.

Replays on rejection, for R2DBC or DynamoDB, are also now instrumented.

The current telemetry tests retain the same behaviour. Tested manually for R2DBC.

Some follow-ups to look at:

- add some telemetry and observer tests specifically for R2DBC and DynamoDB, so we don't break it at some point
- loaded envelopes from backtracking are not currently marked as having the backtracking source, could be useful to retain this for observability
- have a different envelope source for replays, for observability, now that they're instrumented
- reintroduce some way to observe all envelopes again (for our own performance testing and observability), with something like a separate `receivedEnvelope` hook or similar