### PR TITLE
build: use global action step

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,8 +43,6 @@ jobs:
 
       - name: Run akka/github-actions-scripts
         uses: akka/github-actions-scripts/setup_global_resolver@main
-        with:
-          maven-mirror-control: 'NO_MIRROR'
 
       - name: Code style check and binary-compatibility check
         run: sbt "verifyCodeStyle; mimaReportBinaryIssues"
@@ -120,6 +118,8 @@ jobs:
 
       - name: Run akka/github-actions-scripts
         uses: akka/github-actions-scripts/setup_global_resolver@main
+        with:
+          maven-mirror-control: 'NO_MIRROR'
 
       - name: Gather version
         # some cleanup of the sbt output to get the version sbt will use when publishing below

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -118,8 +118,6 @@ jobs:
 
       - name: Run akka/github-actions-scripts
         uses: akka/github-actions-scripts/setup_global_resolver@main
-        with:
-          maven-mirror-control: 'NO_MIRROR'
 
       - name: Gather version
         # some cleanup of the sbt output to get the version sbt will use when publishing below
@@ -241,6 +239,8 @@ jobs:
 
       - name: Run akka/github-actions-scripts
         uses: akka/github-actions-scripts/setup_global_resolver@main
+        with:
+          maven-mirror-control: 'NO_MIRROR'
 
       - name: Restore published artifacts
         # https://github.com/actions/cache/releases

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           jvm: temurin:1.11
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Code style check and binary-compatibility check
         run: sbt "verifyCodeStyle; mimaReportBinaryIssues"
 
@@ -72,6 +75,9 @@ jobs:
         uses: coursier/setup-action@7bde40eee928896f074dbb76d22dd772eed5c65f
         with:
           jvm: temurin:1.11
+
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
 
       - name: Compile all code with fatal warnings for Java 11, Scala 2.13 and Scala 3
         run: sbt "clean ; +compile; +Test/compile; +akka-projection-integration/Test/compile"
@@ -109,6 +115,9 @@ jobs:
         uses: coursier/setup-action@7bde40eee928896f074dbb76d22dd772eed5c65f
         with:
           jvm: temurin:1.11
+
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
 
       - name: Gather version
         # some cleanup of the sbt output to get the version sbt will use when publishing below
@@ -227,6 +236,9 @@ jobs:
         uses: coursier/setup-action@7bde40eee928896f074dbb76d22dd772eed5c65f
         with:
           jvm: temurin:1.11
+
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
 
       - name: Restore published artifacts
         # https://github.com/actions/cache/releases

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Run akka/github-actions-scripts
         uses: akka/github-actions-scripts/setup_global_resolver@main
+        with:
+          maven-mirror-control: 'NO_MIRROR'
 
       - name: Code style check and binary-compatibility check
         run: sbt "verifyCodeStyle; mimaReportBinaryIssues"

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           jvm: temurin:1.11
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: FOSSA policy check
         run: |-
           curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash

--- a/.github/workflows/integration-tests-cassandra.yml
+++ b/.github/workflows/integration-tests-cassandra.yml
@@ -48,6 +48,9 @@ jobs:
         with:
           jvm: ${{ matrix.jvmName }}
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Run all integration tests with default Scala and Java ${{ matrix.jdkVersion }}
         run: sbt "akka-projection-cassandra-integration/test" ${{ matrix.extraOpts }} -Dakka.warn-on-no-license-key=false
         env: # Disable Ryuk resource reaper since we always spin up fresh VMs

--- a/.github/workflows/integration-tests-dynamodb.yml
+++ b/.github/workflows/integration-tests-dynamodb.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           jvm: ${{ matrix.jvmName }}
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Start DynamoDB
         run: |-
           docker compose -f docker-files/docker-compose-dynamodb.yml up --wait

--- a/.github/workflows/integration-tests-grpc.yml
+++ b/.github/workflows/integration-tests-grpc.yml
@@ -48,6 +48,9 @@ jobs:
         with:
           jvm: ${{ matrix.jvmName }}
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Run all integration tests with default Scala and Java ${{ matrix.jdkVersion }}
         run: sbt "akka-projection-grpc-integration/test" ${{ matrix.extraOpts }} -Dakka.warn-on-no-license-key=false
         env: # Disable Ryuk resource reaper since we always spin up fresh VMs

--- a/.github/workflows/integration-tests-jdbc.yml
+++ b/.github/workflows/integration-tests-jdbc.yml
@@ -51,6 +51,9 @@ jobs:
         with:
           jvm: ${{ matrix.jvmName }}
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Run all integration tests with default Scala and Java ${{ matrix.jdkVersion }}
         run: sbt "akka-projection-jdbc-integration/test" ${{ matrix.extraOpts }} -Dakka.warn-on-no-license-key=false
         env: # Disable Ryuk resource reaper since we always spin up fresh VMs

--- a/.github/workflows/integration-tests-kafka.yml
+++ b/.github/workflows/integration-tests-kafka.yml
@@ -47,6 +47,9 @@ jobs:
         with:
           jvm: ${{ matrix.jvmName }}
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Run all integration tests with default Scala and Java ${{ matrix.jdkVersion }}
         run: sbt "akka-projection-kafka-integration/test" ${{ matrix.extraOpts }} -Dakka.warn-on-no-license-key=false
         env: # Disable Ryuk resource reaper since we always spin up fresh VMs

--- a/.github/workflows/integration-tests-r2dbc-mssql.yml
+++ b/.github/workflows/integration-tests-r2dbc-mssql.yml
@@ -45,6 +45,9 @@ jobs:
         with:
           jvm: ${{ matrix.jvmName }}
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Start DB
         run: |-
           docker compose -f docker-files/docker-compose-sqlserver.yml up --wait

--- a/.github/workflows/integration-tests-r2dbc.yml
+++ b/.github/workflows/integration-tests-r2dbc.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           jvm: ${{ matrix.jvmName }}
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Start DB
         run: |-
           docker compose -f docker-files/docker-compose-postgres.yml up --wait
@@ -92,6 +95,9 @@ jobs:
         uses: coursier/setup-action@70323223454ac2a9eb2de46f389b4d045cbcdea5
         with:
           jvm: ${{ matrix.jvmName }}
+
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
 
       - name: Start DB
         run: |-
@@ -141,6 +147,9 @@ jobs:
         uses: coursier/setup-action@7bde40eee928896f074dbb76d22dd772eed5c65f
         with:
           jvm: ${{ matrix.jvmName }}
+
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
 
       - name: Run integration tests with with Scala and Java ${{ matrix.jdkVersion }}
         run: |-

--- a/.github/workflows/integration-tests-slick.yml
+++ b/.github/workflows/integration-tests-slick.yml
@@ -51,6 +51,9 @@ jobs:
         with:
           jvm: ${{ matrix.jvmName }}
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Run all integration tests with default Scala and Java ${{ matrix.jdkVersion }}
         run: sbt "akka-projection-slick-integration/test" ${{ matrix.extraOpts }} -Dakka.warn-on-no-license-key=false
         env: # Disable Ryuk resource reaper since we always spin up fresh VMs

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -39,6 +39,9 @@ jobs:
           jvm: temurin:1.17.0.5
           apps: cs
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Create all API docs for artifacts/website and all reference docs
         run: sbt "unidoc; docs/paradox; akka-distributed-cluster-docs/paradox; akka-edge-docs/paradox"
 

--- a/.github/workflows/native-image-tests.yml
+++ b/.github/workflows/native-image-tests.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           jvm: graalvm-community:21.0.2
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Gather version
         # some cleanup of the sbt output to get the version sbt will use when publishing below
         run: |-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           jvm: temurin:1.11.0.17
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Publish artifacts for all Scala versions
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -72,6 +75,9 @@ jobs:
         uses: coursier/setup-action@7bde40eee928896f074dbb76d22dd772eed5c65f
         with:
           jvm: temurin:1.17
+
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
 
       - name: Publish
         run: |-

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -49,6 +49,9 @@ jobs:
         with:
           jvm: ${{ matrix.jvmName }}
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Run tests with default Scala and Java ${{ matrix.jdkVersion }}
         run: sbt "test" ${{ matrix.extraOpts }} -Dakka.warn-on-no-license-key=false
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ for [Scala](https://doc.akka.io/libraries/akka-projection/current/?language=scal
 
 The current versions of all Akka libraries are listed on the [Akka Dependencies](https://doc.akka.io/libraries/akka-dependencies/current/) page. Releases of the Akka Projections libraries in this repository are listed on the [GitHub releases](https://github.com/akka/akka-projection/releases) page.
 
+## Build Token
+
+To build locally, you need to fetch a token at https://account.akka.io/token that you have to place into `~/.sbt/1.0/akka-commercial.sbt` file like this:
+```
+ThisBuild / resolvers += "lightbend-akka".at("your token resolver here")
+```
+
 License
 -------
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,6 @@ import akka.projections.IntegrationTests
 ThisBuild / dynverSeparator := "-"
 // append -SNAPSHOT to version when isSnapshot
 ThisBuild / dynverSonatypeSnapshots := true
-ThisBuild / resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
 ThisBuild / resolvers ++=
   (if (Dependencies.Versions.Akka.endsWith("-SNAPSHOT"))
      Seq("Akka library snapshot repository".at("https://repo.akka.io/snapshots/github_actions"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
-
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.5")
 addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % "0.10.0")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")

--- a/samples/grpc/iot-service-java/pom.xml
+++ b/samples/grpc/iot-service-java/pom.xml
@@ -34,21 +34,6 @@
         <version.number>${git.commit.time}-${git.commit.id.abbrev}</version.number>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>akka-repository</id>
-            <name>Akka library repository</name>
-            <url>https://repo.akka.io/maven/github_actions</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>akka-repository</id>
-            <name>Akka library repository</name>
-            <url>https://repo.akka.io/maven/github_actions</url>
-        </pluginRepository>
-    </pluginRepositories>
-
     <dependencies>
         <dependency>
             <groupId>com.typesafe.akka</groupId>

--- a/samples/grpc/iot-service-scala/build.sbt
+++ b/samples/grpc/iot-service-scala/build.sbt
@@ -4,8 +4,6 @@ organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
-
 scalaVersion := "2.13.17"
 
 Compile / scalacOptions ++= Seq(

--- a/samples/grpc/iot-service-scala/project/plugins.sbt
+++ b/samples/grpc/iot-service-scala/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
-
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.5.10")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.13")

--- a/samples/grpc/local-drone-control-java/pom.xml
+++ b/samples/grpc/local-drone-control-java/pom.xml
@@ -39,21 +39,6 @@
         <version.number>${git.commit.time}-${git.commit.id.abbrev}</version.number>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>akka-repository</id>
-            <name>Akka library repository</name>
-            <url>https://repo.akka.io/maven/github_actions</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>akka-repository</id>
-            <name>Akka library repository</name>
-            <url>https://repo.akka.io/maven/github_actions</url>
-        </pluginRepository>
-    </pluginRepositories>
-
     <dependencies>
         <dependency>
             <groupId>com.typesafe.akka</groupId>

--- a/samples/grpc/local-drone-control-scala/build.sbt
+++ b/samples/grpc/local-drone-control-scala/build.sbt
@@ -4,8 +4,6 @@ organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
-
 scalaVersion := "2.13.17"
 
 Compile / scalacOptions ++= Seq(

--- a/samples/grpc/local-drone-control-scala/project/plugins.sbt
+++ b/samples/grpc/local-drone-control-scala/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
-
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.5.10")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")

--- a/samples/grpc/restaurant-drone-deliveries-service-java/pom.xml
+++ b/samples/grpc/restaurant-drone-deliveries-service-java/pom.xml
@@ -35,21 +35,6 @@
         <version.number>${git.commit.time}-${git.commit.id.abbrev}</version.number>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>akka-repository</id>
-            <name>Akka library repository</name>
-            <url>https://repo.akka.io/maven/github_actions</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>akka-repository</id>
-            <name>Akka library repository</name>
-            <url>https://repo.akka.io/maven/github_actions</url>
-        </pluginRepository>
-    </pluginRepositories>
-
     <dependencies>
         <dependency>
             <groupId>com.typesafe.akka</groupId>

--- a/samples/grpc/restaurant-drone-deliveries-service-scala/build.sbt
+++ b/samples/grpc/restaurant-drone-deliveries-service-scala/build.sbt
@@ -4,8 +4,6 @@ organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
-
 scalaVersion := "2.13.17"
 
 Compile / scalacOptions ++= Seq(

--- a/samples/grpc/restaurant-drone-deliveries-service-scala/project/plugins.sbt
+++ b/samples/grpc/restaurant-drone-deliveries-service-scala/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
-
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.5.10")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")

--- a/samples/grpc/shopping-analytics-service-java/pom.xml
+++ b/samples/grpc/shopping-analytics-service-java/pom.xml
@@ -34,21 +34,6 @@
         <version.number>${git.commit.time}-${git.commit.id.abbrev}</version.number>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>akka-repository</id>
-            <name>Akka library repository</name>
-            <url>https://repo.akka.io/maven/github_actions</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>akka-repository</id>
-            <name>Akka library repository</name>
-            <url>https://repo.akka.io/maven/github_actions</url>
-        </pluginRepository>
-    </pluginRepositories>
-
     <dependencies>
         <dependency>
             <groupId>com.typesafe.akka</groupId>

--- a/samples/grpc/shopping-analytics-service-scala/build.sbt
+++ b/samples/grpc/shopping-analytics-service-scala/build.sbt
@@ -4,8 +4,6 @@ organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
-
 scalaVersion := "2.13.17"
 
 Compile / scalacOptions ++= Seq(

--- a/samples/grpc/shopping-analytics-service-scala/project/plugins.sbt
+++ b/samples/grpc/shopping-analytics-service-scala/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
-
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.5.10")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")

--- a/samples/grpc/shopping-cart-service-java/pom.xml
+++ b/samples/grpc/shopping-cart-service-java/pom.xml
@@ -34,21 +34,6 @@
         <version.number>${git.commit.time}-${git.commit.id.abbrev}</version.number>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>akka-repository</id>
-            <name>Akka library repository</name>
-            <url>https://repo.akka.io/maven/github_actions</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>akka-repository</id>
-            <name>Akka library repository</name>
-            <url>https://repo.akka.io/maven/github_actions</url>
-        </pluginRepository>
-    </pluginRepositories>
-
     <dependencies>
         <dependency>
             <groupId>com.typesafe.akka</groupId>

--- a/samples/grpc/shopping-cart-service-scala/build.sbt
+++ b/samples/grpc/shopping-cart-service-scala/build.sbt
@@ -4,8 +4,6 @@ organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
-
 scalaVersion := "2.13.17"
 
 Compile / scalacOptions ++= Seq(

--- a/samples/grpc/shopping-cart-service-scala/project/plugins.sbt
+++ b/samples/grpc/shopping-cart-service-scala/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
-
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.5.10")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")

--- a/samples/replicated/shopping-cart-service-java/pom.xml
+++ b/samples/replicated/shopping-cart-service-java/pom.xml
@@ -34,21 +34,6 @@
         <version.number>${git.commit.time}-${git.commit.id.abbrev}</version.number>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>akka-repository</id>
-            <name>Akka library repository</name>
-            <url>https://repo.akka.io/maven/github_actions</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>akka-repository</id>
-            <name>Akka library repository</name>
-            <url>https://repo.akka.io/maven/github_actions</url>
-        </pluginRepository>
-    </pluginRepositories>
-
     <dependencies>
         <dependency>
             <groupId>com.typesafe.akka</groupId>

--- a/samples/replicated/shopping-cart-service-scala/build.sbt
+++ b/samples/replicated/shopping-cart-service-scala/build.sbt
@@ -4,8 +4,6 @@ organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
-
 scalaVersion := "2.13.17"
 
 Compile / scalacOptions ++= Seq(

--- a/samples/replicated/shopping-cart-service-scala/project/plugins.sbt
+++ b/samples/replicated/shopping-cart-service-scala/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
-
 addSbtPlugin("com.lightbend.akka.grpc" % "sbt-akka-grpc" % "2.5.10")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")


### PR DESCRIPTION
## Summary
- Add `akka/github-actions-scripts/setup_global_resolver@main` step to all CI workflow files (after JDK/GraalVM setup in each job)
- Remove the `https://repo.akka.io/maven/github_actions` resolver from all SBT build files (`build.sbt`, `project/plugins.sbt`, and all sample projects) and Maven `pom.xml` files
- Add `## Build Token` section to `README.md` with instructions for local development

## Test plan
- [ ] Verify all CI workflows pass with the new global resolver step
- [ ] Verify that local builds work using the token instructions in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)