### PR TITLE
bump: Slick 3.6.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
     val AkkaProjectionVersionInDocs = "1.6"
 
     val AkkaPersistenceCassandra = "1.3.3"
-    val AkkaPersistenceJdbc = "5.5.4"
+    val AkkaPersistenceJdbc = "5.5.5"
 
     val AkkaPersistenceR2dbc = "1.3.12"
     val AkkaPersistenceR2dbcVersionInDocs = VersionNumber(AkkaPersistenceR2dbc).numbers match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -47,7 +47,7 @@ object Dependencies {
       case Seq(major, minor, _*) => s"$major.$minor"
     }
 
-    val slick = "3.5.1"
+    val slick = "3.6.1"
     val scalaTest = "3.2.18"
     val testContainers = "1.19.3"
     val junit = "4.13.2"


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References https://github.com/akka/akka-projection/issues/1428

Somewhat questionable to release in a patch of projections, since it is a minor version bump in Slick and 3.6 has some binary imcompatibilities with 3.5: https://scala-slick.org/doc/3.6.0/compat-report.html.


We probably should bump it upstream in AP-JDBC as well first before merging here.