### PR TITLE
feat: add backlog status telemetry

### DIFF
--- a/akka-projection-core-test/src/test/scala/akka/projection/internal/metrics/BacklogStatusTelemetrySpec.scala
+++ b/akka-projection-core-test/src/test/scala/akka/projection/internal/metrics/BacklogStatusTelemetrySpec.scala
@@ -1,0 +1,247 @@
+/*
+ * Copyright (C) 2020-2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.internal.metrics
+
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import akka.Done
+import akka.NotUsed
+import akka.actor.typed.ActorSystem
+import akka.event.Logging
+import akka.event.LoggingAdapter
+import akka.projection.ProjectionId
+import akka.projection.internal.AtLeastOnce
+import akka.projection.internal.BacklogStatusProjectionState
+import akka.projection.internal.BacklogStatusSourceProvider
+import akka.projection.internal.InternalProjectionState
+import akka.projection.internal.NoopStatusObserver
+import akka.projection.internal.ProjectionSettings
+import akka.projection.internal.SingleHandlerStrategy
+import akka.projection.internal.metrics.tools.InMemInstruments
+import akka.projection.internal.metrics.tools.InMemInstrumentsRegistry
+import akka.projection.internal.metrics.tools.InternalProjectionStateMetricsSpec
+import akka.projection.internal.metrics.tools.TestHandlers
+import akka.projection.scaladsl.SourceProvider
+import akka.stream.scaladsl.Source
+import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.scaladsl.TestSource
+
+class BacklogStatusTelemetrySpec extends InternalProjectionStateMetricsSpec {
+  import BacklogStatusTelemetrySpec._
+
+  "BacklogStatusTelemetry" should {
+
+    "report backlog status" in withTestBacklogStatus() { (sourceProvider, projectionState, instruments) =>
+      instruments.backlogStatusInitialCheckIntervalSeconds.set(1) // report every second
+      projectionState.start()
+
+      eventually(timeout(3.seconds)) {
+        sourceProvider.isRunning shouldBe true
+        instruments.startedInvocations.get shouldBe 1
+        instruments.backlogStatusCheckIntervalSecondsInvocations.get shouldBe 1
+      }
+
+      // no activity yet
+
+      eventually(timeout(3.seconds)) {
+        instruments.reportTimestampBacklogStatusInvocations.get should be >= 1
+        instruments.backlogStatusLatestSourceTimestamp.get shouldBe 0
+        instruments.backlogStatusLatestOffsetTimestamp.get shouldBe 0
+      }
+
+      val t0 = Instant.now()
+      val envelope1 = TestEnvelope("one", TestOffset(t0.plusSeconds(1)))
+      val envelope2 = TestEnvelope("two", TestOffset(t0.plusSeconds(2)))
+
+      // first envelope produced by source
+      sourceProvider.setLatestEnvelope(envelope1)
+
+      eventually(timeout(3.seconds)) {
+        instruments.reportTimestampBacklogStatusInvocations.get should be >= 2
+        instruments.backlogStatusLatestSourceTimestamp.get shouldBe envelope1.offset.timestamp.toEpochMilli
+        instruments.backlogStatusLatestOffsetTimestamp.get shouldBe 0
+      }
+
+      // first envelope processed
+      projectionState.setLatestOffset(envelope1.offset)
+
+      eventually(timeout(3.seconds)) {
+        instruments.reportTimestampBacklogStatusInvocations.get should be >= 3
+        instruments.backlogStatusLatestSourceTimestamp.get shouldBe envelope1.offset.timestamp.toEpochMilli
+        instruments.backlogStatusLatestOffsetTimestamp.get shouldBe envelope1.offset.timestamp.toEpochMilli
+      }
+
+      // simulate source provider checked first, second envelope already processed
+      projectionState.setLatestOffset(envelope2.offset)
+
+      eventually(timeout(3.seconds)) {
+        instruments.reportTimestampBacklogStatusInvocations.get should be >= 4
+        instruments.backlogStatusLatestSourceTimestamp.get shouldBe envelope1.offset.timestamp.toEpochMilli
+        instruments.backlogStatusLatestOffsetTimestamp.get shouldBe envelope2.offset.timestamp.toEpochMilli
+      }
+
+      // source provider timestamp is there now
+      sourceProvider.setLatestEnvelope(envelope2)
+
+      eventually(timeout(3.seconds)) {
+        instruments.reportTimestampBacklogStatusInvocations.get should be >= 5
+        instruments.backlogStatusLatestSourceTimestamp.get shouldBe envelope2.offset.timestamp.toEpochMilli
+        instruments.backlogStatusLatestOffsetTimestamp.get shouldBe envelope2.offset.timestamp.toEpochMilli
+      }
+
+      // simulate events having been deleted
+      sourceProvider.clearLatestEnvelope()
+
+      eventually(timeout(3.seconds)) {
+        instruments.reportTimestampBacklogStatusInvocations.get should be >= 6
+        instruments.backlogStatusLatestSourceTimestamp.get shouldBe 0
+        instruments.backlogStatusLatestOffsetTimestamp.get shouldBe envelope2.offset.timestamp.toEpochMilli
+      }
+
+      sourceProvider.complete()
+
+      eventually(timeout(3.seconds)) {
+        instruments.stoppedInvocations.get shouldBe 1
+      }
+    }
+
+    "not start if check interval is set to zero" in withTestBacklogStatus() {
+      (sourceProvider, projectionState, instruments) =>
+
+        projectionState.start()
+
+        eventually(timeout(3.seconds)) {
+          sourceProvider.isRunning shouldBe true
+          instruments.startedInvocations.get shouldBe 1
+          instruments.backlogStatusCheckIntervalSecondsInvocations.get shouldBe 1
+          instruments.backlogStatusInitialCheckIntervalSeconds.get shouldBe 0
+        }
+
+        // confirm no backlog status reports for 2 seconds
+        Thread.sleep(2000)
+        instruments.reportTimestampBacklogStatusInvocations.get shouldBe 0
+
+        sourceProvider.complete()
+
+        eventually(timeout(3.seconds)) {
+          instruments.stoppedInvocations.get shouldBe 1
+        }
+    }
+
+    "not start when source provider doesn't support latest event timestamp" in withTestBacklogStatus(
+      supportsLatestEventTimestamp = false) { (sourceProvider, projectionState, instruments) =>
+
+      instruments.backlogStatusInitialCheckIntervalSeconds.set(1) // report every second
+      projectionState.start()
+
+      eventually(timeout(3.seconds)) {
+        sourceProvider.isRunning shouldBe true
+        instruments.startedInvocations.get shouldBe 1
+      }
+
+      // confirm no backlog status reports for 2 seconds
+      Thread.sleep(2000)
+      instruments.backlogStatusInitialCheckIntervalSeconds.get shouldBe 1
+      instruments.backlogStatusCheckIntervalSecondsInvocations.get shouldBe 0
+      instruments.reportTimestampBacklogStatusInvocations.get shouldBe 0
+
+      sourceProvider.complete()
+
+      eventually(timeout(3.seconds)) {
+        instruments.stoppedInvocations.get shouldBe 1
+      }
+    }
+  }
+
+  def withTestBacklogStatus(supportsLatestEventTimestamp: Boolean = true)(
+      test: (TestBacklogStatusSourceProvider, TestBacklogStatusProjectionState, InMemInstruments) => Unit): Unit = {
+    val projectionId = genRandomProjectionId()
+    val projectionSettings = ProjectionSettings(system)
+    val sourceProvider = new TestBacklogStatusSourceProvider(supportsLatestEventTimestamp)
+    val projectionState = new TestBacklogStatusProjectionState(projectionId, sourceProvider, projectionSettings)
+    val instruments = InMemInstrumentsRegistry(system).forId(projectionId)
+    test(sourceProvider, projectionState, instruments)
+  }
+}
+
+object BacklogStatusTelemetrySpec {
+
+  final case class TestOffset(timestamp: Instant)
+
+  final case class TestEnvelope(event: String, offset: TestOffset)
+
+  final class TestBacklogStatusSourceProvider(val supportsLatestEventTimestamp: Boolean)(
+      implicit system: ActorSystem[_])
+      extends SourceProvider[TestOffset, TestEnvelope]
+      with BacklogStatusSourceProvider {
+
+    private val latestEnvelope: AtomicReference[Option[TestEnvelope]] = new AtomicReference(None)
+
+    private val sourceProbe = new AtomicReference[TestPublisher.Probe[TestEnvelope]]()
+
+    private val source = TestSource[TestEnvelope]()(system.classicSystem).mapMaterializedValue { probe =>
+      sourceProbe.set(probe)
+      NotUsed
+    }
+
+    def setLatestEnvelope(envelope: TestEnvelope): Unit = latestEnvelope.set(Some(envelope))
+
+    def clearLatestEnvelope(): Unit = latestEnvelope.set(None)
+
+    def isRunning: Boolean = sourceProbe.get ne null
+
+    def complete(): Unit = sourceProbe.get.sendComplete()
+
+    override private[akka] def latestEventTimestamp(): Future[Option[Instant]] =
+      Future.successful(latestEnvelope.get.map(_.offset.timestamp))
+
+    override def source(offset: () => Future[Option[TestOffset]]): Future[Source[TestEnvelope, NotUsed]] =
+      Future.successful(source)
+
+    override def extractOffset(envelope: TestEnvelope): TestOffset = envelope.offset
+
+    override def extractCreationTime(envelope: TestEnvelope): Long = envelope.offset.timestamp.toEpochMilli
+  }
+
+  final class TestBacklogStatusProjectionState(
+      projectionId: ProjectionId,
+      sourceProvider: TestBacklogStatusSourceProvider,
+      settings: ProjectionSettings)(implicit val system: ActorSystem[_])
+      extends InternalProjectionState(
+        projectionId,
+        sourceProvider,
+        AtLeastOnce(),
+        SingleHandlerStrategy(TestHandlers.single),
+        NoopStatusObserver,
+        settings)
+      with BacklogStatusProjectionState {
+
+    private val latestOffset: AtomicReference[Option[TestOffset]] = new AtomicReference(None)
+
+    def setLatestOffset(offset: TestOffset): Unit = latestOffset.set(Some(offset))
+
+    def clearLatestOffset(): Unit = latestOffset.set(None)
+
+    def start(): Unit = mappedSource().run() // doesn't actually process anything
+
+    override private[akka] def latestOffsetTimestamp(): Future[Option[Instant]] =
+      Future.successful(latestOffset.get.map(_.timestamp))
+
+    override def logger: LoggingAdapter = Logging(system.classicSystem, classOf[TestBacklogStatusProjectionState])
+
+    override implicit def executionContext: ExecutionContext = system.executionContext
+
+    override def readPaused(): Future[Boolean] = Future.successful(false)
+
+    override def readOffsets(): Future[Option[TestOffset]] = Future.successful(latestOffset.get)
+
+    override def saveOffset(projectionId: ProjectionId, offset: TestOffset): Future[Done] = Future.successful(Done)
+  }
+}

--- a/akka-projection-core/src/main/scala/akka/projection/internal/BacklogStatus.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/BacklogStatus.scala
@@ -4,11 +4,11 @@
 
 package akka.projection.internal
 
-import java.time.Duration
 import java.time.Instant
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 import akka.actor.Cancellable
 import akka.actor.typed.ActorSystem
@@ -19,119 +19,43 @@ import akka.projection.scaladsl.SourceProvider
 // TODO: backlog status could be extended to track number of events as well or as an alternative for sequence-based offsets
 
 /**
- * Represents the status of a projection's backlog - whether it's keeping up with events or lagging behind.
- */
-@InternalStableApi
-sealed trait BacklogStatus {
-
-  /**
-   * Indicates whether the projection is synchronized with the latest events.
-   * @return true if the projection is in sync, false if lagging
-   */
-  def isInSync: Boolean
-}
-
-object BacklogStatus {
-
-  /**
-   * Base trait for statuses indicating the projection is synchronized with its event source.
-   * The projection has processed all available events or there's nothing to process.
-   */
-  @InternalStableApi
-  sealed trait InSync extends BacklogStatus {
-    override def isInSync: Boolean = true
-  }
-
-  /**
-   * No events to process and no processing has occurred, so the projection is up-to-date.
-   */
-  @InternalStableApi
-  case object NoActivity extends InSync
-
-  /**
-   * Projection is up-to-date with the latest events, using timestamp comparison.
-   * The latest processed offset timestamp is in-sync with the latest event timestamp.
-   *
-   * @param latestOffsetTimestamp the timestamp of the most recently processed event
-   */
-  @InternalStableApi
-  final case class InSyncInTime(latestOffsetTimestamp: Instant) extends InSync
-
-  /**
-   * Base trait for statuses indicating the projection is lagging behind in processing events.
-   * There are events in the source that haven't been processed yet.
-   */
-  @InternalStableApi
-  sealed trait Lagging extends BacklogStatus {
-    override def isInSync: Boolean = false
-  }
-
-  /**
-   * Projection is lagging behind the latest events, measured in time difference.
-   * The latest processed offset timestamp is behind the latest event timestamp.
-   *
-   * @param latestEventTimestamp  the timestamp of the most recent event in the source
-   * @param latestOffsetTimestamp the timestamp of the most recently processed event
-   */
-  @InternalStableApi
-  final case class LaggingInTime(latestEventTimestamp: Instant, latestOffsetTimestamp: Instant) extends Lagging {
-
-    /**
-     * The time difference between the latest event and the latest processed offset.
-     */
-    val lag: Duration = Duration.between(latestOffsetTimestamp, latestEventTimestamp)
-
-    /**
-     * The lag duration in seconds, with fractional precision.
-     *
-     * @return lag in seconds as a double
-     */
-    def lagSeconds: Double = lag.toNanos / 1_000_000_000.0
-  }
-
-  /**
-   * There are events in the source, but the projection hasn't processed any events yet.
-   * This represents an initial state or a projection that hasn't started processing.
-   *
-   * A telemetry implementation could track time since starting to process the current event,
-   * in case the projection is taking a long time or has actually stalled on the first event.
-   *
-   * @param latestEventTimestamp the timestamp of the most recent event in the source
-   */
-  @InternalStableApi
-  final case class NoProcessingInTime(latestEventTimestamp: Instant) extends Lagging
-
-}
-
-/**
  * Observing backlog status. Supported as an extension of [[Telemetry]].
- * Implementing this trait allows tracking whether projections are keeping up with events.
+ * Implementing this trait allows tracking whether projections are keeping up with their source.
  */
 @InternalStableApi
 trait BacklogStatusTelemetry {
 
   /**
    * Define how frequently backlog status should be checked.
-   * Return Duration.ZERO to disable backlog status checking.
+   * Return 0 to disable backlog status checking.
    *
-   * @return backlog status check interval as a duration
+   * @return backlog status check interval in seconds
    */
-  def backlogStatusCheckInterval(): Duration
+  def backlogStatusCheckIntervalSeconds(): Int
 
   /**
-   * Observe a reported backlog status.
-   * Called periodically with the current backlog status of the projection.
+   * Observe a reported backlog status, based on the latest source and offset timestamps.
    *
-   * @param status latest backlog status
+   * Timestamps are in milliseconds since epoch. Timestamps will be 0 when not present.
+   *
+   * The offset timestamp may be ahead of the source timestamp at the time of checking.
+   * If only the source timestamp is present, then the projection has not yet processed the first envelope.
+   * If only the offset timestamp is present, then the source may have been cleaned and the projection is up-to-date.
+   * If neither timestamp is present, then there has been no activity and the projection is up-to-date.
+   *
+   * Called periodically, based on [[backlogStatusCheckIntervalSeconds]], with the backlog status of the projection.
+   *
+   * @param latestSourceTimestamp latest millisecond-based timestamp for the projection source (0 if not present)
+   * @param latestOffsetTimestamp latest millisecond-based timestamp for projection offsets (0 if not present)
    */
-  def reportBacklogStatus(status: BacklogStatus): Unit
+  def reportTimestampBacklogStatus(latestSourceTimestamp: Long, latestOffsetTimestamp: Long): Unit
 }
 
 object BacklogStatusTelemetry {
 
   /** INTERNAL API */
   @InternalApi
-  def start[Offset, Envelope](
+  private[internal] def start[Offset, Envelope](
       telemetry: Telemetry,
       sourceProvider: SourceProvider[Offset, Envelope],
       projectionState: InternalProjectionState[Offset, Envelope])(
@@ -140,66 +64,32 @@ object BacklogStatusTelemetry {
       backlogStatusTelemetry <- Option(telemetry).collect {
         case statusTelemetry: BacklogStatusTelemetry => statusTelemetry
       }
-      checkInterval <- Option(backlogStatusTelemetry.backlogStatusCheckInterval()).filter { duration =>
-        !duration.isZero && !duration.isNegative
-      }
+      checkInterval <- Option(backlogStatusTelemetry.backlogStatusCheckIntervalSeconds()).filter(_ > 0).map(_.seconds)
       backlogStatusSourceProvider <- Option(sourceProvider).collect {
         case provider: BacklogStatusSourceProvider if provider.supportsLatestEventTimestamp => provider
       }
       backlogStatusProjectionState <- Option(projectionState).collect {
-        case state: BacklogStatusProjectionState if state.supportsLatestOffsetTimestamp => state
+        case state: BacklogStatusProjectionState => state
       }
     } yield {
       implicit val ec: ExecutionContext = system.executionContext
-      system.scheduler.scheduleAtFixedRate(
-        checkInterval,
-        checkInterval,
-        () => checkBacklogStatus(backlogStatusSourceProvider, backlogStatusProjectionState, backlogStatusTelemetry),
-        system.executionContext)
+      system.scheduler.scheduleAtFixedRate(checkInterval, checkInterval) { () =>
+        checkBacklogStatus(backlogStatusSourceProvider, backlogStatusProjectionState, backlogStatusTelemetry)
+      }
     }
   }
 
-  /** INTERNAL API */
-  @InternalApi
   private def checkBacklogStatus(
       backlogStatusSourceProvider: BacklogStatusSourceProvider,
       backlogStatusProjectionState: BacklogStatusProjectionState,
       backlogStatusTelemetry: BacklogStatusTelemetry)(implicit ec: ExecutionContext): Unit = {
-
-    val backlogStatus: Future[BacklogStatus] = for {
-      latestEventTimestamp <- backlogStatusSourceProvider.latestEventTimestamp()
+    for {
+      latestSourceTimestamp <- backlogStatusSourceProvider.latestEventTimestamp()
       latestOffsetTimestamp <- backlogStatusProjectionState.latestOffsetTimestamp()
-    } yield calculateBacklogStatus(latestEventTimestamp, latestOffsetTimestamp)
-
-    backlogStatus.foreach(backlogStatusTelemetry.reportBacklogStatus)
-  }
-
-  private def calculateBacklogStatus(
-      latestEventTimestamp: Option[Instant],
-      latestOffsetTimestamp: Option[Instant]): BacklogStatus = {
-    import BacklogStatus._
-
-    (latestEventTimestamp, latestOffsetTimestamp) match {
-      case (Some(eventTimestamp), Some(offsetTimestamp)) =>
-        // check whether projection is up-to-date
-        // note: for an active projection, the offset may be ahead of events by the time this was checked
-        if (offsetTimestamp.compareTo(eventTimestamp) >= 0) {
-          InSyncInTime(offsetTimestamp)
-        } else {
-          LaggingInTime(eventTimestamp, offsetTimestamp)
-        }
-
-      case (Some(eventTimestamp), None) =>
-        // there are events but none have been processed yet
-        NoProcessingInTime(eventTimestamp)
-
-      case (None, Some(offsetTimestamp)) =>
-        // events have likely been deleted, but projection is up-to-date
-        InSyncInTime(offsetTimestamp)
-
-      case (None, None) =>
-        // no events to process for this projection instance
-        NoActivity
+    } {
+      backlogStatusTelemetry.reportTimestampBacklogStatus(
+        latestSourceTimestamp.fold(0L)(_.toEpochMilli),
+        latestOffsetTimestamp.fold(0L)(_.toEpochMilli))
     }
   }
 }
@@ -214,6 +104,5 @@ private[akka] trait BacklogStatusSourceProvider {
 /** INTERNAL API */
 @InternalApi
 private[akka] trait BacklogStatusProjectionState {
-  private[akka] def supportsLatestOffsetTimestamp: Boolean
   private[akka] def latestOffsetTimestamp(): Future[Option[Instant]]
 }

--- a/akka-projection-core/src/main/scala/akka/projection/internal/BacklogStatus.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/BacklogStatus.scala
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) 2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.internal
+
+import java.time.Duration
+import java.time.Instant
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import akka.actor.Cancellable
+import akka.actor.typed.ActorSystem
+import akka.annotation.InternalApi
+import akka.annotation.InternalStableApi
+import akka.projection.scaladsl.SourceProvider
+
+// TODO: backlog status could be extended to track number of events as well or as an alternative for sequence-based offsets
+
+/**
+ * Represents the status of a projection's backlog - whether it's keeping up with events or lagging behind.
+ */
+@InternalStableApi
+sealed trait BacklogStatus {
+
+  /**
+   * Indicates whether the projection is synchronized with the latest events.
+   * @return true if the projection is in sync, false if lagging
+   */
+  def isInSync: Boolean
+}
+
+object BacklogStatus {
+
+  /**
+   * Base trait for statuses indicating the projection is synchronized with its event source.
+   * The projection has processed all available events or there's nothing to process.
+   */
+  @InternalStableApi
+  sealed trait InSync extends BacklogStatus {
+    override def isInSync: Boolean = true
+  }
+
+  /**
+   * No events to process and no processing has occurred, so the projection is up-to-date.
+   */
+  @InternalStableApi
+  case object NoActivity extends InSync
+
+  /**
+   * Projection is up-to-date with the latest events, using timestamp comparison.
+   * The latest processed offset timestamp is in-sync with the latest event timestamp.
+   *
+   * @param latestOffsetTimestamp the timestamp of the most recently processed event
+   */
+  @InternalStableApi
+  final case class InSyncInTime(latestOffsetTimestamp: Instant) extends InSync
+
+  /**
+   * Base trait for statuses indicating the projection is lagging behind in processing events.
+   * There are events in the source that haven't been processed yet.
+   */
+  @InternalStableApi
+  sealed trait Lagging extends BacklogStatus {
+    override def isInSync: Boolean = false
+  }
+
+  /**
+   * Projection is lagging behind the latest events, measured in time difference.
+   * The latest processed offset timestamp is behind the latest event timestamp.
+   *
+   * @param latestEventTimestamp  the timestamp of the most recent event in the source
+   * @param latestOffsetTimestamp the timestamp of the most recently processed event
+   */
+  @InternalStableApi
+  final case class LaggingInTime(latestEventTimestamp: Instant, latestOffsetTimestamp: Instant) extends Lagging {
+
+    /**
+     * The time difference between the latest event and the latest processed offset.
+     */
+    val lag: Duration = Duration.between(latestOffsetTimestamp, latestEventTimestamp)
+
+    /**
+     * The lag duration in seconds, with fractional precision.
+     *
+     * @return lag in seconds as a double
+     */
+    def lagSeconds: Double = lag.toNanos / 1_000_000_000.0
+  }
+
+  /**
+   * There are events in the source, but the projection hasn't processed any events yet.
+   * This represents an initial state or a projection that hasn't started processing.
+   *
+   * A telemetry implementation could track time since starting to process the current event,
+   * in case the projection is taking a long time or has actually stalled on the first event.
+   *
+   * @param latestEventTimestamp the timestamp of the most recent event in the source
+   */
+  @InternalStableApi
+  final case class NoProcessingInTime(latestEventTimestamp: Instant) extends Lagging
+
+}
+
+/**
+ * Observing backlog status. Supported as an extension of [[Telemetry]].
+ * Implementing this trait allows tracking whether projections are keeping up with events.
+ */
+@InternalStableApi
+trait BacklogStatusTelemetry {
+
+  /**
+   * Define how frequently backlog status should be checked.
+   * Return Duration.ZERO to disable backlog status checking.
+   *
+   * @return backlog status check interval as a duration
+   */
+  def backlogStatusCheckInterval(): Duration
+
+  /**
+   * Observe a reported backlog status.
+   * Called periodically with the current backlog status of the projection.
+   *
+   * @param status latest backlog status
+   */
+  def reportBacklogStatus(status: BacklogStatus): Unit
+}
+
+object BacklogStatusTelemetry {
+
+  /** INTERNAL API */
+  @InternalApi
+  def start[Offset, Envelope](
+      telemetry: Telemetry,
+      sourceProvider: SourceProvider[Offset, Envelope],
+      projectionState: InternalProjectionState[Offset, Envelope])(
+      implicit system: ActorSystem[_]): Option[Cancellable] = {
+    for {
+      backlogStatusTelemetry <- Option(telemetry).collect {
+        case statusTelemetry: BacklogStatusTelemetry => statusTelemetry
+      }
+      checkInterval <- Option(backlogStatusTelemetry.backlogStatusCheckInterval()).filter { duration =>
+        !duration.isZero && !duration.isNegative
+      }
+      backlogStatusSourceProvider <- Option(sourceProvider).collect {
+        case provider: BacklogStatusSourceProvider if provider.supportsLatestEventTimestamp => provider
+      }
+      backlogStatusProjectionState <- Option(projectionState).collect {
+        case state: BacklogStatusProjectionState if state.supportsLatestOffsetTimestamp => state
+      }
+    } yield {
+      implicit val ec: ExecutionContext = system.executionContext
+      system.scheduler.scheduleAtFixedRate(
+        checkInterval,
+        checkInterval,
+        () => checkBacklogStatus(backlogStatusSourceProvider, backlogStatusProjectionState, backlogStatusTelemetry),
+        system.executionContext)
+    }
+  }
+
+  /** INTERNAL API */
+  @InternalApi
+  private def checkBacklogStatus(
+      backlogStatusSourceProvider: BacklogStatusSourceProvider,
+      backlogStatusProjectionState: BacklogStatusProjectionState,
+      backlogStatusTelemetry: BacklogStatusTelemetry)(implicit ec: ExecutionContext): Unit = {
+
+    val backlogStatus: Future[BacklogStatus] = for {
+      latestEventTimestamp <- backlogStatusSourceProvider.latestEventTimestamp()
+      latestOffsetTimestamp <- backlogStatusProjectionState.latestOffsetTimestamp()
+    } yield calculateBacklogStatus(latestEventTimestamp, latestOffsetTimestamp)
+
+    backlogStatus.foreach(backlogStatusTelemetry.reportBacklogStatus)
+  }
+
+  private def calculateBacklogStatus(
+      latestEventTimestamp: Option[Instant],
+      latestOffsetTimestamp: Option[Instant]): BacklogStatus = {
+    import BacklogStatus._
+
+    (latestEventTimestamp, latestOffsetTimestamp) match {
+      case (Some(eventTimestamp), Some(offsetTimestamp)) =>
+        // check whether projection is up-to-date
+        // note: for an active projection, the offset may be ahead of events by the time this was checked
+        if (offsetTimestamp.compareTo(eventTimestamp) >= 0) {
+          InSyncInTime(offsetTimestamp)
+        } else {
+          LaggingInTime(eventTimestamp, offsetTimestamp)
+        }
+
+      case (Some(eventTimestamp), None) =>
+        // there are events but none have been processed yet
+        NoProcessingInTime(eventTimestamp)
+
+      case (None, Some(offsetTimestamp)) =>
+        // events have likely been deleted, but projection is up-to-date
+        InSyncInTime(offsetTimestamp)
+
+      case (None, None) =>
+        // no events to process for this projection instance
+        NoActivity
+    }
+  }
+}
+
+/** INTERNAL API */
+@InternalApi
+private[akka] trait BacklogStatusSourceProvider {
+  private[akka] def supportsLatestEventTimestamp: Boolean
+  private[akka] def latestEventTimestamp(): Future[Option[Instant]]
+}
+
+/** INTERNAL API */
+@InternalApi
+private[akka] trait BacklogStatusProjectionState {
+  private[akka] def supportsLatestOffsetTimestamp: Boolean
+  private[akka] def latestOffsetTimestamp(): Future[Option[Instant]]
+}

--- a/akka-projection-core/src/main/scala/akka/projection/internal/BacklogStatus.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/BacklogStatus.scala
@@ -64,13 +64,13 @@ object BacklogStatusTelemetry {
       backlogStatusTelemetry <- Option(telemetry).collect {
         case statusTelemetry: BacklogStatusTelemetry => statusTelemetry
       }
-      checkInterval <- Option(backlogStatusTelemetry.backlogStatusCheckIntervalSeconds()).filter(_ > 0).map(_.seconds)
       backlogStatusSourceProvider <- Option(sourceProvider).collect {
         case provider: BacklogStatusSourceProvider if provider.supportsLatestEventTimestamp => provider
       }
       backlogStatusProjectionState <- Option(projectionState).collect {
         case state: BacklogStatusProjectionState => state
       }
+      checkInterval <- Option(backlogStatusTelemetry.backlogStatusCheckIntervalSeconds()).filter(_ > 0).map(_.seconds)
     } yield {
       implicit val ec: ExecutionContext = system.executionContext
       system.scheduler.scheduleAtFixedRate(checkInterval, checkInterval) { () =>

--- a/akka-projection-core/src/main/scala/akka/projection/internal/InternalProjectionState.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/InternalProjectionState.scala
@@ -56,7 +56,7 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
   private var telemetry: Telemetry = NoopTelemetry
   private[projection] def getTelemetry() = telemetry
 
-  private var backlogStatusChecks: Option[Cancellable] = None
+  private var backlogStatusChecks: Seq[Cancellable] = Seq.empty
 
   def readPaused(): Future[Boolean]
   def readOffsets(): Future[Option[Offset]]

--- a/akka-projection-core/src/main/scala/akka/projection/internal/JavaToScalaSourceProviderAdapter.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/JavaToScalaSourceProviderAdapter.scala
@@ -65,6 +65,7 @@ private[projection] class JavaToScalaSourceProviderAdapter[Offset, Envelope](
     val delegate: javadsl.SourceProvider[Offset, Envelope])
     extends scaladsl.SourceProvider[Offset, Envelope]
     with BySlicesSourceProvider
+    with BacklogStatusSourceProvider
     with EventTimestampQuery
     with LoadEventQuery {
 
@@ -110,6 +111,19 @@ private[projection] class JavaToScalaSourceProviderAdapter[Offset, Envelope](
             s"EventTimestampQuery when LoadEventQuery is used."))
     }
 
+  override private[akka] def supportsLatestEventTimestamp: Boolean =
+    delegate match {
+      case sourceProvider: BacklogStatusSourceProvider =>
+        sourceProvider.supportsLatestEventTimestamp
+      case _ => false
+    }
+
+  override private[akka] def latestEventTimestamp(): Future[Option[Instant]] =
+    delegate match {
+      case sourceProvider: BacklogStatusSourceProvider =>
+        sourceProvider.latestEventTimestamp()
+      case _ => Future.successful(None)
+    }
 }
 
 /**

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
@@ -1194,8 +1194,6 @@ private[projection] class R2dbcProjectionImpl[Offset, Envelope](
       }
     }
 
-    override private[akka] def supportsLatestOffsetTimestamp: Boolean = true
-
     override private[akka] def latestOffsetTimestamp(): Future[Option[Instant]] =
       Future.successful(offsetStore.getState().latestOffset.map(_.timestamp))
 

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
@@ -4,6 +4,7 @@
 
 package akka.projection.r2dbc.internal
 
+import java.time.Instant
 import java.util.concurrent.atomic.AtomicLong
 
 import scala.annotation.nowarn
@@ -41,6 +42,7 @@ import akka.projection.eventsourced.scaladsl.EventSourcedProvider.LoadEventsByPe
 import akka.projection.internal.ActorHandlerInit
 import akka.projection.internal.AtLeastOnce
 import akka.projection.internal.AtMostOnce
+import akka.projection.internal.BacklogStatusProjectionState
 import akka.projection.internal.CanTriggerReplay
 import akka.projection.internal.ExactlyOnce
 import akka.projection.internal.GroupedHandlerStrategy
@@ -1105,7 +1107,8 @@ private[projection] class R2dbcProjectionImpl[Offset, Envelope](
         offsetStrategy,
         handlerStrategy,
         statusObserver,
-        settings) {
+        settings)
+      with BacklogStatusProjectionState {
 
     implicit val executionContext: ExecutionContext = system.executionContext
     override val logger: LoggingAdapter = Logging(system.classicSystem, classOf[R2dbcProjectionImpl[_, _]])
@@ -1190,6 +1193,11 @@ private[projection] class R2dbcProjectionImpl[Offset, Envelope](
           }
       }
     }
+
+    override private[akka] def supportsLatestOffsetTimestamp: Boolean = true
+
+    override private[akka] def latestOffsetTimestamp(): Future[Option[Instant]] =
+      Future.successful(offsetStore.getState().latestOffset.map(_.timestamp))
 
     private[projection] def newRunningInstance(): RunningProjection =
       new R2dbcRunningProjection(RunningProjection.withBackoff(() => this.mappedSource(), settings), this)


### PR DESCRIPTION
Add backlog status checks, based on the latest event timestamp query, and telemetry SPI extension for reporting these.

Depends on:

- https://github.com/akka/akka/pull/32700

Aligned with:

- https://github.com/akka/akka-persistence-r2dbc/pull/667
- https://github.com/akka/akka-projection/pull/1334

