### PR TITLE
ddb perf: reduce I/O in CAS retries by adopting pessimistic concurrency around offset saves

### DIFF
--- a/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetStoreSpec.scala
+++ b/akka-projection-dynamodb-integration/src/test/scala/akka/projection/dynamodb/DynamoDBTimestampOffsetStoreSpec.scala
@@ -35,7 +35,7 @@ import akka.projection.dynamodb.internal.DynamoDBOffsetStore.Validation.Duplicat
 import akka.projection.dynamodb.internal.DynamoDBOffsetStore.Validation.RejectedBacktrackingSeqNr
 import akka.projection.dynamodb.internal.DynamoDBOffsetStore.Validation.RejectedSeqNr
 import akka.projection.dynamodb.internal.OffsetPidSeqNr
-import akka.projection.dynamodb.internal.OffsetStoreDao
+import akka.projection.dynamodb.internal.OffsetStoreDaoImpl
 import akka.projection.dynamodb.internal.OffsetStoreDao.OffsetStoreAttributes
 import akka.projection.internal.ManagementState
 import com.typesafe.config.Config
@@ -1303,7 +1303,7 @@ abstract class DynamoDBTimestampOffsetStoreBaseSpec(config: Config)
         .futureValue
       // it's evicted immediately
       offsetStore.getState().byPid.keySet shouldBe Set(p7, p8)
-      val dao = new OffsetStoreDao(system, settings, projectionId, client)
+      val dao = new OffsetStoreDaoImpl(system, settings, projectionId, client)
       // but still saved
       dao.loadSequenceNumber(slice(p2), p2).futureValue.get.seqNr shouldBe 2
       // the timestamp was earlier than previously used for this slice, and therefore stored timestamp not changed

--- a/akka-projection-dynamodb/src/main/mima-filters/1.6.20.backwards.excludes/1424-pessimistic-save.excludes
+++ b/akka-projection-dynamodb/src/main/mima-filters/1.6.20.backwards.excludes/1424-pessimistic-save.excludes
@@ -1,0 +1,4 @@
+# InternalApi
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.dynamodb.internal.DynamoDBOffsetStore#State.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.dynamodb.internal.DynamoDBOffsetStore#State.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.projection.dynamodb.internal.DynamoDBOffsetStore#State.apply")

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -523,7 +523,7 @@ private[projection] class DynamoDBOffsetStore(
 
         case _ =>
           throw new IllegalArgumentException(
-            s"$logPrefix Mix of TimestampOffset and ofther offset type in same transaction is not supported.")
+            s"$logPrefix Mix of TimestampOffset and other offset type in same transaction is not supported.")
       }
 
       val currentStore = pendingStore.get()

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -554,7 +554,6 @@ private[projection] class DynamoDBOffsetStore(
         if (pendingStore.compareAndExchange(currentStore, promise.future) eq currentStore) {
           storeTimestampOffsets(records, storeSequenceNumbers, canBeConcurrent)
         } else {
-          logger.error("{} Concurrent storing of offsets detected.  This should not happen", logPrefix)
           Future.failed(new IllegalStateException(s"$logPrefix Concurrent storing of offsets detected"))
         }
       }(ExecutionContext.parasitic)

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -12,6 +12,9 @@ import scala.annotation.tailrec
 import scala.collection.immutable.TreeSet
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.util.Failure
+import scala.util.Success
 import scala.jdk.DurationConverters._
 import scala.util.control.NonFatal
 import akka.Done
@@ -83,7 +86,8 @@ private[projection] object DynamoDBOffsetStore {
   final case class State(
       byPid: Map[Pid, Record],
       bySliceSorted: Map[Int, TreeSet[Record]],
-      offsetBySlice: Map[Int, TimestampOffset]) {
+      offsetBySlice: Map[Int, TimestampOffset],
+      saveCounter: Long = 0) {
 
     def size: Int = byPid.size
 
@@ -229,8 +233,25 @@ private[projection] class DynamoDBOffsetStore(
     sourceProvider: Option[BySlicesSourceProvider],
     system: ActorSystem[_],
     val settings: DynamoDBProjectionSettings,
-    client: DynamoDbAsyncClient,
-    clock: Clock = Clock.systemUTC()) {
+    dao: OffsetStoreDao,
+    clock: Clock) {
+
+  private[projection] def this(
+      projectionId: ProjectionId,
+      uuid: String,
+      sourceProvider: Option[BySlicesSourceProvider],
+      system: ActorSystem[_],
+      settings: DynamoDBProjectionSettings,
+      client: DynamoDbAsyncClient,
+      clock: Clock = Clock.systemUTC()) =
+    this(
+      projectionId,
+      uuid,
+      sourceProvider,
+      system,
+      settings,
+      new OffsetStoreDaoImpl(system, settings, projectionId, client),
+      clock)
 
   import DynamoDBOffsetStore._
 
@@ -244,8 +265,6 @@ private[projection] class DynamoDBOffsetStore(
   private val logger = LoggerFactory.getLogger(this.getClass)
   val logPrefix = s"${projectionId.name} [$minSlice-$maxSlice]${CorrelationId.toCorrelationLogText(uuid)}:"
 
-  private val dao = new OffsetStoreDao(system, settings, projectionId, client)
-
   private val offsetExpiry =
     settings.timeToLiveSettings.projections.get(projectionId.name).offsetTimeToLive.map(_.toJava)
 
@@ -253,13 +272,21 @@ private[projection] class DynamoDBOffsetStore(
 
   // The OffsetStore instance is used by a single projectionId and there shouldn't be many concurrent
   // calls to methods that access the `state`, but for example validate (load) may be concurrent
-  // with save. Therefore, this state can be updated concurrently with CAS retries.
+  // with save. Therefore, this state can be updated concurrently with CAS retries, though retries
+  // are nearly certain to involve I/O
   private val state = new AtomicReference(State.empty)
 
   // Transient state of inflight pid -> seqNr (before they have been stored and included in `state`), which is
   // needed for at-least-once or other projections where the offset is saved afterwards. Not needed for exactly-once.
   // This can be updated concurrently with CAS retries.
   private val inflight = new AtomicReference(Map.empty[Pid, SeqNr])
+
+  // Advisory pessimistic concurrency control to allow validation loads to wait until a save completes
+  // (as a save is multiple queries (slice offset and per-pid timestamps), moreso in at-least-once)
+  // to prevent retrying the save on conflict.
+  //  incomplete future: save is in-progress
+  //  completed future: no in-progress save
+  private val pendingStore = new AtomicReference[Future[Done]](FutureDone)
 
   @volatile private var stopped = false
 
@@ -369,21 +396,77 @@ private[projection] class DynamoDBOffsetStore(
     if (oldState.contains(pid))
       Future.successful(oldState)
     else {
-      val slice = persistenceExt.sliceForPersistenceId(pid)
-      dao.loadSequenceNumber(slice, pid).flatMap {
-        case Some(record) =>
-          logger.trace("{} loaded pid [{}], seqNr [{}]", logPrefix, pid, record.seqNr)
-          val newState = oldState.add(Vector(record), settings.acceptSequenceNumberResetAfter)
-          if (state.compareAndSet(oldState, newState))
-            Future.successful(newState)
-          else
-            load(pid) // CAS retry, concurrent update
-        case None => Future.successful(oldState)
+      val ps = pendingStore.get()
+      ps.value match {
+        case Some(Failure(ex)) => Future.failed(ex)
+        case Some(Success(_))  =>
+          // store completed... it's unlikely that it updated state and completed in the time between state.get
+          // and checking the future, so we can be optimistic here
+          val slice = persistenceExt.sliceForPersistenceId(pid)
+          loadFromDao(slice, pid, oldState)
+
+        case None =>
+          // store is in progress, so when it completes, the state will have probably changed
+          ps.flatMap(_ => load(pid)) // async retry
       }
     }
   }
 
+  private def loadFromDao(slice: Int, pid: Pid, oldState: State): Future[State] = {
+    checkStopped()
+    dao.loadSequenceNumber(slice, pid).flatMap {
+      case None => Future.successful(state.get())
+      case Some(record) =>
+        logger.trace("{} loaded pid [{}], seqNr [{}]", logPrefix, pid, record.seqNr)
+        val newState = oldState.add(Vector(record), settings.acceptSequenceNumberResetAfter)
+
+        if (state.compareAndSet(oldState, newState)) Future.successful(newState)
+        else {
+          // Intervening update(s)
+          val updatedState = state.get()
+          if (updatedState.saveCounter == oldState.saveCounter) {
+            // none of the updates was a save
+            val newerState = updatedState.add(Vector(record), settings.acceptSequenceNumberResetAfter)
+            if (state.compareAndSet(updatedState, newerState)) Future.successful(newerState)
+            else {
+              load(pid) // CAS retry, concurrent update
+            }
+          } else if (updatedState.saveCounter == oldState.saveCounter + 1) {
+            // exactly one save
+            if (updatedState.contains(pid)) Future.successful(updatedState)
+            else {
+              val newerState = updatedState.add(Vector(record), settings.acceptSequenceNumberResetAfter)
+              if (state.compareAndSet(updatedState, newerState)) Future.successful(newerState)
+              else {
+                load(pid) // CAS retry concurrent update
+              }
+            }
+          } else {
+            // Multiple saves (which can evict), so retry from the top
+            load(pid) // CAS retry, concurrent update
+          }
+        }
+    }
+  }
+
   def load(pids: Set[Pid]): Future[State] = {
+    checkStopped()
+    val oldState = state.get()
+    val pidsToLoad = pids.filterNot(oldState.contains)
+
+    if (pidsToLoad.isEmpty) Future.successful(oldState)
+    else {
+      val ps = pendingStore.get()
+      ps.value match {
+        case Some(Failure(ex)) => Future.failed(ex)
+        case Some(Success(_))  => rawLoad(pids)
+        case None              => ps.flatMap { _ => load(pids) }
+      }
+    }
+  }
+
+  // Callable from within storeTimestampOffsets, does not check for current store completion
+  private def rawLoad(pids: Set[Pid]): Future[State] = {
     checkStopped()
     val oldState = state.get()
     val pidsToLoad = pids.filterNot(oldState.contains)
@@ -404,7 +487,7 @@ private[projection] class DynamoDBOffsetStore(
         if (state.compareAndSet(oldState, newState))
           Future.successful(newState)
         else
-          load(pids) // CAS retry, concurrent update
+          rawLoad(pids) // CAS retry, concurrent update
       }
     }
   }
@@ -426,23 +509,44 @@ private[projection] class DynamoDBOffsetStore(
       storeSequenceNumbers: IndexedSeq[Record] => Future[Done],
       canBeConcurrent: Boolean): Future[Done] = {
     checkStopped()
-    if (offsets.isEmpty)
-      FutureDone
+
+    if (offsets.isEmpty) FutureDone
     else if (offsets.head.offset.isInstanceOf[TimestampOffset]) {
       val records = offsets.map {
         case OffsetPidSeqNr(t: TimestampOffset, Some((pid, seqNr))) =>
           val slice = persistenceExt.sliceForPersistenceId(pid)
           Record(slice, pid, seqNr, t.timestamp)
+
         case OffsetPidSeqNr(_: TimestampOffset, None) =>
           throw new IllegalArgumentException(
             s"$logPrefix Required EventEnvelope or DurableStateChange for TimestampOffset.")
+
         case _ =>
           throw new IllegalArgumentException(
-            s"$logPrefix Mix of TimestampOffset and other offset type in same transaction is not supported")
+            s"$logPrefix Mix of TimestampOffset and ofther offset type in same transaction is not supported.")
       }
-      storeTimestampOffsets(records, storeSequenceNumbers, canBeConcurrent)
+
+      val currentStore = pendingStore.get()
+      val promise = Promise[Done]()
+
+      val ret = currentStore.flatMap { _ =>
+        checkStopped()
+        if (pendingStore.compareAndExchange(currentStore, promise.future) eq currentStore) {
+          storeTimestampOffsets(records, storeSequenceNumbers, canBeConcurrent)
+        } else {
+          logger.error("{} Concurrent storing of offsets detected.  This should not happen", logPrefix)
+          Future.failed(new IllegalStateException(s"$logPrefix Concurrent storing of offsets detected"))
+        }
+      }(ExecutionContext.parasitic)
+
+      ret.onComplete { _ =>
+        promise.completeWith(ret)
+      }(ExecutionContext.parasitic)
+
+      ret
     } else {
-      throw new IllegalStateException(s"$logPrefix TimestampOffset is required. Primitive offsets not supported.")
+      Future.failed(
+        new IllegalStateException(s"$logPrefix TimestampOffset is required.  Primitive offsets not supported"))
     }
   }
 
@@ -451,7 +555,7 @@ private[projection] class DynamoDBOffsetStore(
       storeSequenceNumbers: IndexedSeq[Record] => Future[Done],
       canBeConcurrent: Boolean): Future[Done] = {
     checkStopped()
-    load(records.iterator.map(_.pid).toSet).flatMap { oldState =>
+    rawLoad(records.iterator.map(_.pid).toSet).flatMap { oldState =>
       val filteredRecords =
         if (records.size <= 1)
           records.filterNot(record => oldState.isDuplicate(record, settings.acceptSequenceNumberResetAfter))
@@ -479,18 +583,20 @@ private[projection] class DynamoDBOffsetStore(
           else filteredRecords.iterator.map(_.slice).toSet
 
         val currentInflight = getInflight()
-        val evictedNewState = slices.foldLeft(newState) {
-          case (s, slice) =>
-            s.evict(
-              slice,
-              settings.timeWindow,
-              // Only persistence IDs that aren't inflight are evictable,
-              // if only so that those persistence IDs can be removed from
-              // inflight... in the absence of further records from that
-              // persistence ID, the next store will evict (further records
-              // would make that persistence ID recent enough to not be evicted)
-              record => !currentInflight.contains(record.pid))
-        }
+        val evictedNewState = slices
+          .foldLeft(newState) {
+            case (s, slice) =>
+              s.evict(
+                slice,
+                settings.timeWindow,
+                // Only persistence IDs that aren't inflight are evictable,
+                // if only so that those persistence IDs can be removed from
+                // inflight... in the absence of further records from that
+                // persistence ID, the next store will evict (further records
+                // would make that persistence ID recent enough to not be evicted)
+                record => !currentInflight.contains(record.pid))
+          }
+          .copy(saveCounter = oldState.saveCounter + 1)
 
         // FIXME we probably don't have to store the latest offset per slice all the time, but can
         //       accumulate some changes and flush on size/time.
@@ -538,8 +644,10 @@ private[projection] class DynamoDBOffsetStore(
               cleanupInflight(evictedNewState)
               FutureDone
             } else { // concurrent update
-              if (canBeConcurrent) storeTimestampOffsets(records, storeSequenceNumbers, canBeConcurrent) // CAS retry
-              else
+              if (canBeConcurrent) {
+                logger.info(s"$logPrefix re-attempting save of timestamp offsets due to concurrent update.")
+                storeTimestampOffsets(records, storeSequenceNumbers, canBeConcurrent) // CAS retry
+              } else
                 throw new IllegalStateException(
                   s"$logPrefix Unexpected concurrent modification of state in save offsets.")
             }

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -415,7 +415,21 @@ private[projection] class DynamoDBOffsetStore(
   private def loadFromDao(slice: Int, pid: Pid, oldState: State): Future[State] = {
     checkStopped()
     dao.loadSequenceNumber(slice, pid).flatMap {
-      case None => Future.successful(state.get())
+      case None =>
+        // no sequence number found, no update, but we can try to move forward
+        val latestState = state.get()
+        if (latestState eq oldState) Future.successful(oldState)
+        else if (latestState.saveCounter == oldState.saveCounter) {
+          // no saves in the meantime + no updates, move forward to latestState
+          Future.successful(latestState)
+        } else if (latestState.saveCounter == oldState.saveCounter + 1) {
+          // exactly one save: if the save was for this pid, the latest pid is in latestState
+          Future.successful(latestState)
+        } else {
+          // multiple saves, could have saved and then evicted, CAS retry from the top
+          load(pid)
+        }
+
       case Some(record) =>
         logger.trace("{} loaded pid [{}], seqNr [{}]", logPrefix, pid, record.seqNr)
         val newState = oldState.add(Vector(record), settings.acceptSequenceNumberResetAfter)
@@ -483,6 +497,7 @@ private[projection] class DynamoDBOffsetStore(
             logger.trace("{} loaded pid [{}], seqNr [{}]", logPrefix, record.pid, record.seqNr)
           }
         }
+
         val newState = oldState.add(records.flatten, settings.acceptSequenceNumberResetAfter)
         if (state.compareAndSet(oldState, newState))
           Future.successful(newState)
@@ -539,8 +554,16 @@ private[projection] class DynamoDBOffsetStore(
         }
       }(ExecutionContext.parasitic)
 
-      ret.onComplete { _ =>
+      ret.onComplete { result =>
+        // propagate the failure to subsequent operations
         promise.completeWith(ret)
+
+        if (result.isFailure) {
+          // A failure in save will fail the stream using this offset store.
+          // This will trigger a stop() call, but it is certain that the
+          // it will eventually happen... we may as well stop() here
+          stop()
+        }
       }(ExecutionContext.parasitic)
 
       ret

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -195,7 +195,6 @@ private[projection] object DynamoDBOffsetStore {
       sb.append(")")
       sb.toString
     }
-
   }
 
   final class RejectedEnvelope(message: String) extends IllegalStateException(message)
@@ -221,6 +220,12 @@ private[projection] object DynamoDBOffsetStore {
   val FutureDone: Future[Done] = Future.successful(Done)
 
   final class AttemptToUseStoppedOffsetStore(message: String) extends RuntimeException(message)
+
+  // constant added to save counter on failed stores
+  // a fairly large number (> 2^32), larger than any reasonable number of stores between CAS retries in load()
+  // yet would need at least 2^28 failed stores to increment and wrap around to anything close to the save counter
+  // before the failed stores
+  private val WontTurnAround = 0xACE0FBA5EL
 }
 
 /**
@@ -554,17 +559,28 @@ private[projection] class DynamoDBOffsetStore(
         }
       }(ExecutionContext.parasitic)
 
-      ret.onComplete { result =>
-        // propagate the failure to subsequent operations
-        promise.completeWith(ret)
+      ret
+        .recoverWith {
+          // unfortunately, there's no andThen-equivalent for failed futures
+          case _ =>
+            // byPid/bySlice state may or may not be consistent with what's actually been written to DDB
+            // (same for offsetBySlice, but no decisions are made based on offsetBySlice, so no need to invalidate)
+            // therefore, we empty the byPid/bySlice state
+            @tailrec
+            def casRetry(oldState: State): Unit = {
+              val newState =
+                State(Map.empty, Map.empty, oldState.offsetBySlice, oldState.saveCounter + WontTurnAround)
 
-        if (result.isFailure) {
-          // A failure in save will fail the stream using this offset store.
-          // This will trigger a stop() call, but it is certain that the
-          // it will eventually happen... we may as well stop() here
-          stop()
+              if (!state.compareAndSet(oldState, newState)) casRetry(state.get())
+            }
+
+            casRetry(state.get())
+            ret
         }
-      }(ExecutionContext.parasitic)
+        .onComplete { _ =>
+          // unblock other operations
+          promise.success(Done)
+        }(ExecutionContext.parasitic)
 
       ret
     } else {

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -221,9 +221,6 @@ private[projection] object DynamoDBOffsetStore {
   val FutureDone: Future[Done] = Future.successful(Done)
 
   final class AttemptToUseStoppedOffsetStore(message: String) extends RuntimeException(message)
-
-  // a big jump in the save counter (to signal a discontinuity), but not so big that a plausible number of jumps would overflow around
-  private val DontTurnAround = 0xACE0FBA5EL
 }
 
 /**
@@ -237,10 +234,7 @@ private[projection] class DynamoDBOffsetStore(
     system: ActorSystem[_],
     val settings: DynamoDBProjectionSettings,
     dao: OffsetStoreDao,
-    clock: Clock,
-    // if true, offset store is not stopped on a save failure but state is reset (analogous to restart supervision strategy)
-    // if false, offset store is stopped and subsequent operations will fail (note that the stream using the offset store will likely fail also)
-    clearStateOnSaveFailure: Boolean) {
+    clock: Clock) {
 
   private[projection] def this(
       projectionId: ProjectionId,
@@ -249,8 +243,7 @@ private[projection] class DynamoDBOffsetStore(
       system: ActorSystem[_],
       settings: DynamoDBProjectionSettings,
       client: DynamoDbAsyncClient,
-      clock: Clock = Clock.systemUTC(),
-      clearStateOnSaveFailure: Boolean = false) =
+      clock: Clock = Clock.systemUTC()) =
     this(
       projectionId,
       uuid,
@@ -258,8 +251,7 @@ private[projection] class DynamoDBOffsetStore(
       system,
       settings,
       new OffsetStoreDaoImpl(system, settings, projectionId, client),
-      clock,
-      clearStateOnSaveFailure)
+      clock)
 
   import DynamoDBOffsetStore._
 
@@ -382,7 +374,6 @@ private[projection] class DynamoDBOffsetStore(
             s"${dumpState(oldState, getInflight())}")
         clearInflight()
       }
-
       if (offsetBySlice.isEmpty) {
         logger.debug("{} readTimestampOffset no stored offset", logPrefix)
         TimestampOffsetBySlice.empty
@@ -563,54 +554,19 @@ private[projection] class DynamoDBOffsetStore(
         }
       }(ExecutionContext.parasitic)
 
-      if (!clearStateOnSaveFailure) {
-        // analogous to stop supervision
-        // if this is a success, great
-        // if this failed, propagate failure to subsequent operations and stop offset store
-        ret.onComplete { result =>
-          promise.completeWith(ret)
+      ret.onComplete { result =>
+        // propagate the failure to subsequent operations
+        promise.completeWith(ret)
 
-          if (result.isFailure) {
-            stop()
-          }
-        }(ExecutionContext.parasitic)
-
-        ret
-      } else {
-        // analogous to restart supervision
-        ret.transformWith {
-          case Success(_) =>
-            promise.success(Done)
-            ret
-
-          case Failure(_) =>
-            // Must never leave in an inconsistent state
-            def recoverState: Future[Done] =
-              readTimestampOffset(false)
-                .flatMap { offset =>
-                  def newState(from: State): State =
-                    State(Map.empty, Map.empty, offset.offsets, from.saveCounter + DontTurnAround)
-
-                  @tailrec
-                  def casRetry(oldState: State): Unit =
-                    if (!state.compareAndSet(oldState, newState(oldState))) casRetry(state.get())
-
-                  casRetry(state.get())
-                  FutureDone
-                }
-                .recoverWith {
-                  case ex =>
-                    logger.warn("loadTimestampOffset failed when recovering offset store after failed save", ex)
-                    // FIXME: backoff?
-                    recoverState
-                }
-
-            recoverState.flatMap { _ =>
-              promise.success(Done)
-              ret
-            }
+        if (result.isFailure) {
+          // A failure in save will fail the stream using this offset store.
+          // This will trigger a stop() call, but it is certain that the
+          // it will eventually happen... we may as well stop() here
+          stop()
         }
-      }
+      }(ExecutionContext.parasitic)
+
+      ret
     } else {
       Future.failed(
         new IllegalStateException(s"$logPrefix TimestampOffset is required.  Primitive offsets not supported"))

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -684,7 +684,7 @@ private[projection] class DynamoDBOffsetStore(
               FutureDone
             } else { // concurrent update
               if (canBeConcurrent) {
-                logger.info(s"$logPrefix re-attempting save of timestamp offsets due to concurrent update.")
+                logger.info("{} re-attempting save of timestamp offsets due to concurrent update.", logPrefix)
                 storeTimestampOffsets(records, storeSequenceNumbers, canBeConcurrent) // CAS retry
               } else
                 throw new IllegalStateException(

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -221,6 +221,9 @@ private[projection] object DynamoDBOffsetStore {
   val FutureDone: Future[Done] = Future.successful(Done)
 
   final class AttemptToUseStoppedOffsetStore(message: String) extends RuntimeException(message)
+
+  // a big jump in the save counter (to signal a discontinuity), but not so big that a plausible number of jumps would overflow around
+  private val DontTurnAround = 0xACE0FBA5EL
 }
 
 /**
@@ -234,7 +237,10 @@ private[projection] class DynamoDBOffsetStore(
     system: ActorSystem[_],
     val settings: DynamoDBProjectionSettings,
     dao: OffsetStoreDao,
-    clock: Clock) {
+    clock: Clock,
+    // if true, offset store is not stopped on a save failure but state is reset (analogous to restart supervision strategy)
+    // if false, offset store is stopped and subsequent operations will fail (note that the stream using the offset store will likely fail also)
+    clearStateOnSaveFailure: Boolean) {
 
   private[projection] def this(
       projectionId: ProjectionId,
@@ -243,7 +249,8 @@ private[projection] class DynamoDBOffsetStore(
       system: ActorSystem[_],
       settings: DynamoDBProjectionSettings,
       client: DynamoDbAsyncClient,
-      clock: Clock = Clock.systemUTC()) =
+      clock: Clock = Clock.systemUTC(),
+      clearStateOnSaveFailure: Boolean = false) =
     this(
       projectionId,
       uuid,
@@ -251,7 +258,8 @@ private[projection] class DynamoDBOffsetStore(
       system,
       settings,
       new OffsetStoreDaoImpl(system, settings, projectionId, client),
-      clock)
+      clock,
+      clearStateOnSaveFailure)
 
   import DynamoDBOffsetStore._
 
@@ -374,6 +382,7 @@ private[projection] class DynamoDBOffsetStore(
             s"${dumpState(oldState, getInflight())}")
         clearInflight()
       }
+
       if (offsetBySlice.isEmpty) {
         logger.debug("{} readTimestampOffset no stored offset", logPrefix)
         TimestampOffsetBySlice.empty
@@ -554,19 +563,54 @@ private[projection] class DynamoDBOffsetStore(
         }
       }(ExecutionContext.parasitic)
 
-      ret.onComplete { result =>
-        // propagate the failure to subsequent operations
-        promise.completeWith(ret)
+      if (!clearStateOnSaveFailure) {
+        // analogous to stop supervision
+        // if this is a success, great
+        // if this failed, propagate failure to subsequent operations and stop offset store
+        ret.onComplete { result =>
+          promise.completeWith(ret)
 
-        if (result.isFailure) {
-          // A failure in save will fail the stream using this offset store.
-          // This will trigger a stop() call, but it is certain that the
-          // it will eventually happen... we may as well stop() here
-          stop()
+          if (result.isFailure) {
+            stop()
+          }
+        }(ExecutionContext.parasitic)
+
+        ret
+      } else {
+        // analogous to restart supervision
+        ret.transformWith {
+          case Success(_) =>
+            promise.success(Done)
+            ret
+
+          case Failure(_) =>
+            // Must never leave in an inconsistent state
+            def recoverState: Future[Done] =
+              readTimestampOffset(false)
+                .flatMap { offset =>
+                  def newState(from: State): State =
+                    State(Map.empty, Map.empty, offset.offsets, from.saveCounter + DontTurnAround)
+
+                  @tailrec
+                  def casRetry(oldState: State): Unit =
+                    if (!state.compareAndSet(oldState, newState(oldState))) casRetry(state.get())
+
+                  casRetry(state.get())
+                  FutureDone
+                }
+                .recoverWith {
+                  case ex =>
+                    logger.warn("loadTimestampOffset failed when recovering offset store after failed save", ex)
+                    // FIXME: backoff?
+                    recoverState
+                }
+
+            recoverState.flatMap { _ =>
+              promise.success(Done)
+              ret
+            }
         }
-      }(ExecutionContext.parasitic)
-
-      ret
+      }
     } else {
       Future.failed(
         new IllegalStateException(s"$logPrefix TimestampOffset is required.  Primitive offsets not supported"))

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/OffsetStoreDao.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/OffsetStoreDao.scala
@@ -66,13 +66,28 @@ import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse
 /**
  * INTERNAL API
  */
-@InternalApi private[projection] class OffsetStoreDao(
+@InternalApi private[projection] trait OffsetStoreDao {
+  def loadTimestampOffset(slice: Int): Future[Option[TimestampOffset]]
+  def storeTimestampOffsets(offsetsBySlice: Map[Int, TimestampOffset]): Future[Done]
+  def storeSequenceNumbers(records: IndexedSeq[Record]): Future[Done]
+  def loadSequenceNumber(slice: Int, pid: String): Future[Option[Record]]
+  def transactStoreSequenceNumbers(writeItems: Iterable[TransactWriteItem])(records: Seq[Record]): Future[Done]
+  def readManagementState(slice: Int): Future[Option[ManagementState]]
+  def updateManagementState(minSlice: Int, maxSlice: Int, paused: Boolean): Future[Done]
+
+  protected final val log: Logger = OffsetStoreDao.log
+  protected final val MaxTransactItems = OffsetStoreDao.MaxTransactItems
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[projection] class OffsetStoreDaoImpl(
     system: ActorSystem[_],
     settings: DynamoDBProjectionSettings,
     projectionId: ProjectionId,
-    client: DynamoDbAsyncClient) {
-  import OffsetStoreDao.log
-  import OffsetStoreDao.MaxTransactItems
+    client: DynamoDbAsyncClient)
+    extends OffsetStoreDao {
   import settings.offsetBatchSize
   import system.executionContext
 

--- a/akka-projection-dynamodb/src/test/resources/logback-test.xml
+++ b/akka-projection-dynamodb/src/test/resources/logback-test.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%X{akkaAddress}] [%marker] [%thread] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender"/>
+    <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka.projection" level="DEBUG" />
+    <logger name="akka.projection.dynamodb" level="TRACE" />
+    <logger name="akka.persistence.dynamodb" level="DEBUG" />
+    <logger name="software.amazon.awssdk.request" level="INFO" />
+
+
+    <root level="INFO">
+        <appender-ref ref="CapturingAppender"/>
+<!--        <appender-ref ref="STDOUT"/>-->
+    </root>
+
+</configuration>

--- a/akka-projection-dynamodb/src/test/scala/akka/persistence/dynamodb/internal/DynamoDBOffsetStoreSpec.scala
+++ b/akka-projection-dynamodb/src/test/scala/akka/persistence/dynamodb/internal/DynamoDBOffsetStoreSpec.scala
@@ -28,7 +28,6 @@ import akka.projection.internal.ManagementState
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpecLike
 import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem
-import akka.projection.dynamodb.internal.DynamoDBOffsetStore.AttemptToUseStoppedOffsetStore
 
 object DynamoDBOffsetStoreSpec {
   val config = {
@@ -288,27 +287,41 @@ class DynamoDBOffsetStoreSpec
         .futureValue shouldBe 3 // one of the states has both pids
     }
 
-    "stop on failed save and propagate" in {
+    "reset state on failed save but not stop" in {
       val clock = Clock.systemUTC()
+      val startTime = clock.instant()
 
       val dao = new ProbeStubOffsetStoreDao(testKit)
 
       val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
 
-      val t0 = clock.instant()
+      val t0 = startTime
       val offset0 = TimestampOffset(t0, Map("p1" -> 777L))
+      val slice1 = dao.sliceFor("p1")
+      val recordP1N1 = Record(slice1, "p1", 776, offset0.timestamp.minusSeconds(400))
+      Seq("p1", "p2").foreach { pid =>
+        dao.initializeProbes(Some(pid), Some(dao.sliceFor(pid)))
+      }
 
+      val firstLoadFuture = offsetStore.load("p1")
+      val p1Probe = dao.probesByPid.get("p1")
+      p1Probe.expectMessageType[LoadSequenceNumber].promise.success(Some(recordP1N1))
+      firstLoadFuture.futureValue.byPid.get("p1").map(_.seqNr) should contain(776L)
       val saveFuture = offsetStore.saveOffset(OffsetPidSeqNr(offset0, "p1", 777))
-      val loadFromSave = dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber]
-      val loadFuture = offsetStore.load("p2")
-      loadFuture.value shouldBe (empty)
-      loadFromSave.promise.failure(new RuntimeException("DB went boom"))
+      // no need to load...
+      val storeSequenceNumber = p1Probe.expectMessageType[StoreSequenceNumber]
+      storeSequenceNumber.seqNr shouldBe 777
+      val secondLoadFuture = offsetStore.load("p2")
+      val p2Probe = dao.probesByPid.get("p2")
+      p2Probe.expectNoMessage(30.millis)
 
-      saveFuture.failed.futureValue.getMessage should include("DB went boom")
-      eventually { assert(offsetStore.isStopped(), "offset store should stop") }
-      loadFuture.failed.futureValue.getMessage should include("DB went boom")
+      storeSequenceNumber.promise.failure(new RuntimeException("DB failure"))
+      p2Probe.expectMessageType[LoadSequenceNumber].promise.success(None)
 
-      an[AttemptToUseStoppedOffsetStore] shouldBe thrownBy { offsetStore.load("p2") }
+      (the[RuntimeException] thrownBy (saveFuture.futureValue)).getMessage should include("DB failure")
+      (secondLoadFuture.futureValue.byPid.keySet shouldNot contain).oneOf("p1", "p2")
+
+      assert(!offsetStore.isStopped(), "offset store should not be stopped")
     }
   }
 }

--- a/akka-projection-dynamodb/src/test/scala/akka/persistence/dynamodb/internal/DynamoDBOffsetStoreSpec.scala
+++ b/akka-projection-dynamodb/src/test/scala/akka/persistence/dynamodb/internal/DynamoDBOffsetStoreSpec.scala
@@ -1,0 +1,287 @@
+package akka.projection.dynamodb.internal
+
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+
+import akka.Done
+import akka.actor.testkit.typed.scaladsl.ActorTestKit
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.persistence.Persistence
+import akka.persistence.query.TimestampOffset
+import akka.projection.ProjectionId
+import akka.projection.dynamodb.DynamoDBProjectionSettings
+import akka.projection.dynamodb.internal.DynamoDBOffsetStore.Record
+import akka.projection.internal.ManagementState
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpecLike
+import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem
+
+object DynamoDBOffsetStoreSpec {
+  val config = {
+    val default = ConfigFactory.load()
+
+    ConfigFactory.parseString("""
+      akka.loglevel = DEBUG
+    """).withFallback(default)
+  }
+
+  sealed trait ByPidCommand
+
+  final case class LoadSequenceNumber(promise: Promise[Option[Record]]) extends ByPidCommand
+  final case class StoreSequenceNumber(seqNr: Long, timestamp: Instant, promise: Promise[Done]) extends ByPidCommand
+
+  sealed trait BySliceCommand
+
+  final case class StoreTimestampOffset(offset: TimestampOffset, promise: Promise[Done]) extends BySliceCommand
+
+  //@annotation.nowarn("msg=never used")
+  class InMemOffsetStoreDao(testKit: ActorTestKit) extends OffsetStoreDao {
+    import testKit.system
+
+    implicit val ec: ExecutionContext = system.executionContext
+
+    val probesBySlice = new ConcurrentHashMap[Int, TestProbe[BySliceCommand]]()
+    val probesByPid = new ConcurrentHashMap[String, TestProbe[ByPidCommand]]()
+
+    def initializeProbes(pid: Option[String], slice: Option[Int]): Unit = {
+      pid.foreach { p => probesByPid.putIfAbsent(p, TestProbe()) }
+      slice.foreach { s => probesBySlice.putIfAbsent(s, TestProbe()) }
+    }
+
+    def transactStoreSequenceNumbers(writeItems: Iterable[TransactWriteItem])(records: Seq[Record]): Future[Done] =
+      throw new NotImplementedError("Transactional store not tested in this spec, only in the integration test")
+
+    def readManagementState(slice: Int): Future[Option[ManagementState]] = managementStateNotImplemented
+    def updateManagementState(minSlice: Int, maxSlice: Int, paused: Boolean): Future[Done] =
+      managementStateNotImplemented
+
+    def loadTimestampOffset(slice: Int): Future[Option[TimestampOffset]] = ???
+
+    def storeTimestampOffsets(offsetsBySlice: Map[Int, TimestampOffset]): Future[Done] = {
+      offsetsBySlice.keysIterator.foreach { s =>
+        initializeProbes(None, Some(s))
+      }
+
+      Future
+        .reduceLeft(offsetsBySlice.map {
+          case (slice, offset) =>
+            val reified = StoreTimestampOffset(offset, Promise())
+            probesBySlice.get(slice).ref ! reified
+            reified.promise.future
+        })((_, _) => Done)
+    }
+
+    def storeSequenceNumbers(records: IndexedSeq[Record]): Future[Done] = {
+      records.iterator.foreach { r =>
+        initializeProbes(Some(r.pid), Some(r.slice))
+      }
+
+      Future
+        .reduceLeft(records.map { r =>
+          val reified = StoreSequenceNumber(r.seqNr, r.timestamp, Promise())
+          probesByPid.get(r.pid).ref ! reified
+          reified.promise.future
+        })((_, _) => Done)
+    }
+
+    def loadSequenceNumber(slice: Int, pid: String): Future[Option[Record]] = {
+      val reified = LoadSequenceNumber(Promise())
+      initializeProbes(Some(pid), Some(slice))
+      probesByPid.get(pid).ref ! reified
+      reified.promise.future
+    }
+
+    def sliceFor(pid: String): Int = persistenceExt.sliceForPersistenceId(pid)
+
+    private val persistenceExt = Persistence(system)
+
+    private def managementStateNotImplemented: Nothing =
+      throw new NotImplementedError("Management state not tested in this spec, only in the integration test")
+  }
+
+  val projectionId = ProjectionId.of("some-projection", "some-key")
+
+  def uuid() = UUID.randomUUID().toString
+
+  val baseSettings = DynamoDBProjectionSettings(config.getConfig("akka.projection.dynamodb"))
+}
+
+class DynamoDBOffsetStoreSpec
+    extends ScalaTestWithActorTestKit(DynamoDBOffsetStoreSpec.config)
+    with AnyWordSpecLike
+    with LogCapturing {
+  import DynamoDBOffsetStoreSpec._
+
+  implicit val ec: ExecutionContext = system.executionContext
+
+  "A DynamoDBOffsetStore" should {
+    "delay offset load of saved pid until save completes without querying DAO" in {
+      val clock = Clock.systemUTC()
+      val startTime = clock.instant()
+
+      val dao = new InMemOffsetStoreDao(testKit)
+
+      val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
+
+      val t0 = startTime
+      val offset0 = TimestampOffset(t0, Map("p1" -> 42L))
+      dao.initializeProbes(Some("p1"), Some(dao.sliceFor("p1")))
+
+      // NB: not adding to inflight before, which is atypical
+      val saveFuture = offsetStore.saveOffset(OffsetPidSeqNr(offset0, "p1", 42))
+      val loadFromSave = dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber]
+      val loadFuture = offsetStore.load("p1")
+      dao.probesByPid.get("p1").expectNoMessage(30.millis)
+      loadFuture.value should be(empty)
+      loadFromSave.promise.success(Some(Record(dao.sliceFor("p1"), "p1", 41, t0.minusMillis(100))))
+      val storeSeqNr = dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber]
+      storeSeqNr.seqNr shouldBe 42
+      storeSeqNr.timestamp shouldBe t0
+      storeSeqNr.promise.success(Done)
+      dao.probesByPid.get("p1").expectNoMessage(30.millis)
+      val storeTimestampOffset = dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset]
+      storeTimestampOffset.offset shouldBe offset0
+      storeTimestampOffset.promise.success(Done)
+
+      // the load performed by the save means the load needs not actually go to the dao
+      Future
+        .sequence(
+          Seq(
+            // concurrently validate no load activity
+            Future { dao.probesBySlice.get(dao.sliceFor("p1")).expectNoMessage(30.millis) },
+            Future { dao.probesByPid.get("p1").expectNoMessage(30.millis) }))
+        .futureValue
+
+      saveFuture.futureValue
+      loadFuture.futureValue
+    }
+
+    "delay offset load of different new pid until save completes, then perform I/O" in {
+      val clock = Clock.systemUTC()
+      val startTime = clock.instant()
+
+      val dao = new InMemOffsetStoreDao(testKit)
+
+      val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
+
+      val t0 = startTime
+      val offset0 = TimestampOffset(t0, Map("p1" -> 21L))
+      dao.initializeProbes(Some("p1"), Some(dao.sliceFor("p1")))
+      dao.initializeProbes(Some("p2"), Some(dao.sliceFor("p2")))
+
+      val saveFuture = offsetStore.saveOffset(OffsetPidSeqNr(offset0, "p1", 21))
+      val loadFromSave = dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber]
+      val loadFuture = offsetStore.load("p2")
+      dao.probesByPid.get("p2").expectNoMessage(30.millis)
+      loadFuture.value shouldBe (empty)
+      loadFromSave.promise.success(Some(Record(dao.sliceFor("p1"), "p1", 20, t0.minusSeconds(10))))
+      val storeSeqNr = dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber]
+      storeSeqNr.seqNr shouldBe 21
+      storeSeqNr.promise.success(Done)
+      dao.probesByPid.get("p2").expectNoMessage(30.millis)
+      dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset].promise.success(Done)
+
+      saveFuture.futureValue shouldBe Done
+      dao.probesByPid
+        .get("p2")
+        .expectMessageType[LoadSequenceNumber]
+        .promise
+        .success(Some(Record(dao.sliceFor("p2"), "p2", 123, t0.minusSeconds(87654)))) // More than a day ago
+
+      loadFuture.futureValue.byPid("p2").seqNr shouldBe 123
+    }
+
+    "CAS retry loads if multiple saves are performed in time to load from DDB" in {
+      val clock = Clock.systemUTC()
+      val startTime = clock.instant()
+
+      val dao = new InMemOffsetStoreDao(testKit)
+
+      val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
+
+      val t0 = startTime
+      val offset0 = TimestampOffset(t0, Map("p1" -> 7L))
+      val offset1 = TimestampOffset(t0.plusMillis(22), Map("p1" -> 8L))
+      val offset2 = TimestampOffset(t0.plusMillis(35), Map("p1" -> 9L))
+      val p2Record = Record(dao.sliceFor("p2"), "p2", 57, t0.minusSeconds(100))
+      Seq("p1", "p2").foreach { pid =>
+        dao.initializeProbes(Some(pid), Some(dao.sliceFor(pid)))
+      }
+
+      val saveFuture1 = offsetStore.saveOffset(OffsetPidSeqNr(offset0, "p1", 7))
+      val loadFromSave = dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber]
+      val loadFuture = offsetStore.load("p2")
+      loadFuture.value shouldBe (empty)
+      loadFromSave.promise.success(Some(Record(dao.sliceFor("p1"), "p1", 6, t0.minusSeconds(5))))
+      dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber].promise.success(Done)
+      dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset].promise.success(Done)
+
+      saveFuture1.futureValue shouldBe Done
+      // "oldState" in load now has saveCounter 1
+      var loadFromLoad = dao.probesByPid.get("p2").expectMessageType[LoadSequenceNumber]
+      val saveFuture2 = offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p1", 8))
+      dao.probesByPid.get("p2").expectNoMessage(30.millis)
+      val secondSaveSequenceNr = dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber]
+      secondSaveSequenceNr.seqNr shouldBe 8
+      secondSaveSequenceNr.promise.success(Done)
+      dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset].promise.success(Done)
+
+      saveFuture2.futureValue shouldBe Done
+      val saveFuture3 = offsetStore.saveOffset(OffsetPidSeqNr(offset2, "p1", 9))
+      dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber].promise.success(Done)
+      dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset].promise.success(Done)
+
+      saveFuture3.futureValue shouldBe Done
+      loadFromLoad.promise.success(Some(p2Record))
+
+      // intervening save requires reload
+      loadFromLoad = dao.probesByPid.get("p2").expectMessageType[LoadSequenceNumber]
+      loadFromLoad.promise.success(Some(p2Record)) // nothing new was actually written
+
+      loadFuture.futureValue.byPid("p2").seqNr shouldBe 57
+    }
+
+    // The current implementation doesn't actually do concurrent single-pid loads in validation, but we can test this
+    "merge concurrent loads of 2 pids without retrying I/O" in {
+      val clock = Clock.systemUTC()
+      val startTime = clock.instant()
+
+      val dao = new InMemOffsetStoreDao(testKit)
+
+      val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
+
+      val t0 = startTime
+      val p1Record = Record(dao.sliceFor("p1"), "p1", 82, t0)
+      val p2Record = Record(dao.sliceFor("p2"), "p2", 77, t0.plusSeconds(1))
+      Seq("p1", "p2").foreach { pid =>
+        dao.initializeProbes(Some(pid), None)
+      }
+
+      val p1Load = offsetStore.load("p1")
+      val p2Load = offsetStore.load("p2")
+      dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber].promise.success(Some(p1Record))
+      dao.probesByPid.get("p2").expectMessageType[LoadSequenceNumber].promise.success(Some(p2Record))
+
+      Future
+        .sequence(Seq("p1", "p2").map { pid => Future { dao.probesByPid.get(pid).expectNoMessage(30.millis) } })
+        .futureValue
+        .size shouldBe 2
+
+      p1Load
+        .zip(p2Load)
+        .map {
+          case (state1, state2) => state1.byPid.size + state2.byPid.size
+        }
+        .futureValue shouldBe 3 // one of the states has both pids
+    }
+  }
+}

--- a/akka-projection-dynamodb/src/test/scala/akka/persistence/dynamodb/internal/DynamoDBOffsetStoreSpec.scala
+++ b/akka-projection-dynamodb/src/test/scala/akka/persistence/dynamodb/internal/DynamoDBOffsetStoreSpec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2025 Lightbend Inc. <https://akka.io>
+ */
+
 package akka.projection.dynamodb.internal
 
 import java.time.Clock

--- a/akka-projection-dynamodb/src/test/scala/akka/persistence/dynamodb/internal/DynamoDBOffsetStoreSpec.scala
+++ b/akka-projection-dynamodb/src/test/scala/akka/persistence/dynamodb/internal/DynamoDBOffsetStoreSpec.scala
@@ -46,6 +46,7 @@ object DynamoDBOffsetStoreSpec {
 
   sealed trait BySliceCommand
 
+  final case class LoadTimestampOffset(promise: Promise[Option[TimestampOffset]]) extends BySliceCommand
   final case class StoreTimestampOffset(offset: TimestampOffset, promise: Promise[Done]) extends BySliceCommand
 
   class ProbeStubOffsetStoreDao(testKit: ActorTestKit) extends OffsetStoreDao {
@@ -68,7 +69,12 @@ object DynamoDBOffsetStoreSpec {
     def updateManagementState(minSlice: Int, maxSlice: Int, paused: Boolean): Future[Done] =
       managementStateNotImplemented
 
-    def loadTimestampOffset(slice: Int): Future[Option[TimestampOffset]] = ???
+    def loadTimestampOffset(slice: Int): Future[Option[TimestampOffset]] = {
+      initializeProbes(None, Some(slice))
+      val reified = LoadTimestampOffset(Promise())
+      probesBySlice.get(slice).ref ! reified
+      reified.promise.future
+    }
 
     def storeTimestampOffsets(offsetsBySlice: Map[Int, TimestampOffset]): Future[Done] = {
       offsetsBySlice.keysIterator.foreach { s =>
@@ -128,172 +134,179 @@ class DynamoDBOffsetStoreSpec
   implicit val ec: ExecutionContext = system.executionContext
 
   "A DynamoDBOffsetStore" should {
-    "delay offset load of saved pid until save completes without querying DAO" in {
-      val clock = Clock.systemUTC()
-      val startTime = clock.instant()
+    for (clearOnSaveFailure <- Iterator(false, true)) {
+      // clearOnSaveFailure only matters if the save fails
+      s"delay offset load of saved pid until save completes without querying DAO (clearOnSaveFailure=$clearOnSaveFailure)" in {
+        val clock = Clock.systemUTC()
+        val startTime = clock.instant()
 
-      val dao = new ProbeStubOffsetStoreDao(testKit)
+        val dao = new ProbeStubOffsetStoreDao(testKit)
 
-      val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
+        val offsetStore =
+          new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock, clearOnSaveFailure)
 
-      val t0 = startTime
-      val offset0 = TimestampOffset(t0, Map("p1" -> 42L))
-      dao.initializeProbes(Some("p1"), Some(dao.sliceFor("p1")))
+        val t0 = startTime
+        val offset0 = TimestampOffset(t0, Map("p1" -> 42L))
+        dao.initializeProbes(Some("p1"), Some(dao.sliceFor("p1")))
 
-      // NB: not adding to inflight before, which is atypical
-      val saveFuture = offsetStore.saveOffset(OffsetPidSeqNr(offset0, "p1", 42))
-      val loadFromSave = dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber]
-      val loadFuture = offsetStore.load("p1")
-      dao.probesByPid.get("p1").expectNoMessage(30.millis)
-      loadFuture.value should be(empty)
-      loadFromSave.promise.success(Some(Record(dao.sliceFor("p1"), "p1", 41, t0.minusMillis(100))))
-      val storeSeqNr = dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber]
-      storeSeqNr.seqNr shouldBe 42
-      storeSeqNr.timestamp shouldBe t0
-      storeSeqNr.promise.success(Done)
-      dao.probesByPid.get("p1").expectNoMessage(30.millis)
-      val storeTimestampOffset = dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset]
-      storeTimestampOffset.offset shouldBe offset0
-      storeTimestampOffset.promise.success(Done)
+        // NB: not adding to inflight before, which is atypical
+        val saveFuture = offsetStore.saveOffset(OffsetPidSeqNr(offset0, "p1", 42))
+        val loadFromSave = dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber]
+        val loadFuture = offsetStore.load("p1")
+        dao.probesByPid.get("p1").expectNoMessage(30.millis)
+        loadFuture.value should be(empty)
+        loadFromSave.promise.success(Some(Record(dao.sliceFor("p1"), "p1", 41, t0.minusMillis(100))))
+        val storeSeqNr = dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber]
+        storeSeqNr.seqNr shouldBe 42
+        storeSeqNr.timestamp shouldBe t0
+        storeSeqNr.promise.success(Done)
+        dao.probesByPid.get("p1").expectNoMessage(30.millis)
+        val storeTimestampOffset = dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset]
+        storeTimestampOffset.offset shouldBe offset0
+        storeTimestampOffset.promise.success(Done)
 
-      // the load performed by the save means the load needs not actually go to the dao
-      Future
-        .sequence(
-          Seq(
-            // concurrently validate no load activity
-            Future { dao.probesBySlice.get(dao.sliceFor("p1")).expectNoMessage(30.millis) },
-            Future { dao.probesByPid.get("p1").expectNoMessage(30.millis) }))
-        .futureValue
+        // the load performed by the save means the load needs not actually go to the dao
+        Future
+          .sequence(
+            Seq(
+              // concurrently validate no load activity
+              Future { dao.probesBySlice.get(dao.sliceFor("p1")).expectNoMessage(30.millis) },
+              Future { dao.probesByPid.get("p1").expectNoMessage(30.millis) }))
+          .futureValue
 
-      saveFuture.futureValue
-      loadFuture.futureValue
-    }
-
-    "delay offset load of different new pid until save completes, then perform I/O" in {
-      val clock = Clock.systemUTC()
-      val startTime = clock.instant()
-
-      val dao = new ProbeStubOffsetStoreDao(testKit)
-
-      val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
-
-      val t0 = startTime
-      val offset0 = TimestampOffset(t0, Map("p1" -> 21L))
-      dao.initializeProbes(Some("p1"), Some(dao.sliceFor("p1")))
-      dao.initializeProbes(Some("p2"), Some(dao.sliceFor("p2")))
-
-      val saveFuture = offsetStore.saveOffset(OffsetPidSeqNr(offset0, "p1", 21))
-      val loadFromSave = dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber]
-      val loadFuture = offsetStore.load("p2")
-      dao.probesByPid.get("p2").expectNoMessage(30.millis)
-      loadFuture.value shouldBe (empty)
-      loadFromSave.promise.success(Some(Record(dao.sliceFor("p1"), "p1", 20, t0.minusSeconds(10))))
-      val storeSeqNr = dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber]
-      storeSeqNr.seqNr shouldBe 21
-      storeSeqNr.promise.success(Done)
-      dao.probesByPid.get("p2").expectNoMessage(30.millis)
-      dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset].promise.success(Done)
-
-      saveFuture.futureValue shouldBe Done
-      dao.probesByPid
-        .get("p2")
-        .expectMessageType[LoadSequenceNumber]
-        .promise
-        .success(Some(Record(dao.sliceFor("p2"), "p2", 123, t0.minusSeconds(87654)))) // More than a day ago
-
-      loadFuture.futureValue.byPid("p2").seqNr shouldBe 123
-    }
-
-    "CAS retry loads if multiple saves are performed in time to load from DDB" in {
-      val clock = Clock.systemUTC()
-      val startTime = clock.instant()
-
-      val dao = new ProbeStubOffsetStoreDao(testKit)
-
-      val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
-
-      val t0 = startTime
-      val offset0 = TimestampOffset(t0, Map("p1" -> 7L))
-      val offset1 = TimestampOffset(t0.plusMillis(22), Map("p1" -> 8L))
-      val offset2 = TimestampOffset(t0.plusMillis(35), Map("p1" -> 9L))
-      val p2Record = Record(dao.sliceFor("p2"), "p2", 57, t0.minusSeconds(100))
-      Seq("p1", "p2").foreach { pid =>
-        dao.initializeProbes(Some(pid), Some(dao.sliceFor(pid)))
+        saveFuture.futureValue
+        loadFuture.futureValue
       }
 
-      val saveFuture1 = offsetStore.saveOffset(OffsetPidSeqNr(offset0, "p1", 7))
-      val loadFromSave = dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber]
-      val loadFuture = offsetStore.load("p2")
-      loadFuture.value shouldBe (empty)
-      loadFromSave.promise.success(Some(Record(dao.sliceFor("p1"), "p1", 6, t0.minusSeconds(5))))
-      dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber].promise.success(Done)
-      dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset].promise.success(Done)
+      s"delay offset load of different new pid until save completes, then perform I/O (clearOnSaveFailure=$clearOnSaveFailure)" in {
+        val clock = Clock.systemUTC()
+        val startTime = clock.instant()
 
-      saveFuture1.futureValue shouldBe Done
-      // "oldState" in load now has saveCounter 1
-      var loadFromLoad = dao.probesByPid.get("p2").expectMessageType[LoadSequenceNumber]
-      val saveFuture2 = offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p1", 8))
-      dao.probesByPid.get("p2").expectNoMessage(30.millis)
-      val secondSaveSequenceNr = dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber]
-      secondSaveSequenceNr.seqNr shouldBe 8
-      secondSaveSequenceNr.promise.success(Done)
-      dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset].promise.success(Done)
+        val dao = new ProbeStubOffsetStoreDao(testKit)
 
-      saveFuture2.futureValue shouldBe Done
-      val saveFuture3 = offsetStore.saveOffset(OffsetPidSeqNr(offset2, "p1", 9))
-      dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber].promise.success(Done)
-      dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset].promise.success(Done)
+        val offsetStore =
+          new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock, clearOnSaveFailure)
 
-      saveFuture3.futureValue shouldBe Done
-      loadFromLoad.promise.success(Some(p2Record))
+        val t0 = startTime
+        val offset0 = TimestampOffset(t0, Map("p1" -> 21L))
+        dao.initializeProbes(Some("p1"), Some(dao.sliceFor("p1")))
+        dao.initializeProbes(Some("p2"), Some(dao.sliceFor("p2")))
 
-      // intervening save requires reload
-      loadFromLoad = dao.probesByPid.get("p2").expectMessageType[LoadSequenceNumber]
-      loadFromLoad.promise.success(Some(p2Record)) // nothing new was actually written
+        val saveFuture = offsetStore.saveOffset(OffsetPidSeqNr(offset0, "p1", 21))
+        val loadFromSave = dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber]
+        val loadFuture = offsetStore.load("p2")
+        dao.probesByPid.get("p2").expectNoMessage(30.millis)
+        loadFuture.value shouldBe (empty)
+        loadFromSave.promise.success(Some(Record(dao.sliceFor("p1"), "p1", 20, t0.minusSeconds(10))))
+        val storeSeqNr = dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber]
+        storeSeqNr.seqNr shouldBe 21
+        storeSeqNr.promise.success(Done)
+        dao.probesByPid.get("p2").expectNoMessage(30.millis)
+        dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset].promise.success(Done)
 
-      loadFuture.futureValue.byPid("p2").seqNr shouldBe 57
-    }
+        saveFuture.futureValue shouldBe Done
+        dao.probesByPid
+          .get("p2")
+          .expectMessageType[LoadSequenceNumber]
+          .promise
+          .success(Some(Record(dao.sliceFor("p2"), "p2", 123, t0.minusSeconds(87654)))) // More than a day ago
 
-    // The current implementation doesn't actually do concurrent single-pid loads in validation, but we can test this
-    "merge concurrent loads of 2 pids without retrying I/O" in {
-      val clock = Clock.systemUTC()
-      val startTime = clock.instant()
-
-      val dao = new ProbeStubOffsetStoreDao(testKit)
-
-      val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
-
-      val t0 = startTime
-      val p1Record = Record(dao.sliceFor("p1"), "p1", 82, t0)
-      val p2Record = Record(dao.sliceFor("p2"), "p2", 77, t0.plusSeconds(1))
-      Seq("p1", "p2").foreach { pid =>
-        dao.initializeProbes(Some(pid), None)
+        loadFuture.futureValue.byPid("p2").seqNr shouldBe 123
       }
 
-      val p1Load = offsetStore.load("p1")
-      val p2Load = offsetStore.load("p2")
-      dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber].promise.success(Some(p1Record))
-      dao.probesByPid.get("p2").expectMessageType[LoadSequenceNumber].promise.success(Some(p2Record))
+      s"CAS retry loads if multiple saves are performed in time to load from DDB (clearOnSaveFailure=$clearOnSaveFailure)" in {
+        val clock = Clock.systemUTC()
+        val startTime = clock.instant()
 
-      Future
-        .sequence(Seq("p1", "p2").map { pid => Future { dao.probesByPid.get(pid).expectNoMessage(30.millis) } })
-        .futureValue
-        .size shouldBe 2
+        val dao = new ProbeStubOffsetStoreDao(testKit)
 
-      p1Load
-        .zip(p2Load)
-        .map {
-          case (state1, state2) => state1.byPid.size + state2.byPid.size
+        val offsetStore =
+          new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock, clearOnSaveFailure)
+
+        val t0 = startTime
+        val offset0 = TimestampOffset(t0, Map("p1" -> 7L))
+        val offset1 = TimestampOffset(t0.plusMillis(22), Map("p1" -> 8L))
+        val offset2 = TimestampOffset(t0.plusMillis(35), Map("p1" -> 9L))
+        val p2Record = Record(dao.sliceFor("p2"), "p2", 57, t0.minusSeconds(100))
+        Seq("p1", "p2").foreach { pid =>
+          dao.initializeProbes(Some(pid), Some(dao.sliceFor(pid)))
         }
-        .futureValue shouldBe 3 // one of the states has both pids
+
+        val saveFuture1 = offsetStore.saveOffset(OffsetPidSeqNr(offset0, "p1", 7))
+        val loadFromSave = dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber]
+        val loadFuture = offsetStore.load("p2")
+        loadFuture.value shouldBe (empty)
+        loadFromSave.promise.success(Some(Record(dao.sliceFor("p1"), "p1", 6, t0.minusSeconds(5))))
+        dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber].promise.success(Done)
+        dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset].promise.success(Done)
+
+        saveFuture1.futureValue shouldBe Done
+        // "oldState" in load now has saveCounter 1
+        var loadFromLoad = dao.probesByPid.get("p2").expectMessageType[LoadSequenceNumber]
+        val saveFuture2 = offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p1", 8))
+        dao.probesByPid.get("p2").expectNoMessage(30.millis)
+        val secondSaveSequenceNr = dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber]
+        secondSaveSequenceNr.seqNr shouldBe 8
+        secondSaveSequenceNr.promise.success(Done)
+        dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset].promise.success(Done)
+
+        saveFuture2.futureValue shouldBe Done
+        val saveFuture3 = offsetStore.saveOffset(OffsetPidSeqNr(offset2, "p1", 9))
+        dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber].promise.success(Done)
+        dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset].promise.success(Done)
+
+        saveFuture3.futureValue shouldBe Done
+        loadFromLoad.promise.success(Some(p2Record))
+
+        // intervening save requires reload
+        loadFromLoad = dao.probesByPid.get("p2").expectMessageType[LoadSequenceNumber]
+        loadFromLoad.promise.success(Some(p2Record)) // nothing new was actually written
+
+        loadFuture.futureValue.byPid("p2").seqNr shouldBe 57
+      }
+
+      // The current implementation doesn't actually do concurrent single-pid loads in validation, but we can test this
+      s"merge concurrent loads of 2 pids without retrying I/O (clearOnSaveFailure=$clearOnSaveFailure)" in {
+        val clock = Clock.systemUTC()
+        val startTime = clock.instant()
+
+        val dao = new ProbeStubOffsetStoreDao(testKit)
+
+        val offsetStore =
+          new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock, clearOnSaveFailure)
+
+        val t0 = startTime
+        val p1Record = Record(dao.sliceFor("p1"), "p1", 82, t0)
+        val p2Record = Record(dao.sliceFor("p2"), "p2", 77, t0.plusSeconds(1))
+        Seq("p1", "p2").foreach { pid =>
+          dao.initializeProbes(Some(pid), None)
+        }
+
+        val p1Load = offsetStore.load("p1")
+        val p2Load = offsetStore.load("p2")
+        dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber].promise.success(Some(p1Record))
+        dao.probesByPid.get("p2").expectMessageType[LoadSequenceNumber].promise.success(Some(p2Record))
+
+        Future
+          .sequence(Seq("p1", "p2").map { pid => Future { dao.probesByPid.get(pid).expectNoMessage(30.millis) } })
+          .futureValue
+          .size shouldBe 2
+
+        p1Load
+          .zip(p2Load)
+          .map {
+            case (state1, state2) => state1.byPid.size + state2.byPid.size
+          }
+          .futureValue shouldBe 3 // one of the states has both pids
+      }
     }
 
-    "stop on failed save and propagate" in {
+    "stop on failed save and propagate (clearOnSaveFailure=false)" in {
       val clock = Clock.systemUTC()
 
       val dao = new ProbeStubOffsetStoreDao(testKit)
 
-      val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
+      val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock, false)
 
       val t0 = clock.instant()
       val offset0 = TimestampOffset(t0, Map("p1" -> 777L))
@@ -309,6 +322,89 @@ class DynamoDBOffsetStoreSpec
       loadFuture.failed.futureValue.getMessage should include("DB went boom")
 
       an[AttemptToUseStoppedOffsetStore] shouldBe thrownBy { offsetStore.load("p2") }
+    }
+
+    "recover state from DDB on failed save (clearOnSaveFailure=true)" in {
+      val clock = Clock.systemUTC()
+
+      val dao = new ProbeStubOffsetStoreDao(testKit)
+
+      val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock, true)
+
+      val t0 = clock.instant()
+      val offset0 = TimestampOffset(t0, Map("p1" -> 777L))
+      val slice1 = dao.sliceFor("p1")
+      Seq("p1", "p2").foreach { pid =>
+        dao.initializeProbes(Some(pid), Some(dao.sliceFor(pid)))
+      }
+
+      val recordP1_776 = Record(slice1, "p1", 776, t0.minusSeconds(61))
+
+      val loadP1Future = offsetStore.load("p1")
+      dao.probesByPid
+        .get("p1")
+        .expectMessageType[LoadSequenceNumber]
+        .promise
+        .success(Some(recordP1_776))
+
+      val saveFuture = loadP1Future.flatMap { state =>
+        state.byPid.keySet should contain("p1")
+        offsetStore.saveOffset(OffsetPidSeqNr(offset0, "p1", 777))
+      }
+      dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber].promise.success(Done)
+      val loadP2Future = offsetStore.load("p2")
+      dao.probesBySlice
+        .get(slice1)
+        .expectMessageType[StoreTimestampOffset]
+        .promise
+        .failure(new RuntimeException("DB went boom (store timestamp offset)"))
+
+      (offsetStore.minSlice to offsetStore.maxSlice).foreach { slice => dao.initializeProbes(None, Some(slice)) }
+
+      (offsetStore.minSlice to (slice1 - 1).max(offsetStore.minSlice)).foreach { slice =>
+        dao.probesBySlice
+          .get(slice)
+          .expectMessageType[LoadTimestampOffset]
+          .promise
+          .success(None)
+      }
+
+      ((slice1 + 1) to offsetStore.maxSlice).foreach { slice =>
+        // drain the other probes which might have received a message in the mapAsync
+        try { dao.probesBySlice.get(slice).receiveMessage(1.milli) }
+        catch { case _: AssertionError => () }
+      }
+
+      dao.probesBySlice
+        .get(slice1)
+        .expectMessageType[LoadTimestampOffset]
+        .promise
+        .failure(new RuntimeException("DB went boom (load timestamp offset)"))
+
+      // timestamp offset recovery retries
+      (offsetStore.minSlice to offsetStore.maxSlice).foreach { slice =>
+        val promise = dao.probesBySlice.get(slice).expectMessageType[LoadTimestampOffset].promise
+
+        if (slice == slice1)
+          promise.success(Some(TimestampOffset(t0.minusSeconds(10), Map("somePidAssumedToBeInSameSliceAsP1" -> 43L))))
+        else promise.success(None)
+      }
+      dao.probesByPid.get("p2").expectMessageType[LoadSequenceNumber].promise.success(None)
+
+      val secondP1Load = loadP2Future.flatMap { state =>
+        // state has forgotten the successful load of p1
+        state.byPid.keySet shouldNot contain("p1")
+        state.byPid.keySet shouldNot contain("p2")
+        state.offsetBySlice.get(slice1).map(_.timestamp) should contain(t0.minusSeconds(10))
+        offsetStore.load("p1")
+      }
+
+      saveFuture.failed.futureValue.getMessage should include("DB went boom (store timestamp offset)")
+
+      dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber].promise.success(Some(recordP1_776))
+
+      val finalState = secondP1Load.futureValue
+      finalState.byPid.keySet should contain("p1")
     }
   }
 }

--- a/akka-projection-dynamodb/src/test/scala/akka/persistence/dynamodb/internal/DynamoDBOffsetStoreSpec.scala
+++ b/akka-projection-dynamodb/src/test/scala/akka/persistence/dynamodb/internal/DynamoDBOffsetStoreSpec.scala
@@ -28,6 +28,7 @@ import akka.projection.internal.ManagementState
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpecLike
 import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem
+import akka.projection.dynamodb.internal.DynamoDBOffsetStore.AttemptToUseStoppedOffsetStore
 
 object DynamoDBOffsetStoreSpec {
   val config = {
@@ -47,8 +48,7 @@ object DynamoDBOffsetStoreSpec {
 
   final case class StoreTimestampOffset(offset: TimestampOffset, promise: Promise[Done]) extends BySliceCommand
 
-  //@annotation.nowarn("msg=never used")
-  class InMemOffsetStoreDao(testKit: ActorTestKit) extends OffsetStoreDao {
+  class ProbeStubOffsetStoreDao(testKit: ActorTestKit) extends OffsetStoreDao {
     import testKit.system
 
     implicit val ec: ExecutionContext = system.executionContext
@@ -132,7 +132,7 @@ class DynamoDBOffsetStoreSpec
       val clock = Clock.systemUTC()
       val startTime = clock.instant()
 
-      val dao = new InMemOffsetStoreDao(testKit)
+      val dao = new ProbeStubOffsetStoreDao(testKit)
 
       val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
 
@@ -173,7 +173,7 @@ class DynamoDBOffsetStoreSpec
       val clock = Clock.systemUTC()
       val startTime = clock.instant()
 
-      val dao = new InMemOffsetStoreDao(testKit)
+      val dao = new ProbeStubOffsetStoreDao(testKit)
 
       val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
 
@@ -208,7 +208,7 @@ class DynamoDBOffsetStoreSpec
       val clock = Clock.systemUTC()
       val startTime = clock.instant()
 
-      val dao = new InMemOffsetStoreDao(testKit)
+      val dao = new ProbeStubOffsetStoreDao(testKit)
 
       val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
 
@@ -259,7 +259,7 @@ class DynamoDBOffsetStoreSpec
       val clock = Clock.systemUTC()
       val startTime = clock.instant()
 
-      val dao = new InMemOffsetStoreDao(testKit)
+      val dao = new ProbeStubOffsetStoreDao(testKit)
 
       val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
 
@@ -286,6 +286,29 @@ class DynamoDBOffsetStoreSpec
           case (state1, state2) => state1.byPid.size + state2.byPid.size
         }
         .futureValue shouldBe 3 // one of the states has both pids
+    }
+
+    "stop on failed save and propagate" in {
+      val clock = Clock.systemUTC()
+
+      val dao = new ProbeStubOffsetStoreDao(testKit)
+
+      val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
+
+      val t0 = clock.instant()
+      val offset0 = TimestampOffset(t0, Map("p1" -> 777L))
+
+      val saveFuture = offsetStore.saveOffset(OffsetPidSeqNr(offset0, "p1", 777))
+      val loadFromSave = dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber]
+      val loadFuture = offsetStore.load("p2")
+      loadFuture.value shouldBe (empty)
+      loadFromSave.promise.failure(new RuntimeException("DB went boom"))
+
+      saveFuture.failed.futureValue.getMessage should include("DB went boom")
+      eventually { assert(offsetStore.isStopped(), "offset store should stop") }
+      loadFuture.failed.futureValue.getMessage should include("DB went boom")
+
+      an[AttemptToUseStoppedOffsetStore] shouldBe thrownBy { offsetStore.load("p2") }
     }
   }
 }

--- a/akka-projection-dynamodb/src/test/scala/akka/persistence/dynamodb/internal/DynamoDBOffsetStoreSpec.scala
+++ b/akka-projection-dynamodb/src/test/scala/akka/persistence/dynamodb/internal/DynamoDBOffsetStoreSpec.scala
@@ -46,7 +46,6 @@ object DynamoDBOffsetStoreSpec {
 
   sealed trait BySliceCommand
 
-  final case class LoadTimestampOffset(promise: Promise[Option[TimestampOffset]]) extends BySliceCommand
   final case class StoreTimestampOffset(offset: TimestampOffset, promise: Promise[Done]) extends BySliceCommand
 
   class ProbeStubOffsetStoreDao(testKit: ActorTestKit) extends OffsetStoreDao {
@@ -69,12 +68,7 @@ object DynamoDBOffsetStoreSpec {
     def updateManagementState(minSlice: Int, maxSlice: Int, paused: Boolean): Future[Done] =
       managementStateNotImplemented
 
-    def loadTimestampOffset(slice: Int): Future[Option[TimestampOffset]] = {
-      initializeProbes(None, Some(slice))
-      val reified = LoadTimestampOffset(Promise())
-      probesBySlice.get(slice).ref ! reified
-      reified.promise.future
-    }
+    def loadTimestampOffset(slice: Int): Future[Option[TimestampOffset]] = ???
 
     def storeTimestampOffsets(offsetsBySlice: Map[Int, TimestampOffset]): Future[Done] = {
       offsetsBySlice.keysIterator.foreach { s =>
@@ -134,179 +128,172 @@ class DynamoDBOffsetStoreSpec
   implicit val ec: ExecutionContext = system.executionContext
 
   "A DynamoDBOffsetStore" should {
-    for (clearOnSaveFailure <- Iterator(false, true)) {
-      // clearOnSaveFailure only matters if the save fails
-      s"delay offset load of saved pid until save completes without querying DAO (clearOnSaveFailure=$clearOnSaveFailure)" in {
-        val clock = Clock.systemUTC()
-        val startTime = clock.instant()
+    "delay offset load of saved pid until save completes without querying DAO" in {
+      val clock = Clock.systemUTC()
+      val startTime = clock.instant()
 
-        val dao = new ProbeStubOffsetStoreDao(testKit)
+      val dao = new ProbeStubOffsetStoreDao(testKit)
 
-        val offsetStore =
-          new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock, clearOnSaveFailure)
+      val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
 
-        val t0 = startTime
-        val offset0 = TimestampOffset(t0, Map("p1" -> 42L))
-        dao.initializeProbes(Some("p1"), Some(dao.sliceFor("p1")))
+      val t0 = startTime
+      val offset0 = TimestampOffset(t0, Map("p1" -> 42L))
+      dao.initializeProbes(Some("p1"), Some(dao.sliceFor("p1")))
 
-        // NB: not adding to inflight before, which is atypical
-        val saveFuture = offsetStore.saveOffset(OffsetPidSeqNr(offset0, "p1", 42))
-        val loadFromSave = dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber]
-        val loadFuture = offsetStore.load("p1")
-        dao.probesByPid.get("p1").expectNoMessage(30.millis)
-        loadFuture.value should be(empty)
-        loadFromSave.promise.success(Some(Record(dao.sliceFor("p1"), "p1", 41, t0.minusMillis(100))))
-        val storeSeqNr = dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber]
-        storeSeqNr.seqNr shouldBe 42
-        storeSeqNr.timestamp shouldBe t0
-        storeSeqNr.promise.success(Done)
-        dao.probesByPid.get("p1").expectNoMessage(30.millis)
-        val storeTimestampOffset = dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset]
-        storeTimestampOffset.offset shouldBe offset0
-        storeTimestampOffset.promise.success(Done)
+      // NB: not adding to inflight before, which is atypical
+      val saveFuture = offsetStore.saveOffset(OffsetPidSeqNr(offset0, "p1", 42))
+      val loadFromSave = dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber]
+      val loadFuture = offsetStore.load("p1")
+      dao.probesByPid.get("p1").expectNoMessage(30.millis)
+      loadFuture.value should be(empty)
+      loadFromSave.promise.success(Some(Record(dao.sliceFor("p1"), "p1", 41, t0.minusMillis(100))))
+      val storeSeqNr = dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber]
+      storeSeqNr.seqNr shouldBe 42
+      storeSeqNr.timestamp shouldBe t0
+      storeSeqNr.promise.success(Done)
+      dao.probesByPid.get("p1").expectNoMessage(30.millis)
+      val storeTimestampOffset = dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset]
+      storeTimestampOffset.offset shouldBe offset0
+      storeTimestampOffset.promise.success(Done)
 
-        // the load performed by the save means the load needs not actually go to the dao
-        Future
-          .sequence(
-            Seq(
-              // concurrently validate no load activity
-              Future { dao.probesBySlice.get(dao.sliceFor("p1")).expectNoMessage(30.millis) },
-              Future { dao.probesByPid.get("p1").expectNoMessage(30.millis) }))
-          .futureValue
+      // the load performed by the save means the load needs not actually go to the dao
+      Future
+        .sequence(
+          Seq(
+            // concurrently validate no load activity
+            Future { dao.probesBySlice.get(dao.sliceFor("p1")).expectNoMessage(30.millis) },
+            Future { dao.probesByPid.get("p1").expectNoMessage(30.millis) }))
+        .futureValue
 
-        saveFuture.futureValue
-        loadFuture.futureValue
-      }
-
-      s"delay offset load of different new pid until save completes, then perform I/O (clearOnSaveFailure=$clearOnSaveFailure)" in {
-        val clock = Clock.systemUTC()
-        val startTime = clock.instant()
-
-        val dao = new ProbeStubOffsetStoreDao(testKit)
-
-        val offsetStore =
-          new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock, clearOnSaveFailure)
-
-        val t0 = startTime
-        val offset0 = TimestampOffset(t0, Map("p1" -> 21L))
-        dao.initializeProbes(Some("p1"), Some(dao.sliceFor("p1")))
-        dao.initializeProbes(Some("p2"), Some(dao.sliceFor("p2")))
-
-        val saveFuture = offsetStore.saveOffset(OffsetPidSeqNr(offset0, "p1", 21))
-        val loadFromSave = dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber]
-        val loadFuture = offsetStore.load("p2")
-        dao.probesByPid.get("p2").expectNoMessage(30.millis)
-        loadFuture.value shouldBe (empty)
-        loadFromSave.promise.success(Some(Record(dao.sliceFor("p1"), "p1", 20, t0.minusSeconds(10))))
-        val storeSeqNr = dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber]
-        storeSeqNr.seqNr shouldBe 21
-        storeSeqNr.promise.success(Done)
-        dao.probesByPid.get("p2").expectNoMessage(30.millis)
-        dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset].promise.success(Done)
-
-        saveFuture.futureValue shouldBe Done
-        dao.probesByPid
-          .get("p2")
-          .expectMessageType[LoadSequenceNumber]
-          .promise
-          .success(Some(Record(dao.sliceFor("p2"), "p2", 123, t0.minusSeconds(87654)))) // More than a day ago
-
-        loadFuture.futureValue.byPid("p2").seqNr shouldBe 123
-      }
-
-      s"CAS retry loads if multiple saves are performed in time to load from DDB (clearOnSaveFailure=$clearOnSaveFailure)" in {
-        val clock = Clock.systemUTC()
-        val startTime = clock.instant()
-
-        val dao = new ProbeStubOffsetStoreDao(testKit)
-
-        val offsetStore =
-          new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock, clearOnSaveFailure)
-
-        val t0 = startTime
-        val offset0 = TimestampOffset(t0, Map("p1" -> 7L))
-        val offset1 = TimestampOffset(t0.plusMillis(22), Map("p1" -> 8L))
-        val offset2 = TimestampOffset(t0.plusMillis(35), Map("p1" -> 9L))
-        val p2Record = Record(dao.sliceFor("p2"), "p2", 57, t0.minusSeconds(100))
-        Seq("p1", "p2").foreach { pid =>
-          dao.initializeProbes(Some(pid), Some(dao.sliceFor(pid)))
-        }
-
-        val saveFuture1 = offsetStore.saveOffset(OffsetPidSeqNr(offset0, "p1", 7))
-        val loadFromSave = dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber]
-        val loadFuture = offsetStore.load("p2")
-        loadFuture.value shouldBe (empty)
-        loadFromSave.promise.success(Some(Record(dao.sliceFor("p1"), "p1", 6, t0.minusSeconds(5))))
-        dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber].promise.success(Done)
-        dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset].promise.success(Done)
-
-        saveFuture1.futureValue shouldBe Done
-        // "oldState" in load now has saveCounter 1
-        var loadFromLoad = dao.probesByPid.get("p2").expectMessageType[LoadSequenceNumber]
-        val saveFuture2 = offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p1", 8))
-        dao.probesByPid.get("p2").expectNoMessage(30.millis)
-        val secondSaveSequenceNr = dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber]
-        secondSaveSequenceNr.seqNr shouldBe 8
-        secondSaveSequenceNr.promise.success(Done)
-        dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset].promise.success(Done)
-
-        saveFuture2.futureValue shouldBe Done
-        val saveFuture3 = offsetStore.saveOffset(OffsetPidSeqNr(offset2, "p1", 9))
-        dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber].promise.success(Done)
-        dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset].promise.success(Done)
-
-        saveFuture3.futureValue shouldBe Done
-        loadFromLoad.promise.success(Some(p2Record))
-
-        // intervening save requires reload
-        loadFromLoad = dao.probesByPid.get("p2").expectMessageType[LoadSequenceNumber]
-        loadFromLoad.promise.success(Some(p2Record)) // nothing new was actually written
-
-        loadFuture.futureValue.byPid("p2").seqNr shouldBe 57
-      }
-
-      // The current implementation doesn't actually do concurrent single-pid loads in validation, but we can test this
-      s"merge concurrent loads of 2 pids without retrying I/O (clearOnSaveFailure=$clearOnSaveFailure)" in {
-        val clock = Clock.systemUTC()
-        val startTime = clock.instant()
-
-        val dao = new ProbeStubOffsetStoreDao(testKit)
-
-        val offsetStore =
-          new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock, clearOnSaveFailure)
-
-        val t0 = startTime
-        val p1Record = Record(dao.sliceFor("p1"), "p1", 82, t0)
-        val p2Record = Record(dao.sliceFor("p2"), "p2", 77, t0.plusSeconds(1))
-        Seq("p1", "p2").foreach { pid =>
-          dao.initializeProbes(Some(pid), None)
-        }
-
-        val p1Load = offsetStore.load("p1")
-        val p2Load = offsetStore.load("p2")
-        dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber].promise.success(Some(p1Record))
-        dao.probesByPid.get("p2").expectMessageType[LoadSequenceNumber].promise.success(Some(p2Record))
-
-        Future
-          .sequence(Seq("p1", "p2").map { pid => Future { dao.probesByPid.get(pid).expectNoMessage(30.millis) } })
-          .futureValue
-          .size shouldBe 2
-
-        p1Load
-          .zip(p2Load)
-          .map {
-            case (state1, state2) => state1.byPid.size + state2.byPid.size
-          }
-          .futureValue shouldBe 3 // one of the states has both pids
-      }
+      saveFuture.futureValue
+      loadFuture.futureValue
     }
 
-    "stop on failed save and propagate (clearOnSaveFailure=false)" in {
+    "delay offset load of different new pid until save completes, then perform I/O" in {
+      val clock = Clock.systemUTC()
+      val startTime = clock.instant()
+
+      val dao = new ProbeStubOffsetStoreDao(testKit)
+
+      val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
+
+      val t0 = startTime
+      val offset0 = TimestampOffset(t0, Map("p1" -> 21L))
+      dao.initializeProbes(Some("p1"), Some(dao.sliceFor("p1")))
+      dao.initializeProbes(Some("p2"), Some(dao.sliceFor("p2")))
+
+      val saveFuture = offsetStore.saveOffset(OffsetPidSeqNr(offset0, "p1", 21))
+      val loadFromSave = dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber]
+      val loadFuture = offsetStore.load("p2")
+      dao.probesByPid.get("p2").expectNoMessage(30.millis)
+      loadFuture.value shouldBe (empty)
+      loadFromSave.promise.success(Some(Record(dao.sliceFor("p1"), "p1", 20, t0.minusSeconds(10))))
+      val storeSeqNr = dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber]
+      storeSeqNr.seqNr shouldBe 21
+      storeSeqNr.promise.success(Done)
+      dao.probesByPid.get("p2").expectNoMessage(30.millis)
+      dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset].promise.success(Done)
+
+      saveFuture.futureValue shouldBe Done
+      dao.probesByPid
+        .get("p2")
+        .expectMessageType[LoadSequenceNumber]
+        .promise
+        .success(Some(Record(dao.sliceFor("p2"), "p2", 123, t0.minusSeconds(87654)))) // More than a day ago
+
+      loadFuture.futureValue.byPid("p2").seqNr shouldBe 123
+    }
+
+    "CAS retry loads if multiple saves are performed in time to load from DDB" in {
+      val clock = Clock.systemUTC()
+      val startTime = clock.instant()
+
+      val dao = new ProbeStubOffsetStoreDao(testKit)
+
+      val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
+
+      val t0 = startTime
+      val offset0 = TimestampOffset(t0, Map("p1" -> 7L))
+      val offset1 = TimestampOffset(t0.plusMillis(22), Map("p1" -> 8L))
+      val offset2 = TimestampOffset(t0.plusMillis(35), Map("p1" -> 9L))
+      val p2Record = Record(dao.sliceFor("p2"), "p2", 57, t0.minusSeconds(100))
+      Seq("p1", "p2").foreach { pid =>
+        dao.initializeProbes(Some(pid), Some(dao.sliceFor(pid)))
+      }
+
+      val saveFuture1 = offsetStore.saveOffset(OffsetPidSeqNr(offset0, "p1", 7))
+      val loadFromSave = dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber]
+      val loadFuture = offsetStore.load("p2")
+      loadFuture.value shouldBe (empty)
+      loadFromSave.promise.success(Some(Record(dao.sliceFor("p1"), "p1", 6, t0.minusSeconds(5))))
+      dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber].promise.success(Done)
+      dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset].promise.success(Done)
+
+      saveFuture1.futureValue shouldBe Done
+      // "oldState" in load now has saveCounter 1
+      var loadFromLoad = dao.probesByPid.get("p2").expectMessageType[LoadSequenceNumber]
+      val saveFuture2 = offsetStore.saveOffset(OffsetPidSeqNr(offset1, "p1", 8))
+      dao.probesByPid.get("p2").expectNoMessage(30.millis)
+      val secondSaveSequenceNr = dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber]
+      secondSaveSequenceNr.seqNr shouldBe 8
+      secondSaveSequenceNr.promise.success(Done)
+      dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset].promise.success(Done)
+
+      saveFuture2.futureValue shouldBe Done
+      val saveFuture3 = offsetStore.saveOffset(OffsetPidSeqNr(offset2, "p1", 9))
+      dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber].promise.success(Done)
+      dao.probesBySlice.get(dao.sliceFor("p1")).expectMessageType[StoreTimestampOffset].promise.success(Done)
+
+      saveFuture3.futureValue shouldBe Done
+      loadFromLoad.promise.success(Some(p2Record))
+
+      // intervening save requires reload
+      loadFromLoad = dao.probesByPid.get("p2").expectMessageType[LoadSequenceNumber]
+      loadFromLoad.promise.success(Some(p2Record)) // nothing new was actually written
+
+      loadFuture.futureValue.byPid("p2").seqNr shouldBe 57
+    }
+
+    // The current implementation doesn't actually do concurrent single-pid loads in validation, but we can test this
+    "merge concurrent loads of 2 pids without retrying I/O" in {
+      val clock = Clock.systemUTC()
+      val startTime = clock.instant()
+
+      val dao = new ProbeStubOffsetStoreDao(testKit)
+
+      val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
+
+      val t0 = startTime
+      val p1Record = Record(dao.sliceFor("p1"), "p1", 82, t0)
+      val p2Record = Record(dao.sliceFor("p2"), "p2", 77, t0.plusSeconds(1))
+      Seq("p1", "p2").foreach { pid =>
+        dao.initializeProbes(Some(pid), None)
+      }
+
+      val p1Load = offsetStore.load("p1")
+      val p2Load = offsetStore.load("p2")
+      dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber].promise.success(Some(p1Record))
+      dao.probesByPid.get("p2").expectMessageType[LoadSequenceNumber].promise.success(Some(p2Record))
+
+      Future
+        .sequence(Seq("p1", "p2").map { pid => Future { dao.probesByPid.get(pid).expectNoMessage(30.millis) } })
+        .futureValue
+        .size shouldBe 2
+
+      p1Load
+        .zip(p2Load)
+        .map {
+          case (state1, state2) => state1.byPid.size + state2.byPid.size
+        }
+        .futureValue shouldBe 3 // one of the states has both pids
+    }
+
+    "stop on failed save and propagate" in {
       val clock = Clock.systemUTC()
 
       val dao = new ProbeStubOffsetStoreDao(testKit)
 
-      val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock, false)
+      val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
 
       val t0 = clock.instant()
       val offset0 = TimestampOffset(t0, Map("p1" -> 777L))
@@ -322,89 +309,6 @@ class DynamoDBOffsetStoreSpec
       loadFuture.failed.futureValue.getMessage should include("DB went boom")
 
       an[AttemptToUseStoppedOffsetStore] shouldBe thrownBy { offsetStore.load("p2") }
-    }
-
-    "recover state from DDB on failed save (clearOnSaveFailure=true)" in {
-      val clock = Clock.systemUTC()
-
-      val dao = new ProbeStubOffsetStoreDao(testKit)
-
-      val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock, true)
-
-      val t0 = clock.instant()
-      val offset0 = TimestampOffset(t0, Map("p1" -> 777L))
-      val slice1 = dao.sliceFor("p1")
-      Seq("p1", "p2").foreach { pid =>
-        dao.initializeProbes(Some(pid), Some(dao.sliceFor(pid)))
-      }
-
-      val recordP1_776 = Record(slice1, "p1", 776, t0.minusSeconds(61))
-
-      val loadP1Future = offsetStore.load("p1")
-      dao.probesByPid
-        .get("p1")
-        .expectMessageType[LoadSequenceNumber]
-        .promise
-        .success(Some(recordP1_776))
-
-      val saveFuture = loadP1Future.flatMap { state =>
-        state.byPid.keySet should contain("p1")
-        offsetStore.saveOffset(OffsetPidSeqNr(offset0, "p1", 777))
-      }
-      dao.probesByPid.get("p1").expectMessageType[StoreSequenceNumber].promise.success(Done)
-      val loadP2Future = offsetStore.load("p2")
-      dao.probesBySlice
-        .get(slice1)
-        .expectMessageType[StoreTimestampOffset]
-        .promise
-        .failure(new RuntimeException("DB went boom (store timestamp offset)"))
-
-      (offsetStore.minSlice to offsetStore.maxSlice).foreach { slice => dao.initializeProbes(None, Some(slice)) }
-
-      (offsetStore.minSlice to (slice1 - 1).max(offsetStore.minSlice)).foreach { slice =>
-        dao.probesBySlice
-          .get(slice)
-          .expectMessageType[LoadTimestampOffset]
-          .promise
-          .success(None)
-      }
-
-      ((slice1 + 1) to offsetStore.maxSlice).foreach { slice =>
-        // drain the other probes which might have received a message in the mapAsync
-        try { dao.probesBySlice.get(slice).receiveMessage(1.milli) }
-        catch { case _: AssertionError => () }
-      }
-
-      dao.probesBySlice
-        .get(slice1)
-        .expectMessageType[LoadTimestampOffset]
-        .promise
-        .failure(new RuntimeException("DB went boom (load timestamp offset)"))
-
-      // timestamp offset recovery retries
-      (offsetStore.minSlice to offsetStore.maxSlice).foreach { slice =>
-        val promise = dao.probesBySlice.get(slice).expectMessageType[LoadTimestampOffset].promise
-
-        if (slice == slice1)
-          promise.success(Some(TimestampOffset(t0.minusSeconds(10), Map("somePidAssumedToBeInSameSliceAsP1" -> 43L))))
-        else promise.success(None)
-      }
-      dao.probesByPid.get("p2").expectMessageType[LoadSequenceNumber].promise.success(None)
-
-      val secondP1Load = loadP2Future.flatMap { state =>
-        // state has forgotten the successful load of p1
-        state.byPid.keySet shouldNot contain("p1")
-        state.byPid.keySet shouldNot contain("p2")
-        state.offsetBySlice.get(slice1).map(_.timestamp) should contain(t0.minusSeconds(10))
-        offsetStore.load("p1")
-      }
-
-      saveFuture.failed.futureValue.getMessage should include("DB went boom (store timestamp offset)")
-
-      dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber].promise.success(Some(recordP1_776))
-
-      val finalState = secondP1Load.futureValue
-      finalState.byPid.keySet should contain("p1")
     }
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -322,7 +322,10 @@ object Dependencies {
         Compile.akkaPersistenceDynamodb,
         Compile.akkaPersistenceQuery,
         Compile.akkaPersistenceTyped,
-        Compile.akkaStreamTyped)
+        Compile.akkaStreamTyped,
+        Test.akkaTypedTestkit,
+        Test.logback,
+        Test.scalatest)
 
   val dynamodbIntegration = deps ++= Seq(
         Test.akkaStreamTestkit,


### PR DESCRIPTION
In the DDB projection offset store, offset saves are implemented via multiple writes, with the number of writes correlated to the number of distinct persistence IDs in a batch (due to the limit on the number of items in a DDB batch), so in turn the time to save offsets is correlated to the number of distinct persistence IDs.  During the save, loads of sequence numbers may be performed concurrently by offset validation.  If such a load happens while the offset save is running, the optimistic concurrency protocol will retry the save, including redoing the writes.  In addition, any load which starts while the save is running and completes after the save has updated the in-memory state will be retried (including I/O).

Loads in validation happen when an event from a new (or sufficiently dormant) persistence ID is encountered, so the probability of a save being concurrent with such a load is a function of the rate at which such events are encountered (a higher rate increasing that probability) and the time to perform a contention-free offset save (longer increases that probability).  This can be especially pronounced with at-least-once projections (in which backpressure from the offset save generally doesn't propagate through the group-within stage to the business logic and validation stages), and especially so for the at-least-once-flow projections (where the business logic stage itself can, within some bounds, decouple demand to the validation stage from demand from group-within stage).

Workloads which use distinct persistence IDs to represent a higher-level operation (workflows, in the broad sense of the term) will often create many persistence IDs, so loads from validations may occur frequently (albeit with parallelism 1).  If a projection instance can expect to see 15 new persistence IDs per second out of 150 events per second (average of 10 events per persistence ID), saving offsets every 100 events or 500ms (default at-least-once settings), we can deduce the following expectations:

* The offset save will happen every 500ms and encompass an average of 75 events from ~8 pids, so it will need to perform 2 DDB writes (a batch sequence number write and a write of slice offsets (at most 8)): this should take about 20ms (1/50 of a second)
* The expected number of validation loads in 20ms will be 15/50 = 0.3
* By the Poisson distribution, there's a roughly 26% chance of a conflict triggering a CAS retry which performs additional I/O against DDB, needlessly consuming capacity units

Since the offset save operations are generally heavier to retry than the offset loads, this change adopts a more pessimistic form of concurrency control: a load which starts during a save waits for the save to complete.  If the load starts before the save, there will likely still be a retry (this is less pessimistic than a lock or encapsulating the offsets in an actor).