### PR TITLE
Replace hardcoded repo.akka.io/maven references

### DIFF
--- a/docs/release-train-issue-template.md
+++ b/docs/release-train-issue-template.md
@@ -27,15 +27,15 @@ Variables to be expanded in this template:
 - [ ] Update the revision in Fossa in the Akka Group for the Akka umbrella version, e.g. `22.10`. Note that the revisions for the release is udpated by Akka Group > Projects > Edit.
 - [ ] Wait until [main build finished](https://github.com/akka/akka-projection/actions) after merging the latest PR
 - [ ] Create the [draft release](https://github.com/akka/akka-projection/releases/new?tag=v$VERSION$), click `Generate release notes` to get a title and release description. Use the `Publish release` button, which will create the tag.
-- [ ] Check that GitHub Actions release build has executed successfully (GitHub Actions will start a [CI build](https://github.com/akka/akka-projection/actions) for the new tag and publish artifacts to https://repo.akka.io/maven)
+- [ ] Check that GitHub Actions release build has executed successfully (GitHub Actions will start a [CI build](https://github.com/akka/akka-projection/actions) for the new tag and publish artifacts to the Akka repository)
 
 ### Check availability
 
 - [ ] Check [API](https://doc.akka.io/api/akka-projection/$VERSION$/) documentation
 - [ ] Check [reference](https://doc.akka.io/libraries/akka-projection/$VERSION$/) documentation. Check that the reference docs were deployed and show a version warning (see section below on how to fix the version warning).
-- [ ] Check the release `mvn dependency:get -Dartifact=com.lightbend.akka:akka-projection-core_2.13:$VERSION$`
+- [ ] Check the release using your token resolver URL from https://account.akka.io/token: `mvn dependency:get -Dartifact=com.lightbend.akka:akka-projection-core_2.13:$VERSION$ -Dmaven.repo.remote=<token url>`
 
-### When everything is on https://repo.akka.io/maven
+### When everything is available in the Akka repository
   - [ ] Log into `gustav.akka.io` as `akkarepo` 
     - [ ] If this updates the `current` version, run `./update-akka-projection-current-version.sh $VERSION$`
     - [ ] otherwise check changes and commit the new version to the local git repository

--- a/docs/release-train-issue-template.md
+++ b/docs/release-train-issue-template.md
@@ -33,7 +33,7 @@ Variables to be expanded in this template:
 
 - [ ] Check [API](https://doc.akka.io/api/akka-projection/$VERSION$/) documentation
 - [ ] Check [reference](https://doc.akka.io/libraries/akka-projection/$VERSION$/) documentation. Check that the reference docs were deployed and show a version warning (see section below on how to fix the version warning).
-- [ ] Check the release using your token resolver URL from https://account.akka.io/token: `mvn dependency:get -Dartifact=com.lightbend.akka:akka-projection-core_2.13:$VERSION$ -Dmaven.repo.remote=<token url>`
+- [ ] Check the release using your token resolver URL from https://account.akka.io/token: `mvn dependency:get -Dartifact=com.lightbend.akka:akka-projection-core_2.13:$VERSION$ -Dmaven.repo.remote=<token url>`.
 
 ### When everything is available in the Akka repository
   - [ ] Log into `gustav.akka.io` as `akkarepo` 

--- a/docs/release-train-issue-template.md
+++ b/docs/release-train-issue-template.md
@@ -27,7 +27,7 @@ Variables to be expanded in this template:
 - [ ] Update the revision in Fossa in the Akka Group for the Akka umbrella version, e.g. `22.10`. Note that the revisions for the release is udpated by Akka Group > Projects > Edit.
 - [ ] Wait until [main build finished](https://github.com/akka/akka-projection/actions) after merging the latest PR
 - [ ] Create the [draft release](https://github.com/akka/akka-projection/releases/new?tag=v$VERSION$), click `Generate release notes` to get a title and release description. Use the `Publish release` button, which will create the tag.
-- [ ] Check that GitHub Actions release build has executed successfully (GitHub Actions will start a [CI build](https://github.com/akka/akka-projection/actions) for the new tag and publish artifacts to the Akka repository)
+- [ ] Check that GitHub Actions release build has executed successfully (GitHub Actions will start a [CI build](https://github.com/akka/akka-projection/actions) for the new tag and publish artifacts to the Akka repository).
 
 ### Check availability
 

--- a/docs/src/main/paradox/cassandra.md
+++ b/docs/src/main/paradox/cassandra.md
@@ -18,7 +18,7 @@ The Akka dependencies are available from Akka's library repository. To access th
 @@repository [sbt,Maven,Gradle] {
 id="akka-repository"
 name="Akka library repository"
-url="https://repo.akka.io/maven"
+url="<url from https://account.akka.io/token>"
 }
 
 To use the Cassandra module of Akka Projections add the following dependency in your project:

--- a/docs/src/main/paradox/durable-state.md
+++ b/docs/src/main/paradox/durable-state.md
@@ -19,7 +19,7 @@ The Akka dependencies are available from Akka's library repository. To access th
 @@repository [sbt,Maven,Gradle] {
 id="akka-repository"
 name="Akka library repository"
-url="https://repo.akka.io/maven"
+url="<url from https://account.akka.io/token>"
 }
 
 To use the Durable State module of Akka Projections, add the following dependency in your project:

--- a/docs/src/main/paradox/dynamodb.md
+++ b/docs/src/main/paradox/dynamodb.md
@@ -17,7 +17,7 @@ The Akka dependencies are available from Akka's library repository. To access th
 @@repository [Maven,sbt,Gradle] {
 id="akka-repository"
 name="Akka library repository"
-url="https://repo.akka.io/maven"
+url="<url from https://account.akka.io/token>"
 }
 
 To use the DynamoDB module of Akka Projections, add the following dependencies to your project:

--- a/docs/src/main/paradox/eventsourced.md
+++ b/docs/src/main/paradox/eventsourced.md
@@ -10,7 +10,7 @@ The Akka dependencies are available from Akka's library repository. To access th
 @@repository [sbt,Maven,Gradle] {
 id="akka-repository"
 name="Akka library repository"
-url="https://repo.akka.io/maven"
+url="<url from https://account.akka.io/token>"
 }
 
 To use the Event Sourced module of Akka Projections add the following dependency in your project:

--- a/docs/src/main/paradox/getting-started/setup-your-app.md
+++ b/docs/src/main/paradox/getting-started/setup-your-app.md
@@ -8,7 +8,7 @@ The Akka dependencies are available from Akka's library repository. To access th
 @@repository [sbt,Maven,Gradle] {
 id="akka-repository"
 name="Akka library repository"
-url="https://repo.akka.io/maven"
+url="<url from https://account.akka.io/token>"
 }
 
 Additionally, add the dependency as below.

--- a/docs/src/main/paradox/grpc-replicated-event-sourcing-transport.md
+++ b/docs/src/main/paradox/grpc-replicated-event-sourcing-transport.md
@@ -40,7 +40,7 @@ The Akka dependencies are available from Akka's library repository. To access th
 @@repository [sbt,Maven,Gradle] {
 id="akka-repository"
 name="Akka library repository"
-url="https://repo.akka.io/maven"
+url="<url from https://account.akka.io/token>"
 }
 
 To use the gRPC module of Akka Projections add the following dependency in your project:

--- a/docs/src/main/paradox/grpc.md
+++ b/docs/src/main/paradox/grpc.md
@@ -24,7 +24,7 @@ The Akka dependencies are available from Akka's library repository. To access th
 @@repository [sbt,Maven,Gradle] {
 id="akka-repository"
 name="Akka library repository"
-url="https://repo.akka.io/maven"
+url="<url from https://account.akka.io/token>"
 }
 
 To use the gRPC module of Akka Projections add the following dependency in your project:

--- a/docs/src/main/paradox/jdbc.md
+++ b/docs/src/main/paradox/jdbc.md
@@ -15,7 +15,7 @@ The Akka dependencies are available from Akka's library repository. To access th
 @@repository [sbt,Maven,Gradle] {
 id="akka-repository"
 name="Akka library repository"
-url="https://repo.akka.io/maven"
+url="<url from https://account.akka.io/token>"
 }
 
 To use the JDBC module of Akka Projections add the following dependency in your project:

--- a/docs/src/main/paradox/kafka.md
+++ b/docs/src/main/paradox/kafka.md
@@ -24,7 +24,7 @@ The Akka dependencies are available from Akka's library repository. To access th
 @@repository [sbt,Maven,Gradle] {
 id="akka-repository"
 name="Akka library repository"
-url="https://repo.akka.io/maven"
+url="<url from https://account.akka.io/token>"
 }
 
 To use the Kafka module of Akka Projections add the following dependency in your project:

--- a/docs/src/main/paradox/r2dbc.md
+++ b/docs/src/main/paradox/r2dbc.md
@@ -21,7 +21,7 @@ The Akka dependencies are available from Akka's library repository. To access th
 @@repository [sbt,Maven,Gradle] {
 id="akka-repository"
 name="Akka library repository"
-url="https://repo.akka.io/maven"
+url="<url from https://account.akka.io/token>"
 }
 
 To use the R2DBC module of Akka Projections add the following dependency in your project:

--- a/docs/src/main/paradox/running.md
+++ b/docs/src/main/paradox/running.md
@@ -9,7 +9,7 @@ The Akka dependencies are available from Akka's library repository. To access th
 @@repository [sbt,Maven,Gradle] {
 id="akka-repository"
 name="Akka library repository"
-url="https://repo.akka.io/maven"
+url="<url from https://account.akka.io/token>"
 }
 
 To distribute the projection over the cluster we recommend the use of [ShardedDaemonProcess](https://doc.akka.io/libraries/akka-core/current/typed/cluster-sharded-daemon-process.html). Add the following dependency in your project if not yet using Akka Cluster Sharding:

--- a/docs/src/main/paradox/slick.md
+++ b/docs/src/main/paradox/slick.md
@@ -25,7 +25,7 @@ The Akka dependencies are available from Akka's library repository. To access th
 @@repository [sbt,Maven,Gradle] {
 id="akka-repository"
 name="Akka library repository"
-url="https://repo.akka.io/maven"
+url="<url from https://account.akka.io/token>"
 }
 
 To use the Slick module of Akka Projections add the following dependency in your project:

--- a/docs/src/main/paradox/testing.md
+++ b/docs/src/main/paradox/testing.md
@@ -9,7 +9,7 @@ The Akka dependencies are available from Akka's library repository. To access th
 @@repository [sbt,Maven,Gradle] {
 id="akka-repository"
 name="Akka library repository"
-url="https://repo.akka.io/maven"
+url="<url from https://account.akka.io/token>"
 }
 
 To use the Akka Projections TestKit add the following dependency in your project:


### PR DESCRIPTION
## Summary

The bare `https://repo.akka.io/maven` URL requires token-based access from https://account.akka.io/token.

**`docs/src/main/paradox/` (13 files)**
Replace `url="https://repo.akka.io/maven"` with `url="<url from https://account.akka.io/token>"` in dependency setup sections across all connector docs (cassandra, dynamodb, eventsourced, grpc, grpc-replicated-event-sourcing-transport, jdbc, kafka, r2dbc, running, slick, testing, durable-state, getting-started/setup-your-app).

**`docs/release-train-issue-template.md`**
- Publish destination described generically ("the Akka repository")
- `mvn dependency:get` check updated to use `-Dmaven.repo.remote=<token url>` from https://account.akka.io/token
- Section heading updated to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)