### PR TITLE
feat: Metadata to allow sequence number gaps

### DIFF
--- a/akka-projection-core-test/src/test/scala/akka/projection/internal/ProjectionSerializerSpec.scala
+++ b/akka-projection-core-test/src/test/scala/akka/projection/internal/ProjectionSerializerSpec.scala
@@ -9,6 +9,7 @@ import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
+import akka.projection.AllowSeqNrGapsMetadata
 import akka.projection.ProjectionBehavior
 import akka.projection.ProjectionId
 import akka.serialization.SerializationExtension
@@ -32,7 +33,8 @@ class ProjectionSerializerSpec extends ScalaTestWithActorTestKit with AnyWordSpe
       "SetOffset None" -> SetOffset(projectionId, None, ref),
       "IsPaused" -> IsPaused(projectionId, ref),
       "SetPaused true" -> SetPaused(projectionId, paused = true, ref),
-      "SetPaused false" -> SetPaused(projectionId, paused = false, ref)).foreach {
+      "SetPaused false" -> SetPaused(projectionId, paused = false, ref),
+      "AllowSeqNrGapsMetadata" -> AllowSeqNrGapsMetadata).foreach {
       case (scenario, item) =>
         s"resolve serializer for $scenario" in {
           val serializer = SerializationExtension(classicSystem)

--- a/akka-projection-core/src/main/resources/reference.conf
+++ b/akka-projection-core/src/main/resources/reference.conf
@@ -76,6 +76,7 @@ akka {
     serialization-bindings {
       "akka.projection.ProjectionBehavior$Internal$ProjectionManagementCommand" = akka-projection
       "akka.projection.ProjectionBehavior$Internal$CurrentOffset" = akka-projection
+      "akka.projection.AllowSeqNrGapsMetadata" = akka-projection
     }
   }
 }

--- a/akka-projection-core/src/main/scala/akka/projection/AllowSeqNrGapsMetadata.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/AllowSeqNrGapsMetadata.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.projection
+
+/**
+ * When used as metadata of the EventEnvelope the offset store will allow gaps
+ * in sequence numbers when validating the offset.
+ */
+object AllowSeqNrGapsMetadata extends AllowSeqNrGapsMetadata {
+
+  /**
+   * Java API: The singleton instance
+   */
+  def getInstance: AllowSeqNrGapsMetadata = AllowSeqNrGapsMetadata
+
+}
+
+trait AllowSeqNrGapsMetadata

--- a/akka-projection-core/src/main/scala/akka/projection/internal/ProjectionSerializer.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/ProjectionSerializer.scala
@@ -10,6 +10,7 @@ import akka.Done
 import akka.actor.typed.ActorRefResolver
 import akka.actor.typed.scaladsl.adapter._
 import akka.annotation.InternalApi
+import akka.projection.AllowSeqNrGapsMetadata
 import akka.projection.ProjectionBehavior
 import akka.projection.ProjectionId
 import akka.projection.internal.OffsetSerialization.MultipleOffsets
@@ -39,23 +40,26 @@ import akka.serialization.SerializerWithStringManifest
   private val SetOffsetManifest = "c"
   private val IsPausedManifest = "d"
   private val SetPausedManifest = "e"
+  private val AllowSeqNrGapsMetadataManifest = "f"
 
   override def manifest(o: AnyRef): String = o match {
-    case _: GetOffset[_]     => GetOffsetManifest
-    case _: CurrentOffset[_] => CurrentOffsetManifest
-    case _: SetOffset[_]     => SetOffsetManifest
-    case _: IsPaused         => IsPausedManifest
-    case _: SetPaused        => SetPausedManifest
+    case _: GetOffset[_]           => GetOffsetManifest
+    case _: CurrentOffset[_]       => CurrentOffsetManifest
+    case _: SetOffset[_]           => SetOffsetManifest
+    case _: IsPaused               => IsPausedManifest
+    case _: SetPaused              => SetPausedManifest
+    case _: AllowSeqNrGapsMetadata => AllowSeqNrGapsMetadataManifest
     case _ =>
       throw new IllegalArgumentException(s"Can't serialize object of type ${o.getClass} in [${getClass.getName}]")
   }
 
   override def toBinary(o: AnyRef): Array[Byte] = o match {
-    case m: GetOffset[_]     => getOffsetToBinary(m)
-    case m: CurrentOffset[_] => currentOffsetToBinary(m)
-    case m: SetOffset[_]     => setOffsetToBinary(m)
-    case m: IsPaused         => isPausedToBinary(m)
-    case m: SetPaused        => setPausedToBinary(m)
+    case m: GetOffset[_]           => getOffsetToBinary(m)
+    case m: CurrentOffset[_]       => currentOffsetToBinary(m)
+    case m: SetOffset[_]           => setOffsetToBinary(m)
+    case m: IsPaused               => isPausedToBinary(m)
+    case m: SetPaused              => setPausedToBinary(m)
+    case _: AllowSeqNrGapsMetadata => Array.emptyByteArray
     case _ =>
       throw new IllegalArgumentException(s"Cannot serialize object of type [${o.getClass.getName}]")
   }
@@ -118,11 +122,12 @@ import akka.serialization.SerializerWithStringManifest
   }
 
   override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = manifest match {
-    case GetOffsetManifest     => getOffsetFromBinary(bytes)
-    case CurrentOffsetManifest => currentOffsetFromBinary(bytes)
-    case SetOffsetManifest     => setOffsetFromBinary(bytes)
-    case IsPausedManifest      => isPausedFromBinary(bytes)
-    case SetPausedManifest     => setPausedFromBinary(bytes)
+    case GetOffsetManifest              => getOffsetFromBinary(bytes)
+    case CurrentOffsetManifest          => currentOffsetFromBinary(bytes)
+    case SetOffsetManifest              => setOffsetFromBinary(bytes)
+    case IsPausedManifest               => isPausedFromBinary(bytes)
+    case SetPausedManifest              => setPausedFromBinary(bytes)
+    case AllowSeqNrGapsMetadataManifest => AllowSeqNrGapsMetadata
     case _ =>
       throw new NotSerializableException(
         s"Unimplemented deserialization of message with manifest [$manifest] in [${getClass.getName}]")

--- a/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetStoreSpec.scala
+++ b/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetStoreSpec.scala
@@ -5,7 +5,7 @@
 package akka.projection.dynamodb
 
 import java.time.Instant
-import java.time.{ Duration => JDuration }
+import java.time.{Duration => JDuration}
 import java.util.UUID
 
 import scala.concurrent.Await
@@ -24,6 +24,7 @@ import akka.persistence.query.typed.EventEnvelope
 import akka.persistence.query.typed.scaladsl.EventTimestampQuery
 import akka.persistence.query.typed.scaladsl.LoadEventQuery
 import akka.persistence.typed.PersistenceId
+import akka.projection.AllowSeqNrGapsMetadata
 import akka.projection.BySlicesSourceProvider
 import akka.projection.ProjectionId
 import akka.projection.dynamodb.internal.DynamoDBOffsetStore
@@ -801,6 +802,82 @@ abstract class DynamoDBTimestampOffsetStoreBaseSpec(config: Config)
 
       // accept unknown
       val env7 = createUpdatedDurableState("p5", 7L, startTime.plusMillis(8), "s5-7")
+      offsetStore.validate(env7).futureValue shouldBe Accepted
+      offsetStore.addInflight(env7)
+
+      // it's keeping the inflight that are not in the "stored" state
+      offsetStore.getInflight() shouldBe Map("p1" -> 4L, "p3" -> 20L, "p4" -> 2L, "p5" -> 7L)
+      // and they are removed from inflight once they have been stored
+      offsetStore
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusMillis(2), Map("p4" -> 2L)), "p4", 2L))
+        .futureValue
+      offsetStore
+        .saveOffset(OffsetPidSeqNr(TimestampOffset(startTime.plusMillis(9), Map("p5" -> 8L)), "p5", 8L))
+        .futureValue
+      offsetStore.getInflight() shouldBe Map("p1" -> 4L, "p3" -> 20L)
+    }
+
+    "accept gaps when envelope has AllowSeqNrGapsMetadata" in {
+      val projectionId = genRandomProjectionId()
+      val offsetStore = createOffsetStore(projectionId)
+
+      val startTime = TestClock.nowMicros().instant()
+      val offset1 = TimestampOffset(startTime, Map("p1" -> 3L, "p2" -> 1L, "p3" -> 5L))
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p1", 3L)).futureValue
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p2", 1L)).futureValue
+      offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p3", 5L)).futureValue
+
+      // seqNr 1 is always accepted
+      val env1 = createEnvelope("p4", 1L, startTime.plusMillis(1), "s4-1").withMetadata(AllowSeqNrGapsMetadata)
+      offsetStore.validate(env1).futureValue shouldBe Accepted
+      // but not if already inflight, seqNr 1 was accepted
+      offsetStore.addInflight(env1)
+      offsetStore
+        .validate(createEnvelope("p4", 1L, startTime.plusMillis(1), "s4-1").withMetadata(AllowSeqNrGapsMetadata))
+        .futureValue shouldBe Duplicate
+      // subsequent seqNr is accepted
+      val env2 = createEnvelope("p4", 2L, startTime.plusMillis(2), "s4-2").withMetadata(AllowSeqNrGapsMetadata)
+      offsetStore.validate(env2).futureValue shouldBe Accepted
+      offsetStore.addInflight(env2)
+      // and also ok with gap
+      offsetStore
+        .validate(createEnvelope("p4", 4L, startTime.plusMillis(3), "s4-4").withMetadata(AllowSeqNrGapsMetadata))
+        .futureValue shouldBe Accepted
+      // and not if later already inflight, seqNr 2 was accepted
+      offsetStore
+        .validate(createEnvelope("p4", 1L, startTime.plusMillis(1), "s4-1").withMetadata(AllowSeqNrGapsMetadata))
+        .futureValue shouldBe Duplicate
+
+      // greater than known is accepted
+      val env3 = createEnvelope("p1", 4L, startTime.plusMillis(4), "s1-4").withMetadata(AllowSeqNrGapsMetadata)
+      offsetStore.validate(env3).futureValue shouldBe Accepted
+      // but not same
+      offsetStore
+        .validate(createEnvelope("p3", 5L, startTime, "s3-5").withMetadata(AllowSeqNrGapsMetadata))
+        .futureValue shouldBe Duplicate
+      // but not same, even if it's 1
+      offsetStore
+        .validate(createEnvelope("p2", 1L, startTime, "s2-1").withMetadata(AllowSeqNrGapsMetadata))
+        .futureValue shouldBe Duplicate
+      // and not less
+      offsetStore
+        .validate(createEnvelope("p3", 4L, startTime, "s3-4").withMetadata(AllowSeqNrGapsMetadata))
+        .futureValue shouldBe Duplicate
+      offsetStore.addInflight(env3)
+
+      // greater than known, and then also subsequent are accepted (needed for grouped)
+      val env4 = createEnvelope("p3", 8L, startTime.plusMillis(5), "s3-6").withMetadata(AllowSeqNrGapsMetadata)
+      offsetStore.validate(env4).futureValue shouldBe Accepted
+      offsetStore.addInflight(env4)
+      val env5 = createEnvelope("p3", 9L, startTime.plusMillis(6), "s3-7").withMetadata(AllowSeqNrGapsMetadata)
+      offsetStore.validate(env5).futureValue shouldBe Accepted
+      offsetStore.addInflight(env5)
+      val env6 = createEnvelope("p3", 20L, startTime.plusMillis(7), "s3-8").withMetadata(AllowSeqNrGapsMetadata)
+      offsetStore.validate(env6).futureValue shouldBe Accepted
+      offsetStore.addInflight(env6)
+
+      // accept unknown
+      val env7 = createEnvelope("p5", 7L, startTime.plusMillis(8), "s5-7").withMetadata(AllowSeqNrGapsMetadata)
       offsetStore.validate(env7).futureValue shouldBe Accepted
       offsetStore.addInflight(env7)
 


### PR DESCRIPTION
* if EventEnvelope has AllowSeqNrGapsMetadata metadata the validation behaves in the same way as for durable state changes

