### PR TITLE
fix: Don't wait for the backoff when a stopped projection failed before being stopped

### DIFF
--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
@@ -208,7 +208,10 @@ import akka.stream.scaladsl.Source
       extends RunningProjection
       with RunningProjectionManagement[Offset] {
 
-    private val streamDone = source.run()
+    private val streamDone = source
+    // make sure to not wait for RestartSource backoff if the mappedSource failed just before the projection stopped
+      .via(projectionState.killSwitch.flow)
+      .run()
 
     override def stop(): Future[Done] = {
       projectionState.killSwitch.shutdown()

--- a/akka-projection-core-test/src/test/scala/akka/projection/internal/metrics/tools/InternalProjectionStateMetricsSpec.scala
+++ b/akka-projection-core-test/src/test/scala/akka/projection/internal/metrics/tools/InternalProjectionStateMetricsSpec.scala
@@ -216,7 +216,10 @@ object InternalProjectionStateMetricsSpec {
 
     class TestRunningProjection(val source: Source[Done, _], killSwitch: SharedKillSwitch) extends RunningProjection {
 
-      private val futureDone = source.run()
+      private val futureDone = source
+      // make sure to not wait for RestartSource backoff if the mappedSource failed just before the projection stopped
+        .via(killSwitch.flow)
+        .run()
 
       override def stop(): Future[Done] = {
         killSwitch.shutdown()

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBProjectionImpl.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBProjectionImpl.scala
@@ -1182,7 +1182,10 @@ private[projection] class DynamoDBProjectionImpl[Offset, Envelope](
       extends RunningProjection
       with RunningProjectionManagement[Offset] {
 
-    private val streamDone = source.run()
+    private val streamDone = source
+    // make sure to not wait for RestartSource backoff if the mappedSource failed just before the projection stopped
+      .via(projectionState.killSwitch.flow)
+      .run()
 
     override def stop(): Future[Done] = {
       projectionState.killSwitch.shutdown()

--- a/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
+++ b/akka-projection-r2dbc/src/main/scala/akka/projection/r2dbc/internal/R2dbcProjectionImpl.scala
@@ -1263,7 +1263,10 @@ private[projection] class R2dbcProjectionImpl[Offset, Envelope](
       extends RunningProjection
       with RunningProjectionManagement[Offset] {
 
-    private val streamDone = source.run()
+    private val streamDone = source
+    // make sure to not wait for RestartSource backoff if the mappedSource failed just before the projection stopped
+      .via(projectionState.killSwitch.flow)
+      .run()
 
     override def stop(): Future[Done] = {
       projectionState.killSwitch.shutdown()


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References https://github.com/lightbend/akka-runtime/issues/4536

Probably more of an annoyance than an actual problem
