### PR TITLE
feat: keep alive and timeouts for grpc projections

### DIFF
--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/consumer/GrpcQuerySettingsSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/consumer/GrpcQuerySettingsSpec.scala
@@ -12,11 +12,14 @@ import org.scalatest.wordspec.AnyWordSpecLike
 class GrpcQuerySettingsSpec extends AnyWordSpecLike with Matchers {
   "The GrpcQuerySettings" should {
     "parse from config" in {
-      val config = ConfigFactory.parseString(""" 
+      val config = ConfigFactory.parseString("""
         stream-id = "my-stream-id"
         additional-request-headers {
           "x-auth-header" = "secret"
         }
+        keep-alive-interval = 0s
+        keep-alive-timeout = 5s
+        keep-alive-failure-threshold = 3
       """)
 
       val settings = GrpcQuerySettings(config)

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/KeepAliveBidiStageSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/KeepAliveBidiStageSpec.scala
@@ -110,7 +110,7 @@ class KeepAliveBidiStageSpec extends ScalaTestWithActorTestKit("""
 
       val err = toAppSub.expectError()
       err shouldBe a[TimeoutException]
-      err.getMessage should include("No keepalive Pong response")
+      err.getMessage should include("No keepalive Pong observed")
     }
 
     "keep emitting Pings without failing the stream when timeout is zero" in {
@@ -175,11 +175,12 @@ class KeepAliveBidiStageSpec extends ScalaTestWithActorTestKit("""
       val (_, toProdSub, _, toAppSub) = makeProbes(100.millis, Duration.Zero, "test-pending")
       toAppSub.request(10)
       // intentionally do NOT request from toProdSub yet; several ticks will fire while there
-      // is no demand. The first becomes pendingPing, the rest are dropped.
+      // is no demand. The first sets pendingPing, the rest are dropped.
       Thread.sleep(500)
 
-      // Grant single-element demand; the queued pendingPing arrives immediately and its id is 0
-      // (the very first ping), proving the rest were dropped rather than buffered.
+      // Grant single-element demand; the queued pendingPing is materialized at push time with
+      // id=0 (the very first id, since nextId is only incremented on emit), proving the rest
+      // were dropped rather than buffered with reserved ids.
       toProdSub.request(1)
       val queued = expectPing(toProdSub, 200.millis)
       queued.id shouldBe 0L
@@ -189,17 +190,15 @@ class KeepAliveBidiStageSpec extends ScalaTestWithActorTestKit("""
       // timeout = 0 so the stream stays alive while in-flight grows
       val (_, toProdSub, _, toAppSub) = makeProbes(20.millis, Duration.Zero, "test-prune")
       toAppSub.request(50)
-      // Bound demand at exactly 10: ticks 0..9 push, inFlight grows to 10 (== MaxInFlight, no prune yet).
-      // Tick #10 finds no demand, becomes pendingPing, inFlight grows to 11 → exactly one prune fires.
-      // Subsequent ticks find pendingPing already set and are dropped (no further inFlight growth).
-      toProdSub.request(10)
+      // Demand for 20 pushes: ticks 1..10 grow inFlight to 10 (== MaxInFlight, no prune yet),
+      // tick 11 pushes and grows it to 11 → prune fires once. Subsequent ticks push and the
+      // size stays at MaxInFlight via further prunes.
+      toProdSub.request(20)
 
       LoggingTestKit
         .debug("test-prune: Dropping in-flight Ping")
         .expect {
-          for (_ <- 1 to 10) expectPing(toProdSub, 500.millis)
-          // small grace window for the next tick (which becomes pendingPing) to fire and trigger the prune
-          Thread.sleep(100)
+          for (_ <- 1 to 11) expectPing(toProdSub, 500.millis)
         }
     }
 

--- a/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/KeepAliveBidiStageSpec.scala
+++ b/akka-projection-grpc-tests/src/test/scala/akka/projection/grpc/internal/KeepAliveBidiStageSpec.scala
@@ -1,0 +1,283 @@
+/*
+ * Copyright (C) 2025 Lightbend Inc. <https://akka.io>
+ */
+
+package akka.projection.grpc.internal
+
+import java.util.concurrent.TimeoutException
+
+import scala.concurrent.duration._
+
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.LoggingTestKit
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.projection.grpc.internal.proto.Event
+import akka.projection.grpc.internal.proto.InitReq
+import akka.projection.grpc.internal.proto.Ping
+import akka.projection.grpc.internal.proto.Pong
+import akka.projection.grpc.internal.proto.StreamIn
+import akka.projection.grpc.internal.proto.StreamOut
+import akka.stream.ClosedShape
+import akka.stream.scaladsl.BidiFlow
+import akka.stream.scaladsl.GraphDSL
+import akka.stream.scaladsl.RunnableGraph
+import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.TestSubscriber
+import akka.stream.testkit.scaladsl.TestSink
+import akka.stream.testkit.scaladsl.TestSource
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class KeepAliveBidiStageSpec extends ScalaTestWithActorTestKit("""
+    akka.loglevel = DEBUG
+    akka.test.single-expect-default = 5s
+    """) with AnyWordSpecLike with LogCapturing {
+
+  private val pingInterval = 200.millis
+  private val pongTimeout = 500.millis
+
+  private def makeProbes(
+      interval: FiniteDuration,
+      timeout: FiniteDuration,
+      logPrefix: String,
+      failureThreshold: Int = 1): (
+      TestPublisher.Probe[StreamIn],
+      TestSubscriber.Probe[StreamIn],
+      TestPublisher.Probe[StreamOut],
+      TestSubscriber.Probe[StreamOut]) = {
+    val bidi = BidiFlow.fromGraph(new KeepAliveBidiStage(interval, timeout, failureThreshold, logPrefix))
+    RunnableGraph
+      .fromGraph(
+        GraphDSL
+          .createGraph(TestSource[StreamIn](), TestSink[StreamIn](), TestSource[StreamOut](), TestSink[StreamOut]())(
+            (a, b, c, d) => (a, b, c, d)) { implicit b => (appSrc, toProdSink, prodSrc, toAppSink) =>
+            import GraphDSL.Implicits._
+            val bidiShape = b.add(bidi)
+            appSrc ~> bidiShape.in1
+            bidiShape.out1 ~> toProdSink
+            prodSrc ~> bidiShape.in2
+            bidiShape.out2 ~> toAppSink
+            ClosedShape
+          })
+      .run()
+  }
+
+  private def expectPing(probe: TestSubscriber.Probe[StreamIn], max: FiniteDuration): Ping =
+    probe.expectNext(max).message match {
+      case StreamIn.Message.Ping(p) => p
+      case other                    => fail(s"Expected Ping, got [$other]")
+    }
+
+  private class Setup {
+    val (appPub, toProdSub, prodPub, toAppSub) = makeProbes(pingInterval, pongTimeout, "test", failureThreshold = 1)
+  }
+
+  "KeepAliveBidiStage" must {
+
+    "pass through non-ping StreamIn and non-pong StreamOut" in new Setup {
+      toProdSub.request(10)
+      toAppSub.request(10)
+
+      val init = StreamIn(StreamIn.Message.Init(InitReq(streamId = "stream", sliceMin = 0, sliceMax = 1023)))
+      appPub.sendNext(init)
+      toProdSub.expectNext(init)
+
+      val event = StreamOut(
+        StreamOut.Message
+          .Event(Event(persistenceId = "pid", seqNr = 1, slice = 0, offset = Nil, payload = None, source = "")))
+      prodPub.sendNext(event)
+      toAppSub.expectNext(event)
+    }
+
+    "emit Pings at the configured interval and accept Pongs" in new Setup {
+      toProdSub.request(10)
+      toAppSub.request(10)
+
+      val p1 = expectPing(toProdSub, pingInterval + 1.second)
+      prodPub.sendNext(StreamOut(StreamOut.Message.Pong(Pong(p1.id))))
+
+      val p2 = expectPing(toProdSub, pingInterval + 1.second)
+      prodPub.sendNext(StreamOut(StreamOut.Message.Pong(Pong(p2.id))))
+
+      // Pongs were not forwarded to the app side
+      toAppSub.expectNoMessage(100.millis)
+    }
+
+    "fail the stream when no Pong arrives within timeout" in new Setup {
+      toProdSub.request(10)
+      toAppSub.request(10)
+
+      expectPing(toProdSub, pingInterval + 1.second)
+
+      val err = toAppSub.expectError()
+      err shouldBe a[TimeoutException]
+      err.getMessage should include("No keepalive Pong response")
+    }
+
+    "keep emitting Pings without failing the stream when timeout is zero" in {
+      val (_, toProdSub, _, toAppSub) = makeProbes(pingInterval, Duration.Zero, "test-no-timeout")
+      toProdSub.request(10)
+      toAppSub.request(10)
+
+      // Several pings should be emitted, but no Pong responses, and the stream must not fail
+      expectPing(toProdSub, pingInterval + 1.second)
+      expectPing(toProdSub, pingInterval + 1.second)
+      expectPing(toProdSub, pingInterval + 1.second)
+      toAppSub.expectNoMessage(100.millis)
+    }
+
+    "continue forwarding events after handling a Pong" in new Setup {
+      toProdSub.request(10)
+      toAppSub.request(10)
+
+      val p = expectPing(toProdSub, pingInterval + 1.second)
+      prodPub.sendNext(StreamOut(StreamOut.Message.Pong(Pong(p.id))))
+
+      val event = StreamOut(
+        StreamOut.Message
+          .Event(Event(persistenceId = "pid", seqNr = 1, slice = 0, offset = Nil, payload = None, source = "")))
+      prodPub.sendNext(event)
+      toAppSub.expectNext(1.second, event)
+    }
+
+    "ignore Pong with unknown id" in new Setup {
+      toProdSub.request(10)
+      toAppSub.request(10)
+
+      prodPub.sendNext(StreamOut(StreamOut.Message.Pong(Pong(99999L))))
+      toAppSub.expectNoMessage(100.millis)
+
+      val p = expectPing(toProdSub, pingInterval + 1.second)
+      prodPub.sendNext(StreamOut(StreamOut.Message.Pong(Pong(p.id))))
+    }
+
+    "fail on the deadline of the oldest in-flight Ping when only a later one is answered" in {
+      val interval = 200.millis
+      val timeout = 2.seconds
+      val (_, toProdSub, prodPub, toAppSub) = makeProbes(interval, timeout, "test-partial")
+      toProdSub.request(20)
+      toAppSub.request(10)
+
+      val p1 = expectPing(toProdSub, interval + 1.second)
+      val p2 = expectPing(toProdSub, interval + 1.second)
+      // consume the third ping from the probe; we deliberately don't answer it
+      expectPing(toProdSub, interval + 1.second)
+
+      // Only answer the middle one. p1 (the oldest) still has its deadline scheduled.
+      prodPub.sendNext(StreamOut(StreamOut.Message.Pong(Pong(p2.id))))
+
+      val err = toAppSub.expectError()
+      err shouldBe a[TimeoutException]
+      // The first unanswered ping (p1) is the oldest, its deadline fires first
+      err.getMessage should include(s"Ping [${p1.id}]")
+    }
+
+    "queue at most one pending Ping when outProducer is backpressured" in {
+      val (_, toProdSub, _, toAppSub) = makeProbes(100.millis, Duration.Zero, "test-pending")
+      toAppSub.request(10)
+      // intentionally do NOT request from toProdSub yet; several ticks will fire while there
+      // is no demand. The first becomes pendingPing, the rest are dropped.
+      Thread.sleep(500)
+
+      // Grant single-element demand; the queued pendingPing arrives immediately and its id is 0
+      // (the very first ping), proving the rest were dropped rather than buffered.
+      toProdSub.request(1)
+      val queued = expectPing(toProdSub, 200.millis)
+      queued.id shouldBe 0L
+    }
+
+    "prune oldest in-flight Ping when MaxInFlight cap is reached" in {
+      // timeout = 0 so the stream stays alive while in-flight grows
+      val (_, toProdSub, _, toAppSub) = makeProbes(20.millis, Duration.Zero, "test-prune")
+      toAppSub.request(50)
+      // Bound demand at exactly 10: ticks 0..9 push, inFlight grows to 10 (== MaxInFlight, no prune yet).
+      // Tick #10 finds no demand, becomes pendingPing, inFlight grows to 11 → exactly one prune fires.
+      // Subsequent ticks find pendingPing already set and are dropped (no further inFlight growth).
+      toProdSub.request(10)
+
+      LoggingTestKit
+        .debug("test-prune: Dropping in-flight Ping")
+        .expect {
+          for (_ <- 1 to 10) expectPing(toProdSub, 500.millis)
+          // small grace window for the next tick (which becomes pendingPing) to fire and trigger the prune
+          Thread.sleep(100)
+        }
+    }
+
+    "correlate Pongs to Pings by id regardless of order" in {
+      // Short interval, modest timeout. We answer the first three out of order, then keep
+      // answering subsequent pings so the stream stays alive past where the originals
+      // would have timed out if cancellation had failed.
+      val interval = 50.millis
+      val timeout = 500.millis
+      val (_, toProdSub, prodPub, toAppSub) = makeProbes(interval, timeout, "test-ooo")
+      toProdSub.request(50)
+      toAppSub.request(10)
+
+      val p1 = expectPing(toProdSub, interval + 1.second)
+      val p2 = expectPing(toProdSub, interval + 1.second)
+      val p3 = expectPing(toProdSub, interval + 1.second)
+
+      // Reverse order: p3, p1, p2
+      prodPub.sendNext(StreamOut(StreamOut.Message.Pong(Pong(p3.id))))
+      prodPub.sendNext(StreamOut(StreamOut.Message.Pong(Pong(p1.id))))
+      prodPub.sendNext(StreamOut(StreamOut.Message.Pong(Pong(p2.id))))
+
+      // Keep answering subsequent pings so the stream is exercised past the original deadlines.
+      // If any of p1/p2/p3's deadlines had not been cancelled, the stream would fail here.
+      for (_ <- 1 to 15) {
+        val p = expectPing(toProdSub, interval + 1.second)
+        prodPub.sendNext(StreamOut(StreamOut.Message.Pong(Pong(p.id))))
+      }
+
+      // Stream still alive
+      val event = StreamOut(
+        StreamOut.Message
+          .Event(Event(persistenceId = "pid", seqNr = 1, slice = 0, offset = Nil, payload = None, source = "")))
+      prodPub.sendNext(event)
+      toAppSub.expectNext(1.second, event)
+    }
+
+    "tolerate transient overdue Pongs up to failureThreshold and then fail" in {
+      val interval = 200.millis
+      val timeout = 500.millis
+      // checkPeriod = timeout/4 = 125ms, so 3 overdue checks ≈ 375ms past the deadline
+      val (_, toProdSub, _, toAppSub) =
+        makeProbes(interval, timeout, "test-threshold", failureThreshold = 3)
+      toProdSub.request(20)
+      toAppSub.request(10)
+
+      // First overdue check just warns; only the 3rd causes a failure. Total time until failure:
+      // first ping sent ~200ms, deadline at ~700ms, then up to 3 * 125ms more = ~1075ms before fail.
+      val err = LoggingTestKit
+        .warn("overdue")
+        .withOccurrences(2)
+        .expect {
+          val terminal = toAppSub.expectError()
+          terminal shouldBe a[TimeoutException]
+          terminal.getMessage should include("after [3] consecutive overdue checks")
+          terminal
+        }
+      err.getMessage should include("after [3] consecutive overdue checks")
+    }
+
+    "propagate failure from inApp to outProducer" in new Setup {
+      toProdSub.request(10)
+      toAppSub.request(10)
+
+      val cause = new RuntimeException("inApp failure")
+      appPub.sendError(cause)
+
+      toProdSub.expectError() shouldBe cause
+    }
+
+    "propagate failure from inProducer to outApp" in new Setup {
+      toProdSub.request(10)
+      toAppSub.request(10)
+
+      val cause = new RuntimeException("inProducer failure")
+      prodPub.sendError(cause)
+
+      toAppSub.expectError() shouldBe cause
+    }
+  }
+}

--- a/akka-projection-grpc/src/main/protobuf/akka/projection/grpc/event_producer.proto
+++ b/akka-projection-grpc/src/main/protobuf/akka/projection/grpc/event_producer.proto
@@ -55,6 +55,9 @@ message StreamIn {
     // events for a specific entity.
     ReplayReq replay = 3;
     Ack ack = 4;
+    // Application level keep alive request, the producer is expected to respond
+    // with a `Pong` carrying the same id.
+    Ping ping = 5;
   }
 }
 
@@ -257,7 +260,18 @@ message StreamOut {
   oneof message {
     Event event = 1;
     FilteredEvent filtered_event = 2;
+    // Application level keep alive response, echoes back the `id` from the
+    // corresponding `Ping` so the consumer can correlate and measure RTT.
+    Pong pong = 3;
   }
+}
+
+message Ping {
+  int64 id = 1;
+}
+
+message Pong {
+  int64 id = 1;
 }
 
 message Event {

--- a/akka-projection-grpc/src/main/resources/reference.conf
+++ b/akka-projection-grpc/src/main/resources/reference.conf
@@ -32,6 +32,23 @@ akka.projection.grpc {
       # producer will reconnect, possibly after backoff.
       journal-write-timeout = 5s
     }
+
+    # akka-projection-grpc level keep alive for the eventsBySlices stream. The consumer
+    # periodically sends a keep-alive request and verifies that the producer's response
+    # arrives within the configured deadline, exercising the gRPC stream and the producer's
+    # stream handler rather than just the TCP connection. Disabled by default. Requires an
+    # akka-projection producer of version 1.6.24 or newer.
+
+    # How often to send a keep-alive request. Set to 0s to disable the feature entirely.
+    keep-alive-interval = 0s
+
+    # How long a keep-alive request may go unanswered before the response is overdue. Set to
+    # 0s to keep sending requests without ever failing the stream (firewall keep-alive only).
+    keep-alive-timeout = 5s
+
+    # Fail the stream after this many consecutive overdue keep-alive responses; earlier ones
+    # log a warning, letting brief network spikes or a slow producer recover. Must be >= 1.
+    keep-alive-failure-threshold = 3
   }
 
   producer {

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/GrpcQuerySettings.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/GrpcQuerySettings.scala
@@ -155,6 +155,11 @@ final class GrpcQuerySettings private (
    * Set `timeout` to `Duration.Zero` to keep sending requests without ever failing the
    * stream (firewall keep-alive only).
    *
+   * The deadline measures Pong observation at the consumer-side stage. Pongs share the
+   * inbound channel with Events, so a consumer-side downstream that stalls pulling events
+   * for longer than `timeout * failureThreshold` can also trigger failure even when the
+   * producer is responsive. Pick `timeout` and `failureThreshold` with that in mind.
+   *
    * Requires an akka-projection producer of version 1.6.24 or newer.
    */
   def withKeepAlive(interval: FiniteDuration, timeout: FiniteDuration, failureThreshold: Int): GrpcQuerySettings =

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/GrpcQuerySettings.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/GrpcQuerySettings.scala
@@ -10,7 +10,9 @@ import akka.grpc.scaladsl.MetadataBuilder
 import akka.projection.grpc.consumer.scaladsl.GrpcReadJournal
 import com.typesafe.config.Config
 import scala.collection.immutable
+import scala.concurrent.duration.FiniteDuration
 import scala.jdk.CollectionConverters._
+import scala.jdk.DurationConverters._
 
 import akka.annotation.InternalApi
 import akka.persistence.typed.ReplicaId
@@ -48,7 +50,18 @@ object GrpcQuerySettings {
             .build())
     }
 
-    new GrpcQuerySettings(streamId, additionalHeaders, Vector.empty, None)
+    val keepAliveInterval = config.getDuration("keep-alive-interval").toScala
+    val keepAliveTimeout = config.getDuration("keep-alive-timeout").toScala
+    val keepAliveFailureThreshold = config.getInt("keep-alive-failure-threshold")
+
+    new GrpcQuerySettings(
+      streamId,
+      additionalHeaders,
+      Vector.empty,
+      None,
+      keepAliveInterval,
+      keepAliveTimeout,
+      keepAliveFailureThreshold)
   }
 
   /**
@@ -73,7 +86,10 @@ object GrpcQuerySettings {
       streamId,
       additionalRequestMetadata = None,
       initialConsumerFilter = Vector.empty,
-      fromReplica = None)
+      fromReplica = None,
+      keepAliveInterval = scala.concurrent.duration.Duration.Zero,
+      keepAliveTimeout = scala.concurrent.duration.Duration.Zero,
+      keepAliveFailureThreshold = 3)
   }
 
   /**
@@ -86,7 +102,10 @@ object GrpcQuerySettings {
       streamId,
       additionalRequestMetadata = None,
       initialConsumerFilter = Vector.empty,
-      fromReplica = None)
+      fromReplica = None,
+      keepAliveInterval = scala.concurrent.duration.Duration.Zero,
+      keepAliveTimeout = scala.concurrent.duration.Duration.Zero,
+      keepAliveFailureThreshold = 3)
   }
 }
 
@@ -94,10 +113,14 @@ final class GrpcQuerySettings private (
     val streamId: String,
     val additionalRequestMetadata: Option[Metadata],
     val initialConsumerFilter: immutable.Seq[ConsumerFilter.FilterCriteria],
-    val fromReplica: Option[ReplicaId]) {
+    val fromReplica: Option[ReplicaId],
+    val keepAliveInterval: FiniteDuration,
+    val keepAliveTimeout: FiniteDuration,
+    val keepAliveFailureThreshold: Int) {
   require(
     streamId != "",
     "streamId must be an id exposed by the producing side but was undefined on the consuming side.")
+  require(keepAliveFailureThreshold >= 1, s"keepAliveFailureThreshold must be >= 1, was [$keepAliveFailureThreshold]")
 
   /**
    * Additional request metadata, for authentication/authorization of the request on the remote side.
@@ -122,6 +145,34 @@ final class GrpcQuerySettings private (
     copy(initialConsumerFilter = initialConsumerFilter.asScala.toVector)
 
   /**
+   * Enable akka-projection-grpc level keep alive on the eventsBySlices stream. The consumer
+   * sends a keep-alive request every `interval` and verifies that the producer's response
+   * arrives within `timeout`, exercising the gRPC stream and the producer's stream handler
+   * rather than just the TCP connection. The stream fails after `failureThreshold`
+   * consecutive overdue responses (earlier ones log a warning), letting brief network spikes
+   * or a slow producer recover.
+   *
+   * Set `timeout` to `Duration.Zero` to keep sending requests without ever failing the
+   * stream (firewall keep-alive only).
+   *
+   * Requires an akka-projection producer of version 1.6.24 or newer.
+   */
+  def withKeepAlive(interval: FiniteDuration, timeout: FiniteDuration, failureThreshold: Int): GrpcQuerySettings =
+    copy(keepAliveInterval = interval, keepAliveTimeout = timeout, keepAliveFailureThreshold = failureThreshold)
+
+  /**
+   * Java API: see the Scala `withKeepAlive` overload.
+   */
+  def withKeepAlive(
+      interval: java.time.Duration,
+      timeout: java.time.Duration,
+      failureThreshold: Int): GrpcQuerySettings =
+    copy(
+      keepAliveInterval = interval.toScala,
+      keepAliveTimeout = timeout.toScala,
+      keepAliveFailureThreshold = failureThreshold)
+
+  /**
    * INTERNAL API
    */
   @InternalApi private[akka] def withFromReplica(replica: ReplicaId): GrpcQuerySettings =
@@ -131,7 +182,17 @@ final class GrpcQuerySettings private (
       streamId: String = streamId,
       additionalRequestMetadata: Option[Metadata] = additionalRequestMetadata,
       initialConsumerFilter: immutable.Seq[ConsumerFilter.FilterCriteria] = initialConsumerFilter,
-      fromReplica: Option[ReplicaId] = fromReplica): GrpcQuerySettings =
-    new GrpcQuerySettings(streamId, additionalRequestMetadata, initialConsumerFilter, fromReplica)
+      fromReplica: Option[ReplicaId] = fromReplica,
+      keepAliveInterval: FiniteDuration = keepAliveInterval,
+      keepAliveTimeout: FiniteDuration = keepAliveTimeout,
+      keepAliveFailureThreshold: Int = keepAliveFailureThreshold): GrpcQuerySettings =
+    new GrpcQuerySettings(
+      streamId,
+      additionalRequestMetadata,
+      initialConsumerFilter,
+      fromReplica,
+      keepAliveInterval,
+      keepAliveTimeout,
+      keepAliveFailureThreshold)
 
 }

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
@@ -28,6 +28,7 @@ import akka.projection.grpc.consumer.ConsumerFilter
 import akka.projection.grpc.consumer.GrpcQuerySettings
 import akka.projection.grpc.consumer.scaladsl
 import akka.projection.grpc.consumer.scaladsl.GrpcReadJournal.withChannelBuilderOverrides
+import akka.projection.grpc.internal.KeepAliveBidiStage
 import akka.projection.grpc.internal.ProjectionGrpcSerialization
 import akka.projection.grpc.internal.ConnectionException
 import akka.projection.grpc.internal.ProtoAnySerialization
@@ -46,7 +47,11 @@ import akka.projection.grpc.internal.proto.StreamIn
 import akka.projection.grpc.internal.proto.StreamOut
 import akka.projection.internal.CanTriggerReplay
 import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.BidiFlow
+import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
+
+import scala.concurrent.duration.Duration
 import akka.util.Timeout
 import com.google.protobuf.Descriptors
 import com.typesafe.config.Config
@@ -400,19 +405,45 @@ final class GrpcReadJournal private (
         .mapMaterializedValue(_ => NotUsed)
     }
 
-    val streamOut: Source[StreamOut, NotUsed] =
-      addRequestHeaders(client.eventsBySlices())
-        .invoke(streamIn)
-        .recover {
-          case ex: akka.grpc.GrpcServiceException if ex.status.getCode == Status.Code.UNAVAILABLE =>
-            val port = clientSettings.servicePortName.getOrElse(clientSettings.defaultPort.toString)
-            throw new ConnectionException(clientSettings.serviceName, port, streamId)
+    val grpcFlow: Flow[StreamIn, StreamOut, NotUsed] =
+      Flow[StreamIn]
+        .prefixAndTail(0)
+        .flatMapConcat {
+          case (_, tail) =>
+            addRequestHeaders(client.eventsBySlices())
+              .invoke(tail)
+              .recover {
+                case ex: akka.grpc.GrpcServiceException if ex.status.getCode == Status.Code.UNAVAILABLE =>
+                  val port = clientSettings.servicePortName.getOrElse(clientSettings.defaultPort.toString)
+                  throw new ConnectionException(clientSettings.serviceName, port, streamId)
 
-          case th: Throwable =>
-            throw new RuntimeException(
-              s"Failure to consume gRPC event stream for [$streamId]${CorrelationId.toLogText(correlationId)}",
-              th)
+                case th: Throwable =>
+                  throw new RuntimeException(
+                    s"Failure to consume gRPC event stream for [$streamId]${CorrelationId.toLogText(correlationId)}",
+                    th)
+              }
         }
+        .mapMaterializedValue(_ => NotUsed)
+
+    val effectiveFlow: Flow[StreamIn, StreamOut, NotUsed] =
+      if (settings.keepAliveInterval > Duration.Zero) {
+        log.debug(
+          "{}: Application level keepalive enabled, interval [{}], timeout [{}]",
+          logPrefix,
+          settings.keepAliveInterval,
+          settings.keepAliveTimeout)
+        BidiFlow
+          .fromGraph(
+            new KeepAliveBidiStage(
+              settings.keepAliveInterval,
+              settings.keepAliveTimeout,
+              settings.keepAliveFailureThreshold,
+              logPrefix))
+          .join(grpcFlow)
+      } else
+        grpcFlow
+
+    val streamOut: Source[StreamOut, NotUsed] = streamIn.via(effectiveFlow)
 
     streamOut.map {
       case StreamOut(StreamOut.Message.Event(event), _) =>

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/EventProducerServiceImpl.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/EventProducerServiceImpl.scala
@@ -26,12 +26,17 @@ import akka.projection.grpc.internal.proto.FilteredEvent
 import akka.projection.grpc.internal.proto.InitReq
 import akka.projection.grpc.internal.proto.LoadEventRequest
 import akka.projection.grpc.internal.proto.LoadEventResponse
+import akka.projection.grpc.internal.proto.Pong
 import akka.projection.grpc.internal.proto.StreamIn
 import akka.projection.grpc.internal.proto.StreamOut
 import akka.projection.grpc.producer.scaladsl.EventProducer
 import akka.projection.grpc.producer.scaladsl.EventProducerInterceptor
+import akka.stream.FlowShape
 import akka.stream.scaladsl.BidiFlow
 import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.GraphDSL
+import akka.stream.scaladsl.MergePreferred
+import akka.stream.scaladsl.Partition
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import com.google.protobuf.timestamp.Timestamp
@@ -123,7 +128,7 @@ import akka.projection.internal.CorrelationId
   override def eventsBySlices(in: Source[StreamIn, NotUsed], metadata: Metadata): Source[StreamOut, NotUsed] = {
     in.prefixAndTail(1).flatMapConcat {
       case (Seq(StreamIn(StreamIn.Message.Init(init), _)), tail) =>
-        tail.via(runEventsBySlices(init, metadata))
+        tail.via(pingPongFlow(runEventsBySlices(init, metadata)))
       case (Seq(), _) =>
         // if error during recovery in proxy the stream will be completed before init
         log.warn("Event stream closed before init.")
@@ -137,6 +142,29 @@ import akka.projection.internal.CorrelationId
         throw new IllegalStateException(s"Unexpected Seq prefix with [${seq.size}] elements.")
     }
   }
+
+  // Diverts incoming `Ping` messages to direct `Pong` responses merged into the StreamOut,
+  // so the rest of the inbound flow (FilterStage) never sees them and Pongs don't wait
+  // behind buffered events.
+  private def pingPongFlow(eventsFlow: Flow[StreamIn, StreamOut, NotUsed]): Flow[StreamIn, StreamOut, NotUsed] =
+    Flow.fromGraph(GraphDSL.create() { implicit b =>
+      import GraphDSL.Implicits._
+
+      val partition = b.add(Partition[StreamIn](2, {
+        case StreamIn(_: StreamIn.Message.Ping, _) => 0
+        case _                                     => 1
+      }))
+      val pingToPong = b.add(Flow[StreamIn].collect {
+        case StreamIn(StreamIn.Message.Ping(ping), _) => StreamOut(StreamOut.Message.Pong(Pong(ping.id)))
+      })
+      val events = b.add(eventsFlow)
+      val merge = b.add(MergePreferred[StreamOut](1))
+
+      partition.out(0) ~> pingToPong ~> merge.preferred
+      partition.out(1) ~> events ~> merge.in(0)
+
+      FlowShape(partition.in, merge.out)
+    })
 
   private def runEventsBySlices(init: InitReq, metadata: Metadata): Flow[StreamIn, StreamOut, NotUsed] = {
     val futureFlow = intercept(init.streamId, metadata).map { _ =>

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/KeepAliveBidiStage.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/KeepAliveBidiStage.scala
@@ -32,6 +32,10 @@ import org.slf4j.LoggerFactory
  * oldest entry older than `timeout`. Below the threshold each overdue check logs a warning.
  * If `timeout` is `Duration.Zero` the watchdog is disabled — pings still flow to keep the
  * connection alive and RTT is logged at debug on Pong.
+ *
+ * Note: the deadline measures Pong observation at this stage. Pongs share the inbound channel
+ * with Events, so a consumer-side downstream that stalls pulling events for longer than
+ * `timeout * failureThreshold` can also trigger failure even when the producer is responsive.
  */
 @InternalApi
 private[akka] final class KeepAliveBidiStage(
@@ -56,15 +60,18 @@ private[akka] final class KeepAliveBidiStage(
     private val PingTickKey = "ping-tick"
     private val DeadlineCheckKey = "deadline-check"
 
-    // Bounds the in-flight tracker when the watchdog is disabled (timeout = 0)
+    // Bounds the in-flight tracker when the watchdog is disabled (timeout = 0); 10 is
+    // generous given typical intervals (seconds) and gives a clear breadcrumb in the prune log.
     private val MaxInFlight = 10
 
     private var nextId: Long = 0L
     private var inFlight = Map[Long, Long]()
     private var consecutiveOverdueChecks: Int = 0
 
-    // At most one Ping is queued here when outProducer has no demand; newer ticks are dropped.
-    private var pendingPing: Option[StreamIn] = None
+    // A tick fired with no demand on outProducer; the Ping itself is materialized only when
+    // we actually push, so its id and inFlight timestamp reflect the real send time. Newer
+    // ticks while pendingPing is already true are dropped.
+    private var pendingPing: Boolean = false
 
     setHandler(inApp, new InHandler {
       override def onPush(): Unit = push(outProducer, grab(inApp))
@@ -76,16 +83,13 @@ private[akka] final class KeepAliveBidiStage(
       outProducer,
       new OutHandler {
         override def onPull(): Unit = {
-          pendingPing match {
-            case Some(p) =>
-              pendingPing = None
-              push(outProducer, p)
-            case None =>
-              if (isClosed(inApp)) {
-                complete(outProducer)
-              } else if (!hasBeenPulled(inApp)) {
-                pull(inApp)
-              }
+          if (pendingPing) {
+            pendingPing = false
+            emitPing()
+          } else if (isClosed(inApp)) {
+            complete(outProducer)
+          } else if (!hasBeenPulled(inApp)) {
+            pull(inApp)
           }
         }
         override def onDownstreamFinish(cause: Throwable): Unit = cancel(inApp, cause)
@@ -137,27 +141,10 @@ private[akka] final class KeepAliveBidiStage(
 
     override protected def onTimer(timerKey: Any): Unit = timerKey match {
       case PingTickKey =>
-        val id = nextId
-        nextId += 1
-        val ping = StreamIn(StreamIn.Message.Ping(Ping(id)))
-
-        val emitted =
-          if (isAvailable(outProducer)) {
-            push(outProducer, ping)
-            true
-          } else if (pendingPing.isEmpty) {
-            pendingPing = Some(ping)
-            true
-          } else {
-            log.debug("{}: Skipping Ping [{}] because outProducer is backed up", logPrefix, id)
-            false
-          }
-
-        if (emitted) {
-          inFlight += (id -> System.nanoTime())
-          // Prune only with watchdog disabled; otherwise failStage would beat the cap.
-          if (timeout <= Duration.Zero && inFlight.size > MaxInFlight) pruneInFlight()
-        }
+        if (isAvailable(outProducer)) emitPing()
+        else if (!pendingPing) pendingPing = true
+        else
+          log.debug("{}: Skipping Ping tick because outProducer is backed up and a Ping is already pending", logPrefix)
 
       case DeadlineCheckKey =>
         if (inFlight.isEmpty) {
@@ -171,15 +158,17 @@ private[akka] final class KeepAliveBidiStage(
             if (consecutiveOverdueChecks >= failureThreshold) {
               failStage(
                 new TimeoutException(
-                  s"$logPrefix: No keepalive Pong response for Ping [$oldestId] within [$timeout] " +
-                  s"after [$failureThreshold] consecutive overdue checks (elapsed [$elapsedMs ms])"))
+                  s"$logPrefix: No keepalive Pong observed for Ping [$oldestId] within [$timeout] " +
+                  s"after [$failureThreshold] consecutive overdue checks (elapsed [$elapsedMs ms]). " +
+                  s"May indicate a stuck producer, slow network, or consumer-side downstream backpressure."))
             } else {
               log.warn(
-                "{}: Keepalive Pong for Ping [{}] overdue [{} ms > {}], consecutive overdue checks [{}/{}]",
+                "{}: Keepalive Pong not observed for Ping [{}] within [{}] (overdue [{} ms]), " +
+                "consecutive overdue checks [{}/{}]",
                 logPrefix,
                 oldestId,
-                elapsedMs,
                 timeout,
+                elapsedMs,
                 consecutiveOverdueChecks,
                 failureThreshold)
             }
@@ -190,6 +179,15 @@ private[akka] final class KeepAliveBidiStage(
 
       case other =>
         log.warn("{}: Unexpected timer key [{}]", logPrefix, other)
+    }
+
+    private def emitPing(): Unit = {
+      val id = nextId
+      nextId += 1
+      push(outProducer, StreamIn(StreamIn.Message.Ping(Ping(id))))
+      inFlight += (id -> System.nanoTime())
+      // Prune only with watchdog disabled; otherwise failStage would beat the cap.
+      if (timeout <= Duration.Zero && inFlight.size > MaxInFlight) pruneInFlight()
     }
 
     private def pruneInFlight(): Unit = {

--- a/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/KeepAliveBidiStage.scala
+++ b/akka-projection-grpc/src/main/scala/akka/projection/grpc/internal/KeepAliveBidiStage.scala
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2025 Lightbend Inc. <https://akka.io>
+ */
+
+package akka.projection.grpc.internal
+
+import java.util.concurrent.TimeoutException
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
+import akka.annotation.InternalApi
+import akka.projection.grpc.internal.proto.Ping
+import akka.projection.grpc.internal.proto.StreamIn
+import akka.projection.grpc.internal.proto.StreamOut
+import akka.stream.Attributes
+import akka.stream.BidiShape
+import akka.stream.Inlet
+import akka.stream.Outlet
+import akka.stream.stage.GraphStage
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.InHandler
+import akka.stream.stage.OutHandler
+import akka.stream.stage.TimerGraphStageLogic
+import org.slf4j.LoggerFactory
+
+/**
+ * INTERNAL API
+ *
+ * akka-projection-grpc level keep alive for the consumer side of the gRPC `eventsBySlices` stream.
+ *
+ * Emits `Ping(id)` at `interval` and expects `Pong(id)` back. A watchdog scans in-flight pings
+ * every `timeout / 4`; the stream fails after `failureThreshold` consecutive checks find the
+ * oldest entry older than `timeout`. Below the threshold each overdue check logs a warning.
+ * If `timeout` is `Duration.Zero` the watchdog is disabled — pings still flow to keep the
+ * connection alive and RTT is logged at debug on Pong.
+ */
+@InternalApi
+private[akka] final class KeepAliveBidiStage(
+    interval: FiniteDuration,
+    timeout: FiniteDuration,
+    failureThreshold: Int,
+    logPrefix: String)
+    extends GraphStage[BidiShape[StreamIn, StreamIn, StreamOut, StreamOut]] {
+  require(failureThreshold >= 1, s"failureThreshold must be >= 1, was [$failureThreshold]")
+
+  private val inApp = Inlet[StreamIn]("KeepAliveBidi.inApp")
+  private val outProducer = Outlet[StreamIn]("KeepAliveBidi.outProducer")
+  private val inProducer = Inlet[StreamOut]("KeepAliveBidi.inProducer")
+  private val outApp = Outlet[StreamOut]("KeepAliveBidi.outApp")
+
+  override val shape: BidiShape[StreamIn, StreamIn, StreamOut, StreamOut] =
+    BidiShape(inApp, outProducer, inProducer, outApp)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new TimerGraphStageLogic(shape) {
+    private val log = LoggerFactory.getLogger(classOf[KeepAliveBidiStage])
+
+    private val PingTickKey = "ping-tick"
+    private val DeadlineCheckKey = "deadline-check"
+
+    // Bounds the in-flight tracker when the watchdog is disabled (timeout = 0)
+    private val MaxInFlight = 10
+
+    private var nextId: Long = 0L
+    private var inFlight = Map[Long, Long]()
+    private var consecutiveOverdueChecks: Int = 0
+
+    // At most one Ping is queued here when outProducer has no demand; newer ticks are dropped.
+    private var pendingPing: Option[StreamIn] = None
+
+    setHandler(inApp, new InHandler {
+      override def onPush(): Unit = push(outProducer, grab(inApp))
+      override def onUpstreamFinish(): Unit = complete(outProducer)
+      override def onUpstreamFailure(ex: Throwable): Unit = fail(outProducer, ex)
+    })
+
+    setHandler(
+      outProducer,
+      new OutHandler {
+        override def onPull(): Unit = {
+          pendingPing match {
+            case Some(p) =>
+              pendingPing = None
+              push(outProducer, p)
+            case None =>
+              if (isClosed(inApp)) {
+                complete(outProducer)
+              } else if (!hasBeenPulled(inApp)) {
+                pull(inApp)
+              }
+          }
+        }
+        override def onDownstreamFinish(cause: Throwable): Unit = cancel(inApp, cause)
+      })
+
+    setHandler(
+      inProducer,
+      new InHandler {
+        override def onPush(): Unit = {
+          val msg = grab(inProducer)
+          msg.message match {
+            case StreamOut.Message.Pong(pong) =>
+              inFlight.get(pong.id) match {
+                case Some(sentAt) =>
+                  inFlight -= pong.id
+                  if (log.isDebugEnabled) {
+                    val rttMs = (System.nanoTime() - sentAt) / 1000000L
+                    log.debug("{}: Keepalive RTT for ping [{}]: [{} ms]", logPrefix, pong.id, rttMs)
+                  }
+                case None =>
+                  log.debug("{}: Received Pong with unknown id [{}], ignoring", logPrefix, pong.id)
+              }
+              if (!hasBeenPulled(inProducer)) pull(inProducer)
+            case _ =>
+              push(outApp, msg)
+          }
+        }
+        override def onUpstreamFinish(): Unit = complete(outApp)
+        override def onUpstreamFailure(ex: Throwable): Unit = fail(outApp, ex)
+      })
+
+    setHandler(
+      outApp,
+      new OutHandler {
+        override def onPull(): Unit = {
+          if (isClosed(inProducer)) complete(outApp)
+          else if (!hasBeenPulled(inProducer)) pull(inProducer)
+        }
+        override def onDownstreamFinish(cause: Throwable): Unit = cancel(inProducer, cause)
+      })
+
+    override def preStart(): Unit = {
+      scheduleAtFixedRate(PingTickKey, interval, interval)
+      if (timeout > Duration.Zero) {
+        val checkPeriod = timeout / 4
+        scheduleAtFixedRate(DeadlineCheckKey, checkPeriod, checkPeriod)
+      }
+    }
+
+    override protected def onTimer(timerKey: Any): Unit = timerKey match {
+      case PingTickKey =>
+        val id = nextId
+        nextId += 1
+        val ping = StreamIn(StreamIn.Message.Ping(Ping(id)))
+
+        val emitted =
+          if (isAvailable(outProducer)) {
+            push(outProducer, ping)
+            true
+          } else if (pendingPing.isEmpty) {
+            pendingPing = Some(ping)
+            true
+          } else {
+            log.debug("{}: Skipping Ping [{}] because outProducer is backed up", logPrefix, id)
+            false
+          }
+
+        if (emitted) {
+          inFlight += (id -> System.nanoTime())
+          // Prune only with watchdog disabled; otherwise failStage would beat the cap.
+          if (timeout <= Duration.Zero && inFlight.size > MaxInFlight) pruneInFlight()
+        }
+
+      case DeadlineCheckKey =>
+        if (inFlight.isEmpty) {
+          consecutiveOverdueChecks = 0
+        } else {
+          val (oldestId, oldestSentAt) = inFlight.minBy(_._2)
+          val now = System.nanoTime()
+          if (oldestSentAt < now - timeout.toNanos) {
+            consecutiveOverdueChecks += 1
+            val elapsedMs = (now - oldestSentAt) / 1000000L
+            if (consecutiveOverdueChecks >= failureThreshold) {
+              failStage(
+                new TimeoutException(
+                  s"$logPrefix: No keepalive Pong response for Ping [$oldestId] within [$timeout] " +
+                  s"after [$failureThreshold] consecutive overdue checks (elapsed [$elapsedMs ms])"))
+            } else {
+              log.warn(
+                "{}: Keepalive Pong for Ping [{}] overdue [{} ms > {}], consecutive overdue checks [{}/{}]",
+                logPrefix,
+                oldestId,
+                elapsedMs,
+                timeout,
+                consecutiveOverdueChecks,
+                failureThreshold)
+            }
+          } else {
+            consecutiveOverdueChecks = 0
+          }
+        }
+
+      case other =>
+        log.warn("{}: Unexpected timer key [{}]", logPrefix, other)
+    }
+
+    private def pruneInFlight(): Unit = {
+      val (oldestId, _) = inFlight.toSeq.minBy(_._2)
+      log.debug("{}: Dropping in-flight Ping [{}] from tracker, cap reached", logPrefix, oldestId)
+      inFlight -= oldestId
+    }
+  }
+
+}


### PR DESCRIPTION
Add an opt-in akka-projection-grpc level keep-alive for the consumer eventsBySlices stream: the consumer sends periodic keep-alive requests, the producer echoes them back, and the stream fails after a configurable number of consecutive overdue responses — exercising the gRPC stream and the producer's stream handler.

Configured via `akka.projection.grpc.consumer.keep-alive-{interval,timeout,failure-threshold}` (disabled by default), or programmatically via `GrpcQuerySettings.withKeepAlive(interval, timeout, failureThreshold)`. Setting `keep-alive-timeout = 0s` keeps requests flowing without ever failing the stream (for firewall keep-alive only); below-threshold overdue responses log warnings so brief network spikes or a temporarily slow producer can recover.