### PR TITLE
fix: New instance of R2dbcOffsetStore for each incarnation

### DIFF
--- a/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
+++ b/akka-projection-cassandra/src/main/scala/akka/projection/cassandra/internal/CassandraProjectionImpl.scala
@@ -214,8 +214,13 @@ import akka.stream.scaladsl.Source
       projectionState.killSwitch.shutdown()
       // if the handler is retrying it will be aborted by this,
       // otherwise the stream would not be completed by the killSwitch until after all retries
-      projectionState.abort.failure(AbortProjectionException)
+      projectionState.abort.tryFailure(AbortProjectionException)
       streamDone
+    }
+
+    override def forcedStop(): Unit = {
+      projectionState.killSwitch.shutdown()
+      projectionState.abort.tryFailure(AbortProjectionException)
     }
 
     // RunningProjectionManagement

--- a/akka-projection-core-test/src/test/scala/akka/projection/ProjectionBehaviorSpec.scala
+++ b/akka-projection-core-test/src/test/scala/akka/projection/ProjectionBehaviorSpec.scala
@@ -43,6 +43,7 @@ object ProjectionBehaviorSpec {
   case object StartObserved extends ProbeMessage
   case class Consumed(n: Int, currentState: String) extends ProbeMessage
   case object StopObserved extends ProbeMessage
+  case object ForcedStopObserved extends ProbeMessage
 
   private val TestProjectionId = ProjectionId("test-projection", "00")
 
@@ -160,6 +161,11 @@ object ProjectionBehaviorSpec {
           .andThen {
             case _ => testProbe.ref ! StopObserved
           }
+      }
+
+      override def forcedStop(): Unit = {
+        killSwitch.shutdown()
+        testProbe.ref ! ForcedStopObserved
       }
 
       override def getOffset(): Future[Option[Int]] = {
@@ -284,7 +290,7 @@ class ProjectionBehaviorSpec extends ScalaTestWithActorTestKit("""
       // good, things are flowing
 
       testKit.stop(projectionRef)
-      testProbe.expectMessage(StopObserved)
+      testProbe.expectMessage(ForcedStopObserved)
       streamDoneProbe.expectMessage(Done)
 
       createTestProbe().expectTerminated(projectionRef)

--- a/akka-projection-core-test/src/test/scala/akka/projection/internal/metrics/tools/InternalProjectionStateMetricsSpec.scala
+++ b/akka-projection-core-test/src/test/scala/akka/projection/internal/metrics/tools/InternalProjectionStateMetricsSpec.scala
@@ -222,6 +222,10 @@ object InternalProjectionStateMetricsSpec {
         killSwitch.shutdown()
         futureDone
       }
+
+      override def forcedStop(): Unit = {
+        killSwitch.shutdown()
+      }
     }
   }
 

--- a/akka-projection-core/src/main/scala/akka/projection/Projection.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/Projection.scala
@@ -118,10 +118,16 @@ private[projection] object RunningProjection {
 private[projection] trait RunningProjection {
 
   /**
-   * Stop the projection if it's running.
+   * Gracefully stop the projection if it's running.
    * @return Future[Done] - the returned Future should return the stream materialized value.
    */
   def stop(): Future[Done]
+
+  /**
+   * Hard stop in case ProjectionBehavior is terminated, or restarted, or other reasons
+   * force a stop.
+   */
+  def forcedStop(): Unit
 }
 
 /**

--- a/akka-projection-core/src/main/scala/akka/projection/ProjectionBehavior.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/ProjectionBehavior.scala
@@ -187,7 +187,7 @@ object ProjectionBehavior {
           // Make sure it is stopped in case the actor is terminated/restarted in other ways
           // than with ProjectionBehavior.Stop message. Note that we can't wait in that case, so
           // it's always better to use ProjectionBehavior.Stop message.
-          running.stop()
+          running.forcedStop()
           Behaviors.same
       }
 

--- a/akka-projection-core/src/main/scala/akka/projection/internal/ProjectionContextImpl.scala
+++ b/akka-projection-core/src/main/scala/akka/projection/internal/ProjectionContextImpl.scala
@@ -17,7 +17,8 @@ import akka.projection.ProjectionContext
     envelope: Envelope,
     observer: HandlerObserver[Envelope],
     externalContext: AnyRef,
-    groupSize: Int)
+    groupSize: Int,
+    uuid: String)
     extends ProjectionContext {
 
   def withObserver(observer: HandlerObserver[Envelope]): ProjectionContextImpl[Offset, Envelope] =
@@ -30,20 +31,29 @@ import akka.projection.ProjectionContext
    * scala3 makes `copy` private
    */
   def withGroupSize(groupSize: Int): ProjectionContextImpl[Offset, Envelope] = copy(groupSize = groupSize)
+
 }
 
 /**
  * INTERNAL API
  */
 @InternalApi private[projection] object ProjectionContextImpl {
+
   def apply[Offset, Envelope](offset: Offset, envelope: Envelope): ProjectionContextImpl[Offset, Envelope] =
-    new ProjectionContextImpl(offset, envelope, observer = NoopHandlerObserver, externalContext = null, groupSize = 1)
+    apply(offset, envelope, uuid = "")
+
+  def apply[Offset, Envelope](
+      offset: Offset,
+      envelope: Envelope,
+      uuid: String): ProjectionContextImpl[Offset, Envelope] =
+    apply(offset, envelope, observer = NoopHandlerObserver, externalContext = null, uuid)
 
   def apply[Offset, Envelope](
       offset: Offset,
       envelope: Envelope,
       observer: HandlerObserver[Envelope],
-      externalContext: AnyRef): ProjectionContextImpl[Offset, Envelope] =
-    new ProjectionContextImpl(offset, envelope, observer, externalContext, groupSize = 1)
+      externalContext: AnyRef,
+      uuid: String): ProjectionContextImpl[Offset, Envelope] =
+    new ProjectionContextImpl(offset, envelope, observer, externalContext, groupSize = 1, uuid)
 
 }

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBProjectionImpl.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBProjectionImpl.scala
@@ -1188,8 +1188,13 @@ private[projection] class DynamoDBProjectionImpl[Offset, Envelope](
       projectionState.killSwitch.shutdown()
       // if the handler is retrying it will be aborted by this,
       // otherwise the stream would not be completed by the killSwitch until after all retries
-      projectionState.abort.failure(AbortProjectionException)
+      projectionState.abort.tryFailure(AbortProjectionException)
       streamDone
+    }
+
+    override def forcedStop(): Unit = {
+      projectionState.killSwitch.shutdown()
+      projectionState.abort.tryFailure(AbortProjectionException)
     }
 
     // RunningProjectionManagement

--- a/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcProjectionImpl.scala
+++ b/akka-projection-jdbc/src/main/scala/akka/projection/jdbc/internal/JdbcProjectionImpl.scala
@@ -283,6 +283,11 @@ private[projection] class JdbcProjectionImpl[Offset, Envelope, S <: JdbcSession]
       streamDone
     }
 
+    override def forcedStop(): Unit = {
+      projectionState.killSwitch.shutdown()
+      projectionState.abort.tryFailure(AbortProjectionException)
+    }
+
     // RunningProjectionManagement
     override def getOffset(): Future[Option[Offset]] = {
       offsetStore.readOffset(projectionId)

--- a/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreSpec.scala
+++ b/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreSpec.scala
@@ -39,7 +39,7 @@ class R2dbcOffsetStoreSpec
   private implicit val queryAdapter: QueryAdapter = r2dbcSettings.codecSettings.queryAdapter
 
   private def createOffsetStore(projectionId: ProjectionId) =
-    new R2dbcOffsetStore(projectionId, None, system, settings, r2dbcExecutor, clock)
+    new R2dbcOffsetStore(projectionId, UUID.randomUUID().toString, None, system, settings, r2dbcExecutor, clock)
 
   private val table = settings.offsetTableWithSchema
 

--- a/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcProjectionSpec.scala
+++ b/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcProjectionSpec.scala
@@ -215,7 +215,7 @@ class R2dbcProjectionSpec
   private val logger = LoggerFactory.getLogger(getClass)
   private val settings = R2dbcProjectionSettings(testKit.system)
   private def createOffsetStore(projectionId: ProjectionId): R2dbcOffsetStore =
-    new R2dbcOffsetStore(projectionId, None, system, settings, r2dbcExecutor)
+    new R2dbcOffsetStore(projectionId, UUID.randomUUID().toString, None, system, settings, r2dbcExecutor)
   private val projectionTestKit = ProjectionTestKit(system)
 
   override protected def beforeAll(): Unit = {

--- a/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetProjectionSpec.scala
+++ b/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetProjectionSpec.scala
@@ -237,7 +237,13 @@ class R2dbcTimestampOffsetProjectionSpec
   private def createOffsetStore(
       projectionId: ProjectionId,
       sourceProvider: TestTimestampSourceProvider): R2dbcOffsetStore =
-    new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
+    new R2dbcOffsetStore(
+      projectionId,
+      UUID.randomUUID().toString,
+      Some(sourceProvider),
+      system,
+      settings,
+      r2dbcExecutor)
   private val projectionTestKit = ProjectionTestKit(system)
 
   override protected def beforeAll(): Unit = {
@@ -274,7 +280,7 @@ class R2dbcTimestampOffsetProjectionSpec
       complete: Boolean = true): (TestTimestampSourceProvider, Future[TestPublisher.Probe[EventEnvelope[String]]]) = {
     val sourceProbe = Promise[TestPublisher.Probe[EventEnvelope[String]]]()
     val source = TestSource[EventEnvelope[String]]().mapMaterializedValue { probe =>
-      sourceProbe.success(probe)
+      sourceProbe.trySuccess(probe)
       NotUsed
     }
     val sourceProvider = createTestSourceProvider(source, allEnvelopes, enableCurrentEventsByPersistenceId, complete)
@@ -773,7 +779,13 @@ class R2dbcTimestampOffsetProjectionSpec
         createSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          settings,
+          r2dbcExecutor)
 
       val projectionRef = spawn(
         ProjectionBehavior(
@@ -830,7 +842,13 @@ class R2dbcTimestampOffsetProjectionSpec
         createSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          settings,
+          r2dbcExecutor)
 
       val projectionRef = spawn(
         ProjectionBehavior(
@@ -878,7 +896,13 @@ class R2dbcTimestampOffsetProjectionSpec
       val sourceProvider = createSourceProvider(envelopes)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, testSettings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          testSettings,
+          r2dbcExecutor)
 
       val projectionRef = spawn(
         ProjectionBehavior(R2dbcProjection
@@ -925,7 +949,13 @@ class R2dbcTimestampOffsetProjectionSpec
         createSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, testSettings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          testSettings,
+          r2dbcExecutor)
 
       val projectionRef = spawn(
         ProjectionBehavior(R2dbcProjection
@@ -1092,7 +1122,13 @@ class R2dbcTimestampOffsetProjectionSpec
         createSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          settings,
+          r2dbcExecutor)
 
       val handlerProbe = createTestProbe[String]("calls-to-handler")
 
@@ -1152,7 +1188,13 @@ class R2dbcTimestampOffsetProjectionSpec
         createSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          settings,
+          r2dbcExecutor)
 
       val handlerProbe = createTestProbe[String]("calls-to-handler")
 
@@ -1202,7 +1244,13 @@ class R2dbcTimestampOffsetProjectionSpec
       val (sourceProvider, sourceProbe) = createDynamicSourceProvider(allEnvelopes)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, testSettings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          testSettings,
+          r2dbcExecutor)
 
       val handlerProbe = createTestProbe[String]("calls-to-handler")
 
@@ -1261,7 +1309,13 @@ class R2dbcTimestampOffsetProjectionSpec
         createDynamicSourceProvider(allEnvelopes, enableCurrentEventsByPersistenceId = true)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, testSettings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          testSettings,
+          r2dbcExecutor)
 
       val handlerProbe = createTestProbe[String]("calls-to-handler")
 
@@ -1379,7 +1433,13 @@ class R2dbcTimestampOffsetProjectionSpec
       val startTime = TestClock.nowMicros().instant()
       val sourceProvider = new TestSourceProviderWithInput()
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          settings,
+          r2dbcExecutor)
 
       val result1 = new StringBuffer()
       val result2 = new StringBuffer()
@@ -1482,7 +1542,13 @@ class R2dbcTimestampOffsetProjectionSpec
         createSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          settings,
+          r2dbcExecutor)
 
       val results = new ConcurrentHashMap[String, String]()
 
@@ -1552,7 +1618,13 @@ class R2dbcTimestampOffsetProjectionSpec
         createSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          settings,
+          r2dbcExecutor)
 
       val results = new ConcurrentHashMap[String, String]()
 
@@ -1612,7 +1684,13 @@ class R2dbcTimestampOffsetProjectionSpec
       val (sourceProvider, sourceProbe) = createDynamicSourceProvider(allEnvelopes)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, testSettings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          testSettings,
+          r2dbcExecutor)
 
       val results = new ConcurrentHashMap[String, String]()
 
@@ -1677,7 +1755,13 @@ class R2dbcTimestampOffsetProjectionSpec
         createDynamicSourceProvider(allEnvelopes, enableCurrentEventsByPersistenceId = true)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, testSettings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          testSettings,
+          r2dbcExecutor)
 
       val results = new ConcurrentHashMap[String, String]()
 
@@ -1733,7 +1817,13 @@ class R2dbcTimestampOffsetProjectionSpec
         createJavaSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          settings,
+          r2dbcExecutor)
 
       val results = new ConcurrentHashMap[String, String]()
 
@@ -1804,7 +1894,13 @@ class R2dbcTimestampOffsetProjectionSpec
         createJavaSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          settings,
+          r2dbcExecutor)
 
       val results = new ConcurrentHashMap[String, String]()
 
@@ -1890,7 +1986,13 @@ class R2dbcTimestampOffsetProjectionSpec
       val startTime = TestClock.nowMicros().instant()
       val sourceProvider = new TestSourceProviderWithInput()
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          settings,
+          r2dbcExecutor)
 
       val projectionRef = spawn(
         ProjectionBehavior(
@@ -2094,7 +2196,13 @@ class R2dbcTimestampOffsetProjectionSpec
       val startTime = TestClock.nowMicros().instant()
       val sourceProvider = new TestSourceProviderWithInput()
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          settings,
+          r2dbcExecutor)
 
       val result1 = new StringBuffer()
       val result2 = new StringBuffer()
@@ -2183,7 +2291,13 @@ class R2dbcTimestampOffsetProjectionSpec
         createSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          settings,
+          r2dbcExecutor)
 
       val projectionRef = spawn(
         ProjectionBehavior(
@@ -2240,7 +2354,13 @@ class R2dbcTimestampOffsetProjectionSpec
         createSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          settings,
+          r2dbcExecutor)
 
       val projectionRef = spawn(
         ProjectionBehavior(
@@ -2288,7 +2408,13 @@ class R2dbcTimestampOffsetProjectionSpec
       val (sourceProvider, sourceProbe) = createDynamicSourceProvider(allEnvelopes)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, testSettings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          testSettings,
+          r2dbcExecutor)
 
       val projectionRef = spawn(
         ProjectionBehavior(R2dbcProjection
@@ -2339,7 +2465,13 @@ class R2dbcTimestampOffsetProjectionSpec
         createDynamicSourceProvider(allEnvelopes, enableCurrentEventsByPersistenceId = true)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, testSettings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          testSettings,
+          r2dbcExecutor)
 
       val projectionRef = spawn(
         ProjectionBehavior(R2dbcProjection
@@ -2434,7 +2566,13 @@ class R2dbcTimestampOffsetProjectionSpec
       val startTime = TestClock.nowMicros().instant()
       val sourceProvider = new TestSourceProviderWithInput()
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          settings,
+          r2dbcExecutor)
 
       val flowHandler =
         FlowWithContext[EventEnvelope[String], ProjectionContext]
@@ -2530,7 +2668,13 @@ class R2dbcTimestampOffsetProjectionSpec
         createSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          settings,
+          r2dbcExecutor)
 
       offsetShouldBeEmpty()
 
@@ -2606,7 +2750,13 @@ class R2dbcTimestampOffsetProjectionSpec
         createSourceProviderWithMoreEnvelopes(envelopes, allEnvelopes, enableCurrentEventsByPersistenceId = true)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, settings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          settings,
+          r2dbcExecutor)
 
       offsetShouldBeEmpty()
 
@@ -2660,7 +2810,13 @@ class R2dbcTimestampOffsetProjectionSpec
       val (sourceProvider, sourceProbe) = createDynamicSourceProvider(allEnvelopes)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, testSettings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          testSettings,
+          r2dbcExecutor)
 
       val flowHandler =
         FlowWithContext[EventEnvelope[String], ProjectionContext]
@@ -2719,7 +2875,13 @@ class R2dbcTimestampOffsetProjectionSpec
         createDynamicSourceProvider(allEnvelopes, enableCurrentEventsByPersistenceId = true)
 
       implicit val offsetStore: R2dbcOffsetStore =
-        new R2dbcOffsetStore(projectionId, Some(sourceProvider), system, testSettings, r2dbcExecutor)
+        new R2dbcOffsetStore(
+          projectionId,
+          UUID.randomUUID().toString,
+          Some(sourceProvider),
+          system,
+          testSettings,
+          r2dbcExecutor)
 
       val flowHandler =
         FlowWithContext[EventEnvelope[String], ProjectionContext]

--- a/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
+++ b/akka-projection-r2dbc-integration/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
@@ -71,6 +71,7 @@ class R2dbcTimestampOffsetStoreSpec
       eventTimestampQueryClock: TestClock = clock) =
     new R2dbcOffsetStore(
       projectionId,
+      UUID.randomUUID().toString,
       Some(new TestTimestampSourceProvider(0, persistenceExt.numberOfSlices - 1, eventTimestampQueryClock)),
       system,
       customSettings,
@@ -368,6 +369,7 @@ class R2dbcTimestampOffsetStoreSpec
       val offsetStore0 =
         new R2dbcOffsetStore(
           projectionId0,
+          UUID.randomUUID().toString,
           Some(new TestTimestampSourceProvider(0, persistenceExt.numberOfSlices - 1, clock)),
           system,
           settings,
@@ -389,6 +391,7 @@ class R2dbcTimestampOffsetStoreSpec
       val offsetStore1 =
         new R2dbcOffsetStore(
           projectionId1,
+          UUID.randomUUID().toString,
           Some(new TestTimestampSourceProvider(0, 511, clock)),
           system,
           settings,
@@ -399,6 +402,7 @@ class R2dbcTimestampOffsetStoreSpec
       val offsetStore2 =
         new R2dbcOffsetStore(
           projectionId2,
+          UUID.randomUUID().toString,
           Some(new TestTimestampSourceProvider(512, 1023, clock)),
           system,
           settings,
@@ -1593,18 +1597,21 @@ class R2dbcTimestampOffsetStoreSpec
       val projectionId4 = ProjectionId(projectionId1.name, "512-1023")
       val offsetStore1 = new R2dbcOffsetStore(
         projectionId1,
+        UUID.randomUUID().toString,
         Some(new TestTimestampSourceProvider(640, 767, clock)),
         system,
         settings,
         r2dbcExecutor)
       val offsetStore2 = new R2dbcOffsetStore(
         projectionId2,
+        UUID.randomUUID().toString,
         Some(new TestTimestampSourceProvider(512, 767, clock)),
         system,
         settings,
         r2dbcExecutor)
       val offsetStore3 = new R2dbcOffsetStore(
         projectionId3,
+        UUID.randomUUID().toString,
         Some(new TestTimestampSourceProvider(768, 1023, clock)),
         system,
         settings,
@@ -1630,6 +1637,7 @@ class R2dbcTimestampOffsetStoreSpec
       // after downscaling
       val offsetStore4 = new R2dbcOffsetStore(
         projectionId4,
+        UUID.randomUUID().toString,
         Some(new TestTimestampSourceProvider(512, 1023, clock)),
         system,
         settings,
@@ -1653,6 +1661,7 @@ class R2dbcTimestampOffsetStoreSpec
       def offsetStore(minSlice: Int, maxSlice: Int) =
         new R2dbcOffsetStore(
           ProjectionId(projectionName, s"$minSlice-$maxSlice"),
+          UUID.randomUUID().toString,
           Some(new TestTimestampSourceProvider(minSlice, maxSlice, clock)),
           system,
           settings.withTimeWindow(10.seconds).withDeleteAfter(10.seconds),
@@ -1846,6 +1855,7 @@ class R2dbcTimestampOffsetStoreSpec
       def offsetStore(minSlice: Int, maxSlice: Int) =
         new R2dbcOffsetStore(
           ProjectionId(projectionName, s"$minSlice-$maxSlice"),
+          UUID.randomUUID().toString,
           Some(new TestTimestampSourceProvider(minSlice, maxSlice, clock)),
           system,
           settings,

--- a/akka-projection-r2dbc/src/main/mima-filters/1.6.16.backwards.excludes/r2dbc-offset-store.excludes
+++ b/akka-projection-r2dbc/src/main/mima-filters/1.6.16.backwards.excludes/r2dbc-offset-store.excludes
@@ -1,0 +1,2 @@
+# internal
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.r2dbc.internal.R2dbcProjectionImpl#R2dbcInternalProjectionState.this")

--- a/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
+++ b/akka-projection-slick/src/main/scala/akka/projection/slick/internal/SlickProjectionImpl.scala
@@ -207,8 +207,13 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
       projectionState.killSwitch.shutdown()
       // if the handler is retrying it will be aborted by this,
       // otherwise the stream would not be completed by the killSwitch until after all retries
-      projectionState.abort.failure(AbortProjectionException)
+      projectionState.abort.tryFailure(AbortProjectionException)
       streamDone
+    }
+
+    override def forcedStop(): Unit = {
+      projectionState.killSwitch.shutdown()
+      projectionState.abort.tryFailure(AbortProjectionException)
     }
 
     // RunningProjectionManagement

--- a/akka-projection-testkit/src/main/scala/akka/projection/testkit/internal/TestProjectionImpl.scala
+++ b/akka-projection-testkit/src/main/scala/akka/projection/testkit/internal/TestProjectionImpl.scala
@@ -188,4 +188,8 @@ private[projection] class TestRunningProjection(val source: Source[Done, _], kil
     killSwitch.shutdown()
     futureDone
   }
+
+  override def forcedStop(): Unit = {
+    killSwitch.shutdown()
+  }
 }

--- a/akka-projection-testkit/src/test/java/akka/projection/testkit/javadsl/ProjectionTestKitTest.java
+++ b/akka-projection-testkit/src/test/java/akka/projection/testkit/javadsl/ProjectionTestKitTest.java
@@ -281,6 +281,11 @@ public class ProjectionTestKitTest extends JUnitSuite {
         killSwitch.shutdown();
         return this.futureDone;
       }
+
+      @Override
+      public void forcedStop() {
+        killSwitch.shutdown();
+      }
     }
   }
 }


### PR DESCRIPTION
The shared offset store instance is problematic because of possible in-flight access for fail restart scenario. Creating a new store instance for each materialization. Any attempts to use a stopped store will be rejected.

* factory of R2dbcOffsetStore
* factory of handler since adapter needs same offset store

