### PR TITLE
fix: Don't trigger replay from pub-sub events

### DIFF
--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBProjectionImpl.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBProjectionImpl.scala
@@ -506,6 +506,9 @@ private[projection] object DynamoDBProjectionImpl {
     def replayIfPossible(originalEnvelope: Envelope, observer: HandlerObserver[Envelope]): Future[Boolean] = {
       val logPrefix = offsetStore.logPrefix
       originalEnvelope match {
+        case originalEventEnvelope: EventEnvelope[Any @unchecked] if EnvelopeOrigin.fromPubSub(originalEventEnvelope) =>
+          // don't replay from pubsub events
+          FutureFalse
         case originalEventEnvelope: EventEnvelope[Any @unchecked] if originalEventEnvelope.sequenceNr > 1 =>
           val underlyingProvider = sourceProvider match {
             case adapted: JavaToScalaBySliceSourceProviderAdapter[_, _] => adapted.delegate
@@ -719,6 +722,9 @@ private[projection] object DynamoDBProjectionImpl {
       system: ActorSystem[_]): Future[Boolean] = {
     val logPrefix = offsetStore.logPrefix
     originalEnvelope match {
+      case originalEventEnvelope: EventEnvelope[Any @unchecked] if EnvelopeOrigin.fromPubSub(originalEventEnvelope) =>
+        // don't replay from pubsub events
+        FutureFalse
       case originalEventEnvelope: EventEnvelope[Any @unchecked] if originalEventEnvelope.sequenceNr > 1 =>
         val underlyingProvider = sourceProvider match {
           case adapted: JavaToScalaBySliceSourceProviderAdapter[_, _] => adapted.delegate

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
@@ -581,6 +581,9 @@ private[projection] object R2dbcProjectionImpl {
     def replayIfPossible(originalEnvelope: Envelope, observer: HandlerObserver[Envelope]): Future[Boolean] = {
       val logPrefix = offsetStore.logPrefix
       originalEnvelope match {
+        case originalEventEnvelope: EventEnvelope[Any @unchecked] if EnvelopeOrigin.fromPubSub(originalEventEnvelope) =>
+          // don't replay from pubsub events
+          FutureFalse
         case originalEventEnvelope: EventEnvelope[Any @unchecked] if originalEventEnvelope.sequenceNr > 1 =>
           val underlyingProvider = sourceProvider match {
             case adapted: JavaToScalaBySliceSourceProviderAdapter[_, _] => adapted.delegate
@@ -794,6 +797,9 @@ private[projection] object R2dbcProjectionImpl {
       system: ActorSystem[_]): Future[Boolean] = {
     val logPrefix = offsetStore.logPrefix
     originalEnvelope match {
+      case originalEventEnvelope: EventEnvelope[Any @unchecked] if EnvelopeOrigin.fromPubSub(originalEventEnvelope) =>
+        // don't replay from pubsub events
+        FutureFalse
       case originalEventEnvelope: EventEnvelope[Any @unchecked] if originalEventEnvelope.sequenceNr > 1 =>
         val underlyingProvider = sourceProvider match {
           case adapted: JavaToScalaBySliceSourceProviderAdapter[_, _] => adapted.delegate


### PR DESCRIPTION
* since those may be out of sync more frequently and the replay will increase the load on the system/db
* note that this also applies to grpc projections

