### PR TITLE
perf(ddb): don't load pid when pid is inflight

### DIFF
--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -796,7 +796,16 @@ private[projection] class DynamoDBOffsetStore(
     val pid = recordWithOffset.record.pid
     val seqNr = recordWithOffset.record.seqNr
 
-    load(pid).flatMap { currentState =>
+    // If the pid is currently in flight, we'll prefer that pid over current state in all cases except when it's a sequence number
+    // reset, so only attempt the load if not inflight or if seqNr is 1 and we allow sequence number reset
+    val loadedIfNecessary =
+      if (currentInflight.contains(pid)) {
+        if (seqNr > 1 || settings.acceptSequenceNumberResetAfter.isEmpty)
+          Future.successful(state.get()) // definitely not a seqNr reset
+        else load(pid)
+      } else load(pid)
+
+    loadedIfNecessary.flatMap { currentState =>
       try {
         val duplicate = currentState.isDuplicate(recordWithOffset.record, settings.acceptSequenceNumberResetAfter)
 

--- a/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
+++ b/akka-projection-dynamodb/src/main/scala/akka/projection/dynamodb/internal/DynamoDBOffsetStore.scala
@@ -796,16 +796,14 @@ private[projection] class DynamoDBOffsetStore(
     val pid = recordWithOffset.record.pid
     val seqNr = recordWithOffset.record.seqNr
 
-    // If the pid is currently in flight, we'll prefer that pid over current state in all cases except when it's a sequence number
-    // reset, so only attempt the load if not inflight or if seqNr is 1 and we allow sequence number reset
-    val loadedIfNecessary =
-      if (currentInflight.contains(pid)) {
-        if (seqNr > 1 || settings.acceptSequenceNumberResetAfter.isEmpty)
-          Future.successful(state.get()) // definitely not a seqNr reset
-        else load(pid)
-      } else load(pid)
+    // The logic operating on the current state only requires a record for that pid in state when
+    // the pid is not inflight OR the incoming record resets the sequence number
+    val mightBeReset = (seqNr == 1) && settings.acceptSequenceNumberResetAfter.isDefined
+    val currentStateFut =
+      if (mightBeReset || !currentInflight.contains(pid)) load(pid)
+      else Future.successful(state.get())
 
-    loadedIfNecessary.flatMap { currentState =>
+    currentStateFut.flatMap { currentState =>
       try {
         val duplicate = currentState.isDuplicate(recordWithOffset.record, settings.acceptSequenceNumberResetAfter)
 

--- a/akka-projection-dynamodb/src/test/scala/akka/persistence/dynamodb/internal/DynamoDBOffsetStoreSpec.scala
+++ b/akka-projection-dynamodb/src/test/scala/akka/persistence/dynamodb/internal/DynamoDBOffsetStoreSpec.scala
@@ -118,7 +118,7 @@ object DynamoDBOffsetStoreSpec {
   def uuid() = UUID.randomUUID().toString
 
   val baseSettings = DynamoDBProjectionSettings(config.getConfig("akka.projection.dynamodb"))
-    .withAcceptSequenceNumberResetAfter(3600.seconds)
+    .withAcceptSequenceNumberResetAfter(3600.seconds) // needed for test "...number reset is possible"
 }
 
 class DynamoDBOffsetStoreSpec

--- a/akka-projection-dynamodb/src/test/scala/akka/persistence/dynamodb/internal/DynamoDBOffsetStoreSpec.scala
+++ b/akka-projection-dynamodb/src/test/scala/akka/persistence/dynamodb/internal/DynamoDBOffsetStoreSpec.scala
@@ -353,8 +353,10 @@ class DynamoDBOffsetStoreSpec
       validation2.futureValue shouldBe Validation.Accepted // no load attempted
       dao.probesByPid.get("p1").expectNoMessage(30.millis)
       offsetStore.addInflight(env1)
-      // for whatever reason, no save of the offsets...
+      // no offset save to remove from inflight and update state
       val validation3 = offsetStore.validate(env2) // reset the sequence number
+      // since no save (which would update state and clear inflight) happened, there shouldn't actually be a record
+      // for p1 in the offset store, but assume that there now is.
       dao.probesByPid
         .get("p1")
         .expectMessageType[LoadSequenceNumber]

--- a/akka-projection-dynamodb/src/test/scala/akka/persistence/dynamodb/internal/DynamoDBOffsetStoreSpec.scala
+++ b/akka-projection-dynamodb/src/test/scala/akka/persistence/dynamodb/internal/DynamoDBOffsetStoreSpec.scala
@@ -28,6 +28,8 @@ import akka.projection.internal.ManagementState
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpecLike
 import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem
+import akka.persistence.query.typed.EventEnvelope
+import akka.projection.dynamodb.internal.DynamoDBOffsetStore.Validation
 
 object DynamoDBOffsetStoreSpec {
   val config = {
@@ -116,6 +118,7 @@ object DynamoDBOffsetStoreSpec {
   def uuid() = UUID.randomUUID().toString
 
   val baseSettings = DynamoDBProjectionSettings(config.getConfig("akka.projection.dynamodb"))
+    .withAcceptSequenceNumberResetAfter(3600.seconds)
 }
 
 class DynamoDBOffsetStoreSpec
@@ -253,7 +256,6 @@ class DynamoDBOffsetStoreSpec
       loadFuture.futureValue.byPid("p2").seqNr shouldBe 57
     }
 
-    // The current implementation doesn't actually do concurrent single-pid loads in validation, but we can test this
     "merge concurrent loads of 2 pids without retrying I/O" in {
       val clock = Clock.systemUTC()
       val startTime = clock.instant()
@@ -322,6 +324,43 @@ class DynamoDBOffsetStoreSpec
       (secondLoadFuture.futureValue.byPid.keySet shouldNot contain).oneOf("p1", "p2")
 
       assert(!offsetStore.isStopped(), "offset store should not be stopped")
+    }
+
+    "not load when validating in-flight pid unless sequence number reset is possible" in {
+      val clock = Clock.systemUTC()
+      val startTime = clock.instant()
+
+      val dao = new ProbeStubOffsetStoreDao(testKit)
+
+      val offsetStore = new DynamoDBOffsetStore(projectionId, uuid(), None, system, baseSettings, dao, clock)
+
+      val t0 = startTime.minusSeconds(3610)
+      val offset0 = TimestampOffset(t0, Map("p1" -> 1L))
+      val env0 = EventEnvelope(offset0, "p1", 1, "e1", t0.toEpochMilli, "", dao.sliceFor("p1"))
+      val offset1 = TimestampOffset(t0.plusMillis(100), Map("p1" -> 2))
+      val env1 = EventEnvelope(offset1, "p1", 2, "e2", offset1.timestamp.toEpochMilli, "", dao.sliceFor("p1"))
+      val t1 = startTime.minusSeconds(5)
+      val offset2 = TimestampOffset(t1, Map("p1" -> 1L)) // sequence number reset
+      val env2 = EventEnvelope(offset2, "p1", 1, "e1a", offset2.timestamp.toEpochMilli, "", dao.sliceFor("p1"))
+      dao.initializeProbes(Some("p1"), None)
+
+      val validation1 = offsetStore.validate(env0)
+      dao.probesByPid.get("p1").expectMessageType[LoadSequenceNumber].promise.success(None)
+      // offset store state does not have a seqNr for p1
+      validation1.futureValue shouldBe Validation.Accepted
+      offsetStore.addInflight(env0)
+      val validation2 = offsetStore.validate(env1)
+      validation2.futureValue shouldBe Validation.Accepted // no load attempted
+      dao.probesByPid.get("p1").expectNoMessage(30.millis)
+      offsetStore.addInflight(env1)
+      // for whatever reason, no save of the offsets...
+      val validation3 = offsetStore.validate(env2) // reset the sequence number
+      dao.probesByPid
+        .get("p1")
+        .expectMessageType[LoadSequenceNumber]
+        .promise
+        .success(Some(Record(env1.slice, env1.persistenceId, env1.sequenceNr, Instant.ofEpochMilli(env1.timestamp))))
+      validation3.futureValue shouldBe Validation.Accepted
     }
   }
 }


### PR DESCRIPTION
Discovered this while testing #1425.

If there is no sequence number for a given pid in the offset store nor one in the by-pid state (e.g. this is a new pid):

* the first-encountered event performs a load, finding no result (so the pid continues to not have a sequence number in by-pid state).  If this event has seqNr 1, it will be accepted and move inflight
* any subsequent event for that pid being encountered before an offset is saved (e.g. in an at-least-once projection) will cause validation to perform another load even though there shouldn't be one saved (since there's a general assumption of only one offset store being active for a given projectionId and slice)... the validation logic then _prefers to use the inflight seqNr instead of any loaded by-pid state_
  * the one exception to this preference is if a sequence number reset is in play: the incoming sequence number is 1 and the stored sequence number has timestamp more than `accept-sequence-number-reset-after` ago

This change adjusts validation to only load the pid if the pid isn't inflight or if the incoming event might indicate a sequence number reset (this may be excessively conservative).